### PR TITLE
feat(cli): extract sanitized CLI helpers to runtime/cli/ (EXTRACT-08)

### DIFF
--- a/.planning/phases/01-runtime-extraction/01-10-SUMMARY.md
+++ b/.planning/phases/01-runtime-extraction/01-10-SUMMARY.md
@@ -1,0 +1,91 @@
+---
+phase: 01-runtime-extraction
+plan: 10
+type: summary
+status: complete
+---
+
+# Plan 10 Summary: Extract sanitized CLI helpers to runtime/cli/
+
+## Helpers extracted
+
+| Helper | Source LOC | Destination | Notes |
+|---|---|---|---|
+| `face` | 27 | `runtime/cli/face` | Clean; no sanitization needed beyond header tweak |
+| `speak` | 41 | `runtime/cli/speak` | Parameterized Piper paths; `plughw:2,0` TODO(phase-5) |
+| `stt` | 14 | `runtime/cli/stt` | `plughw:2,0` TODO(phase-5) |
+| `record` | 7 | `runtime/cli/record` | `plughw:2,0` TODO(phase-5) |
+| `boot-check` | 60 | `runtime/cli/boot-check` | High sanitization; see below |
+| `purge-logs` | 25 | `runtime/cli/purge-logs` | Log path parameterized |
+| `run-logrotate` | 3 | `runtime/cli/run-logrotate` | Config path parameterized; state path moved to `/var/lib/arlowe/` |
+| `wake-train` | 23 | `runtime/cli/wake-train` | Wake-word dir and venv parameterized |
+
+Total extracted: ~200 LOC across 8 scripts.
+
+## Sanitization edits per script
+
+**`boot-check`** (highest priority):
+- Deleted `check_service openclaw-gateway "OpenClaw Gateway"` line entirely
+- Deleted `check_port 18789 "OpenClaw Gateway API"` line entirely
+- Parameterized systemctl via `ARLOWE_SYSTEMCTL_FLAGS` env var (default `--user`)
+- Added `arlowe-dashboard` service check (product service)
+- Added port 3000 check for dashboard
+- Stripped decorative emoji characters (not appropriate for machine-parseable output)
+
+**`speak`**:
+- `~/models/piper/piper` replaced with `${PIPER_BIN:-/opt/arlowe/runtime/tts/bin/piper}`
+- `~/models/piper-voices/en_US-lessac-medium.onnx` replaced with `${PIPER_VOICE:-/opt/arlowe/models/piper-voices/en_US-lessac-medium.onnx}`
+- `plughw:2,0` left in place with `# TODO(phase-5)` comment
+- Header stripped device-specific label
+
+**`purge-logs`**:
+- `$HOME/whisplay/logs` replaced with `${ARLOWE_LOGS_DIR:-/var/lib/arlowe/logs}`
+
+**`run-logrotate`**:
+- `~/.config/logrotate/arlowe.conf` replaced with `${ARLOWE_LOGROTATE_CONF:-/opt/arlowe/runtime/cli/logrotate.conf}`
+- logrotate state file moved from `~/.config/logrotate/status` to `/var/lib/arlowe/logrotate.status`
+
+**`wake-train`**:
+- `cd ~/wake_word` replaced with `cd "${ARLOWE_WAKE_WORD_DIR:-/opt/arlowe/runtime/wake-word}"`
+- `python3` replaced with `"${ARLOWE_VENV:-/opt/arlowe/venv}/bin/python3"` throughout
+
+**`stt`**, **`record`**: `plughw:2,0` left in place with `# TODO(phase-5)` comment.
+
+**`face`**: No sanitization required; clean as-is.
+
+## Excluded helpers
+
+| Helper | Reason |
+|---|---|
+| `wifi-watchdog` | Hardcodes founder home Wi-Fi SSID literal; dashboard `/api/connectivity/*` routes replace the functionality |
+| `iol-sync` | Personal founder tool; out of scope per `docs/04-scope.md` |
+| `usage-stats` | Personal founder tool; out of scope per `docs/04-scope.md` |
+| `stats` | Personal founder tool; out of scope per `docs/04-scope.md` |
+
+## Artifacts created
+
+- `runtime/cli/face` — executable, 25 LOC
+- `runtime/cli/speak` — executable, 44 LOC (sanitized)
+- `runtime/cli/stt` — executable, 16 LOC (sanitized)
+- `runtime/cli/record` — executable, 9 LOC (sanitized)
+- `runtime/cli/boot-check` — executable, 58 LOC (sanitized, seed for Phase 11 BOOT-01)
+- `runtime/cli/purge-logs` — executable, 27 LOC (sanitized, seed for Phase 11 LOG-02)
+- `runtime/cli/run-logrotate` — executable, 9 LOC (sanitized)
+- `runtime/cli/wake-train` — executable, 39 LOC (sanitized)
+- `runtime/cli/logrotate.conf` — minimal default config (written fresh; not present on Pi stash)
+- `runtime/cli/README.md` — 50 LOC helpers index, env knobs, exclusion rationale
+
+## Open TODOs for future phases
+
+**Phase 5 (audio auto-detection):**
+- `runtime/cli/record`: replace `plughw:2,0` with auto-detected device
+- `runtime/cli/stt`: same
+- `runtime/cli/speak`: same
+- `runtime/cli/boot-check`: same
+
+**Phase 11 (system units / image build):**
+- `runtime/cli/boot-check`: flip `ARLOWE_SYSTEMCTL_FLAGS` from `--user` to empty for system-level units
+
+## EXTRACT-08 status
+
+Complete. All acceptance criteria met.

