### PR TITLE
ci: gate Node jobs on package.json presence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  detect:
+    name: Detect Node project
+    runs-on: ubuntu-latest
+    outputs:
+      has_node: ${{ steps.check.outputs.has_node }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: check
+        run: |
+          if [ -f package.json ]; then
+            echo "has_node=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_node=false" >> "$GITHUB_OUTPUT"
+          fi
+
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    needs: detect
+    if: needs.detect.outputs.has_node == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -29,6 +46,8 @@ jobs:
   typecheck:
     name: Typecheck
     runs-on: ubuntu-latest
+    needs: detect
+    if: needs.detect.outputs.has_node == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -44,6 +63,8 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    needs: detect
+    if: needs.detect.outputs.has_node == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -59,7 +80,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, test]
+    needs: [detect, lint, typecheck, test]
+    if: needs.detect.outputs.has_node == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4


### PR DESCRIPTION
## Summary

- Adds a `detect` job that checks for `package.json` at repo root
- `Lint`, `Typecheck`, `Test`, `Build` now `needs: detect` and gate on `if: needs.detect.outputs.has_node == 'true'`
- When no `package.json` exists, jobs skip — branch protection treats skipped as success

## Why

Repo is Pi firmware (Python). The original `ci.yml` from the workforce template assumes a Node monorepo and runs `pnpm install --frozen-lockfile` unconditionally → fails on every PR. PR #16 (Phase 1 scaffolding) is blocked solely by this.

When a Node footprint lands later (`runtime/dashboard/` in Phase 1 Plan 08), the jobs auto-activate.

Closes #17

## Test plan

- [ ] CI on this PR: `Lint`, `Typecheck`, `Test`, `Build` show as skipped (green)
- [ ] `Conventional commit title`, `PR size`, `Linked issue`, `Label PR by touched paths` pass
- [ ] After merge: re-run CI on PR #16, verify it goes green and unblocks merge

## Out of scope

- Board-sync workflow failure (`Could not resolve to an Organization with the login of 'focal55'`) — separate problem; GITHUB_TOKEN can't read user-level ProjectV2. Needs a PAT with `project` scope as a repo secret. Will file as a follow-up issue.