--- a/runtime/cli/README.md
+++ b/runtime/cli/README.md
@@ -1,0 +1,50 @@
+# runtime/cli — Operator CLI Helpers
+
+Operator-facing shell scripts for verifying and interacting with the Arlowe on-device runtime. These are the primary verification path for the operator during development and post-boot checks.
+
+## Helpers
+
+| Helper | Purpose | Used by |
+|---|---|---|
+| `face` | Set face state via HTTP on port 8080 | Manual ops, smoke test |
+| `speak` | Run TTS once via Piper with optional face sync | Manual ops, smoke test |
+| `stt` | Record mic and transcribe via STT server on port 8082 | Manual ops, smoke test |
+| `record` | Capture mic audio to a file (debug/sampling) | Debug, wake-word collection |
+| `boot-check` | Post-boot service and hardware verification (seed for Phase 11 BOOT-01) | Operator, systemd oneshot |
+| `purge-logs` | Delete stale logs by age; truncate oversized debug log (seed for Phase 11 LOG-02) | logrotate timer |
+| `run-logrotate` | Wraps logrotate with the Arlowe config | systemd timer |
+| `wake-train` | Re-train the wake-word verifier from operator samples | Manual (Phase 8 personalization) |
+
+## Env knobs
+
+All scripts use `/opt/arlowe/` defaults and accept environment overrides for local dev and testing.
+
+| Var | Default | Used by |
+|---|---|---|
+| `PIPER_BIN` | `/opt/arlowe/runtime/tts/bin/piper` | `speak` |
+| `PIPER_VOICE` | `/opt/arlowe/models/piper-voices/en_US-lessac-medium.onnx` | `speak` |
+| `ARLOWE_LOGS_DIR` | `/var/lib/arlowe/logs` | `purge-logs` |
+| `ARLOWE_LOGROTATE_CONF` | `/opt/arlowe/runtime/cli/logrotate.conf` | `run-logrotate` |
+| `ARLOWE_WAKE_WORD_DIR` | `/opt/arlowe/runtime/wake-word` | `wake-train` |
+| `ARLOWE_VENV` | `/opt/arlowe/venv` | `wake-train` |
+| `ARLOWE_SYSTEMCTL_FLAGS` | `--user` | `boot-check` |
+
+`ARLOWE_SYSTEMCTL_FLAGS` defaults to `--user` for Phase 1 (services run as the current user during development). Set to empty string for system-level units once the image build lands (Phase 11).
+
+## Known open items
+
+**TODO(phase-5):** Every `plughw:2,0` site is marked with a comment. Phase 5 replaces this with audio auto-detection. Affected scripts: `record`, `stt`, `speak`, `boot-check`.
+
+**TODO(phase-11):** `boot-check` uses `--user` systemctl mode by default. When the image build introduces a dedicated `arlowe` system user and system-level units, flip `ARLOWE_SYSTEMCTL_FLAGS` to empty.
+
+## Excluded scripts
+
+### `wifi-watchdog` — deleted
+
+Research (§EXTRACT-08) flagged that the live `~/bin/wifi-watchdog` on the device hardcodes the founder's home Wi-Fi SSID as a literal string. This is a founder-identity literal that cannot ship in any form.
+
+The script's function (reconnect to a known SSID on link loss) is replaced by the dashboard's `/api/connectivity/*` routes (NetworkManager-backed), which allow the device owner to configure their own network via the pairing flow (Phase 8). If a programmatic Wi-Fi-failure-recovery helper becomes necessary in a future phase, design it fresh using NetworkManager's D-Bus API, not a hardcoded SSID.
+
+### `iol-sync`, `usage-stats`, `stats` — personal tools, out of scope
+
+Per `docs/04-scope.md`, these three helpers are personal founder tools tied to the IOL/OpenClaw infrastructure. They are not extracted into the firmware.

--- a/runtime/cli/boot-check
+++ b/runtime/cli/boot-check
@@ -1,0 +1,90 @@
+#!/bin/bash
+# Arlowe Boot Verification Script
+# Run after reboot to verify all services are operational
+#
+# Env overrides:
+#   ARLOWE_SYSTEMCTL_FLAGS  Flags passed to systemctl (default: --user)
+#                           Set to empty string for system-level units (Phase 11+)
+
+# TODO(phase-11): --user mode flips to system-level when image build lands.
+SYSTEMCTL_FLAGS="${ARLOWE_SYSTEMCTL_FLAGS:---user}"
+
+echo "============================================================"
+echo "           ARLOWE BOOT VERIFICATION"
+echo "============================================================"
+echo ""
+
+PASS=0
+FAIL=0
+
+check_service() {
+    local svc=$1
+    local desc=$2
+    if systemctl $SYSTEMCTL_FLAGS is-active --quiet $svc; then
+        echo "OK  $desc"
+        ((PASS++))
+    else
+        echo "FAIL $desc"
+        ((FAIL++))
+    fi
+}
+
+check_port() {
+    local port=$1
+    local desc=$2
+    if lsof -ti :$port >/dev/null 2>&1; then
+        echo "OK  $desc (port $port)"
+        ((PASS++))
+    else
+        echo "FAIL $desc (port $port NOT listening)"
+        ((FAIL++))
+    fi
+}
+
+echo "CORE SERVICES:"
+echo "------------------------------------------------------------"
+check_service qwen-tokenizer "Qwen Tokenizer"
+check_service qwen-api "Qwen LLM API"
+check_service qwen-openai "Qwen OpenAI Wrapper"
+check_service whisper-stt "Whisper STT Server"
+check_service arlowe-face "Face Display Service"
+check_service arlowe-voice "Voice Assistant"
+check_service arlowe-dashboard "Arlowe Dashboard"
+
+echo ""
+echo "NETWORK ENDPOINTS:"
+echo "------------------------------------------------------------"
+check_port 12345 "Tokenizer Service"
+check_port 8000 "Qwen Native API"
+check_port 8001 "Qwen OpenAI API"
+check_port 8082 "STT Server"
+check_port 8080 "Face Control API"
+check_port 3000 "Dashboard"
+
+echo ""
+echo "HARDWARE:"
+echo "------------------------------------------------------------"
+if /usr/bin/axcl/axcl-smi >/dev/null 2>&1; then
+    echo "OK  Axera NPU detected"
+    ((PASS++))
+else
+    echo "FAIL Axera NPU not responding"
+    ((FAIL++))
+fi
+
+# TODO(phase-5): plughw:2,0 hardcoded; replace with auto-detected device.
+if arecord -D plughw:2,0 -d 1 /dev/null 2>/dev/null; then
+    echo "OK  Microphone (WM8960)"
+    ((PASS++))
+else
+    echo "WARN Microphone may be in use"
+fi
+
+echo ""
+echo "============================================================"
+echo "Results: $PASS passed, $FAIL failed"
+if [ $FAIL -eq 0 ]; then
+    echo "ALL SYSTEMS OPERATIONAL"
+else
+    echo "Some services need attention"
+fi

--- a/runtime/cli/face
+++ b/runtime/cli/face
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Quick face control helper
+# Usage: face <state> [bg] [source]
+# Examples:
+#   face thinking wake
+#   face talking talking cloud
+#   face idle
+#   face discord thinking
+#   face discord message cloud
+#   face discord idle
+
+FACE_API="http://localhost:8080"
+
+if [ "$1" = "discord" ]; then
+    activity="${2:-message}"
+    source="${3:-cloud}"
+    curl -s -X POST "$FACE_API/discord" \
+        -H "Content-Type: application/json" \
+        -d "{\"activity\":\"$activity\",\"source\":\"$source\"}" > /dev/null
+else
+    state="${1:-idle}"
+    bg="${2:-default}"
+    source="${3:-}"
+    curl -s -X POST "$FACE_API/state" \
+        -H "Content-Type: application/json" \
+        -d "{\"state\":\"$state\",\"bg\":\"$bg\",\"source\":\"$source\"}" > /dev/null
+fi

--- a/runtime/cli/logrotate.conf
+++ b/runtime/cli/logrotate.conf
@@ -1,0 +1,8 @@
+/var/lib/arlowe/logs/*.log {
+    daily
+    rotate 7
+    compress
+    missingok
+    notifempty
+    copytruncate
+}

--- a/runtime/cli/purge-logs
+++ b/runtime/cli/purge-logs
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Log purge script for Arlowe
+# Keeps 7 days of daily logs, truncates debug log if over 10MB
+#
+# Env overrides:
+#   ARLOWE_LOGS_DIR  Log directory (default: /var/lib/arlowe/logs)
+
+LOG_DIR="${ARLOWE_LOGS_DIR:-/var/lib/arlowe/logs}"
+RETENTION_DAYS=7
+
+echo "$(date '+%Y-%m-%d %H:%M:%S') Starting log purge..."
+
+# Delete daily logs older than retention period
+find "$LOG_DIR" -name "voice_*.log" -mtime +$RETENTION_DAYS -delete -print 2>/dev/null | while read f; do
+    echo "  Deleted: $f"
+done
+
+# Truncate debug log if over 10MB
+DEBUG_LOG="$LOG_DIR/voice_assistant.log"
+if [ -f "$DEBUG_LOG" ]; then
+    SIZE=$(stat -f%z "$DEBUG_LOG" 2>/dev/null || stat -c%s "$DEBUG_LOG" 2>/dev/null)
+    MAX_SIZE=$((10 * 1024 * 1024))  # 10MB
+
+    if [ "$SIZE" -gt "$MAX_SIZE" ]; then
+        echo "  Debug log is ${SIZE} bytes, truncating to last 1000 lines..."
+        tail -n 1000 "$DEBUG_LOG" > "$DEBUG_LOG.tmp" && mv "$DEBUG_LOG.tmp" "$DEBUG_LOG"
+    fi
+fi
+
+echo "$(date '+%Y-%m-%d %H:%M:%S') Log purge complete."

--- a/runtime/cli/record
+++ b/runtime/cli/record
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Arlowe Mic Recording
+# Usage: record [seconds] [output_file]
+
+DURATION=${1:-5}
+OUTPUT=${2:-/tmp/recording.wav}
+
+# TODO(phase-5): plughw:2,0 hardcoded; replace with auto-detected device.
+arecord -D plughw:2,0 -f S16_LE -r 16000 -c 2 -d $DURATION $OUTPUT 2>/dev/null
+echo $OUTPUT

--- a/runtime/cli/run-logrotate
+++ b/runtime/cli/run-logrotate
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Run logrotate with Arlowe config
+#
+# Env overrides:
+#   ARLOWE_LOGROTATE_CONF  Config file path (default: /opt/arlowe/runtime/cli/logrotate.conf)
+
+CONF="${ARLOWE_LOGROTATE_CONF:-/opt/arlowe/runtime/cli/logrotate.conf}"
+/usr/sbin/logrotate --state /var/lib/arlowe/logrotate.status "$CONF"

--- a/runtime/cli/speak
+++ b/runtime/cli/speak
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Arlowe TTS - speak text through Piper with face sync
+# Usage: speak "text to say"
+# Options:
+#   --no-face    Skip face state changes
+#
+# Env overrides:
+#   PIPER_BIN    Path to piper binary   (default: /opt/arlowe/runtime/tts/bin/piper)
+#   PIPER_VOICE  Path to .onnx voice model (default: /opt/arlowe/models/piper-voices/en_US-lessac-medium.onnx)
+
+FACE_SYNC=true
+if [ "$1" = "--no-face" ]; then
+    FACE_SYNC=false
+    shift
+fi
+
+TEXT="$*"
+if [ -z "$TEXT" ]; then
+    read TEXT
+fi
+
+PIPER="${PIPER_BIN:-/opt/arlowe/runtime/tts/bin/piper}"
+MODEL="${PIPER_VOICE:-/opt/arlowe/models/piper-voices/en_US-lessac-medium.onnx}"
+TMPFILE=$(mktemp /tmp/tts_XXXXXX.wav)
+FACE_URL="http://localhost:8080/state"
+
+# Notify face we're about to talk
+if [ "$FACE_SYNC" = true ]; then
+    # Save current state (best effort)
+    PREV_STATE=$(curl -s http://localhost:8080/status 2>/dev/null | grep -o '"state":"[^"]*"' | cut -d'"' -f4)
+    [ -z "$PREV_STATE" ] && PREV_STATE="idle"
+
+    curl -s -X POST "$FACE_URL" -d '{"state":"talking"}' >/dev/null 2>&1
+fi
+
+# Generate speech
+echo "$TEXT" | $PIPER --model $MODEL --output_file $TMPFILE 2>/dev/null
+
+# TODO(phase-5): plughw:2,0 hardcoded; replace with auto-detected device.
+# Resample to 48kHz for WM8960 and play
+sox $TMPFILE -r 48000 -c 2 -t wav - 2>/dev/null | aplay -D plughw:2,0 -q 2>/dev/null
+
+# Restore face state
+if [ "$FACE_SYNC" = true ]; then
+    curl -s -X POST "$FACE_URL" -d "{\"state\":\"$PREV_STATE\"}" >/dev/null 2>&1
+fi
+
+# Cleanup
+rm -f $TMPFILE

--- a/runtime/cli/stt
+++ b/runtime/cli/stt
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Quick STT helper - records and transcribes
+# Usage: stt [duration_seconds]
+
+DURATION=${1:-5}
+TMPFILE=$(mktemp --suffix=.wav)
+
+echo "Recording for ${DURATION}s..."
+# TODO(phase-5): plughw:2,0 hardcoded; replace with auto-detected device.
+arecord -D plughw:2,0 -f S16_LE -r 16000 -c 1 -d "$DURATION" "$TMPFILE" 2>/dev/null
+
+echo "Transcribing..."
+RESULT=$(curl -s -X POST http://localhost:8082/transcribe --data-binary @"$TMPFILE")
+TEXT=$(echo "$RESULT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('text',''))")
+
+rm -f "$TMPFILE"
+
+echo ">>> $TEXT"

--- a/runtime/cli/wake-train
+++ b/runtime/cli/wake-train
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Wake word training helper
+# Usage: wake-train [positive|negative|status|train|test]
+#
+# Env overrides:
+#   ARLOWE_WAKE_WORD_DIR  Directory containing training scripts and samples
+#                         (default: /opt/arlowe/runtime/wake-word)
+#   ARLOWE_VENV           Python venv prefix (default: /opt/arlowe/venv)
+
+WAKE_DIR="${ARLOWE_WAKE_WORD_DIR:-/opt/arlowe/runtime/wake-word}"
+PYTHON="${ARLOWE_VENV:-/opt/arlowe/venv}/bin/python3"
+
+cd "$WAKE_DIR"
+
+case "${1:-status}" in
+    positive|pos)
+        "$PYTHON" collect_samples.py positive
+        ;;
+    negative|neg)
+        "$PYTHON" collect_samples.py negative
+        ;;
+    status|s)
+        "$PYTHON" collect_samples.py status
+        ;;
+    train|t)
+        "$PYTHON" train_verifier.py
+        ;;
+    test)
+        "$PYTHON" test_verifier.py
+        ;;
+    *)
+        echo "Wake Word Training Helper"
+        echo ""
+        echo "Usage: wake-train [command]"
+        echo ""
+        echo "Commands:"
+        echo "  positive  - Record 'Hey Arlowe' samples (need 50)"
+        echo "  negative  - Record other speech samples (need 30)"
+        echo "  status    - Show current sample counts"
+        echo "  train     - Train the verifier model"
+        echo "  test      - Test wake word detection"
+        echo ""
+        "$PYTHON" collect_samples.py status
+        ;;
+esac


### PR DESCRIPTION
## Summary

- Extracts 8 `~/bin/` CLI helpers from arlowe-1 into `runtime/cli/`, sanitized at extraction time (EXTRACT-08)
- `wifi-watchdog` deleted — hardcoded founder home Wi-Fi SSID; dashboard connectivity routes replace its function
- `boot-check` stripped of `openclaw-gateway` service check and port 18789 endpoint check; systemctl mode parameterized via `ARLOWE_SYSTEMCTL_FLAGS` (default `--user`, flips to system in Phase 11)
- `speak`, `purge-logs`, `wake-train`, `run-logrotate` paths replaced with env-overridable `/opt/arlowe` defaults
- `logrotate.conf` written fresh (minimal default); `README.md` documents helpers, env knobs, and exclusion rationale

## Sanitization decisions

| Script | Action |
|---|---|
| `face` | No changes needed; `localhost:8080` is intentional |
| `speak` | `~/models/piper` → `${PIPER_BIN}` / `${PIPER_VOICE}` env vars |
| `stt` | `plughw:2,0` TODO(phase-5) comment added |
| `record` | `plughw:2,0` TODO(phase-5) comment added |
| `boot-check` | Stripped `openclaw-gateway` + port 18789; parameterized systemctl |
| `purge-logs` | `$HOME/whisplay/logs` → `${ARLOWE_LOGS_DIR:-/var/lib/arlowe/logs}` |
| `run-logrotate` | `~/.config/logrotate/...` → `${ARLOWE_LOGROTATE_CONF}` + `/var/lib/arlowe` state dir |
| `wake-train` | `cd ~/wake_word` → `${ARLOWE_WAKE_WORD_DIR}`; bare `python3` → `${ARLOWE_VENV}/bin/python3` |
| `wifi-watchdog` | Deleted — see README |
| `iol-sync`, `usage-stats`, `stats` | Not extracted — personal tools, out of scope |

## Test plan

- [ ] All 8 scripts present, executable, syntactically valid (`bash -n`)
- [ ] `wifi-watchdog`, `iol-sync`, `usage-stats`, `stats` absent from `runtime/cli/`
- [ ] No founder literals (`focal55`, `casa_ybarra`, `openclaw`, `18789`, `iol-monorepo`) in `runtime/cli/`
- [ ] `purge-logs` uses `/var/lib/arlowe/logs`
- [ ] `speak` references `/opt/arlowe` paths
- [ ] `boot-check` has `ARLOWE_SYSTEMCTL_FLAGS` and no openclaw/18789 references
- [ ] `runtime/cli/logrotate.conf` present
- [ ] `runtime/cli/README.md` >= 30 lines, documents wifi-watchdog deletion rationale and env knobs

Closes #8