### PR TITLE
feat(wake-word): extract training pipeline to runtime/wake-word/ (EXTRACT-07)

### DIFF
--- a/.planning/phases/01-runtime-extraction/01-11-SUMMARY.md
+++ b/.planning/phases/01-runtime-extraction/01-11-SUMMARY.md
@@ -1,0 +1,85 @@
+# Plan 11 Summary -- Wake-Word Training Pipeline Extraction
+
+**Plan:** 11
+**Phase:** 01-runtime-extraction
+**Completed:** 2026-05-02
+
+## Scripts extracted
+
+All 5 scripts from canonical source ~/wake_word/ (via .dev-stash/arlowe-1/wake_word/):
+
+| Script | Source LOC | Sanitization needed |
+|---|---|---|
+| auto_collect.py | 91 | /home/focal55/bin/speak -> env override; hardcoded plughw:2,0 -> env |
+| collect_samples.py | 186 | SAMPLE_DIR-relative positive/negative dirs -> ARLOWE_WAKE_WORD_STATE env |
+| quick_test.py | 79 | venv path hack; /home/focal55/bin/speak -> env; hardcoded verifier -> env; added graceful no-verifier path |
+| test_verifier.py | 114 | venv path hack; hardcoded SAMPLE_DIR/hey_arlowe_verifier.pkl -> env |
+| train_verifier.py | 75 | venv path hack; SAMPLE_DIR-relative positive/negative/output -> env |
+
+## Sanitization edits per script
+
+### All scripts with venv path hack (train_verifier.py, test_verifier.py, quick_test.py)
+
+Before:
+  sys.path.insert(0, '/home/focal55/venvs/voice/lib/python3.13/site-packages')
+
+After:
+  _extra = os.environ.get("ARLOWE_VENV_SITE_PACKAGES")
+  if _extra and _extra not in sys.path:
+      sys.path.insert(0, _extra)
+
+### State paths (all 5 scripts)
+
+All SAMPLE_DIR-relative paths to positive/, negative/, and hey_arlowe_verifier.pkl replaced with:
+  _STATE_DIR = os.environ.get("ARLOWE_WAKE_WORD_STATE", "/var/lib/arlowe/wake-word")
+  VERIFIER_MODEL = os.environ.get("ARLOWE_WAKE_WORD_VERIFIER", os.path.join(_STATE_DIR, "verifier.pkl"))
+
+### speak helper (auto_collect.py, quick_test.py)
+
+Before: subprocess.run(["/home/focal55/bin/speak", text], ...)
+After:  ARLOWE_SPEAK_BIN env var defaulting to /usr/local/bin/speak; guarded with os.path.exists check.
+
+### ALSA device (auto_collect.py)
+
+Before: hardcoded plughw:2,0
+After:  ARLOWE_ALSA_DEVICE env var defaulting to plughw:2,0
+
+### quick_test.py -- added graceful no-verifier code path
+
+Original assumed verifier always present and crashed on missing file. Sanitized version detects
+missing verifier on startup and falls back to base-model-only mode at threshold 0.7 (the
+generic-model path from the README).
+
+## R6 enforcement -- biometric data excluded (Mn3)
+
+### Filesystem layer
+
+.gitignore (added in plan 01) already excludes: *.pkl, runtime/wake-word/positive/,
+runtime/wake-word/negative/, runtime/wake-word/*.pkl. Verified via find command -- empty.
+
+### Git-history layer (defense-in-depth)
+
+git log --all --diff-filter=A --name-only -- '*.pkl' '*.wav' -- empty (no commit has ever added
+biometric data).
+
+### rsync excludes (source layer)
+
+scripts/dev-pull-from-pi.sh already has --exclude='*.pkl' --exclude='positive/' --exclude='negative/'
+on the wake_word/ rsync target. Dry-run confirmed excludes are active.
+
+## Canonical source decision
+
+Research Q5 identified a duplicate at ~/iol-monorepo/packages/whisplay/wake_word/ with an older
+split (record_negative.py, record_positive.py, test_wake.py). Only the canonical ~/wake_word/ was
+extracted -- the path where voice_client.py resolves the verifier. The whisplay-level copy is stale
+and was not extracted.
+
+## Artifacts produced
+
+- runtime/wake-word/auto_collect.py
+- runtime/wake-word/collect_samples.py
+- runtime/wake-word/quick_test.py
+- runtime/wake-word/test_verifier.py
+- runtime/wake-word/train_verifier.py
+- runtime/wake-word/requirements.txt (pinned from arlowe-1 ~/venvs/voice/)
+- runtime/wake-word/README.md (>50 lines; documents generic-model swap path, personalization deferral, R6 enforcement)

--- a/runtime/wake-word/README.md
+++ b/runtime/wake-word/README.md
@@ -1,0 +1,107 @@
+# Wake-Word Pipeline
+
+This directory contains the wake-word training and verification scripts for "Hey Arlowe".
+
+## Status
+
+- **v1**: Bare `hey_jarvis` base model from openwakeword (a known proxy for the "Hey Arlowe" phrase
+  shape) with an elevated activation threshold. No speaker-specific verifier ships in v1 (per
+  WAKE-01: generic model trained on diverse voices).
+- **v1 personalization (off by default)**: Owner can opt into recording samples and training a
+  verifier overlay. Personalization toggle will be exposed in the dashboard (WAKE-03). Deferred to
+  v1.1 (per WAKE-04 in REQUIREMENTS.md).
+- **v2 (deferred)**: Personalization flow records owner samples, retrains a personalized model
+  overlay, and swaps atomically. False-positive / false-negative rates surface in dashboard health.
+
+## Scripts
+
+| Script | Purpose | Used in |
+|---|---|---|
+| `auto_collect.py` | Auto-collect "wake" samples during normal use | Personalization (post-pairing) |
+| `collect_samples.py` | Interactive mic capture for samples | Personalization (manual mode) |
+| `train_verifier.py` | Train a sklearn verifier from samples | Personalization training step |
+| `test_verifier.py` | Evaluate a trained verifier against live audio | Diagnostics |
+| `quick_test.py` | One-shot wake-word test | Manual ops + smoke test |
+
+## Generic-model swap path
+
+For a clean Pi without a trained verifier:
+
+1. The voice orchestrator (`runtime/voice/voice_client.py`) loads the openwakeword base model
+   `hey_jarvis_v0.1`.
+2. Set `VERIFIER_MODEL` to None or skip the verifier-stage gate (the model file simply will not
+   exist at the default path).
+3. Raise the base activation threshold (default 0.5 -> 0.7) to compensate for the lack of
+   speaker-specific filtering.
+4. Accept higher false-positive rate as the v1 trade-off.
+
+Concretely, in `voice_client.py`:
+
+```python
+VERIFIER_MODEL = Path(os.environ.get("ARLOWE_WAKE_WORD_VERIFIER",
+                                     "/var/lib/arlowe/wake-word/verifier.pkl"))
+if not VERIFIER_MODEL.exists():
+    VERIFIER_MODEL = None
+    WAKE_THRESHOLD = 0.7
+```
+
+Plan 02 wired this via env override; the verifier-absent code path is the v1 generic-model
+behaviour.
+
+`quick_test.py` also handles the missing-verifier case gracefully: if the `.pkl` is absent it
+runs in base-model-only mode at threshold 0.7.
+
+## Personalization training procedure (post-v1)
+
+When personalization ships:
+
+1. Owner triggers from dashboard.
+2. `auto_collect.py` records ~50 wake samples while the user goes about their day (passively gated
+   by base-model trigger).
+3. `collect_samples.py` runs interactively to fill the negative set with ambient noise.
+4. `train_verifier.py` produces `/var/lib/arlowe/wake-word/verifier.pkl`.
+5. Voice orchestrator picks it up on next start (no restart-on-change in v1; that is Phase 4
+   territory).
+
+## State on disk
+
+| Path | Purpose | Notes |
+|---|---|---|
+| `/var/lib/arlowe/wake-word/positive/` | Wake samples (.wav) | Owner data; never leaves device |
+| `/var/lib/arlowe/wake-word/negative/` | Negative samples (.wav) | Owner data; never leaves device |
+| `/var/lib/arlowe/wake-word/verifier.pkl` | Trained verifier | Owner-bound; never leaves device |
+
+All three paths default from `ARLOWE_WAKE_WORD_STATE` (base dir) and `ARLOWE_WAKE_WORD_VERIFIER`
+(explicit verifier path). See "Env knobs" below.
+
+## Why no founder data ships in this repo
+
+The script-only extraction is enforced by `.gitignore` (plan 01 added `*.pkl`,
+`runtime/wake-word/positive/`, and `runtime/wake-word/negative/`). Defense-in-depth: this plan
+also runs `git log --all --diff-filter=A -- '*.pkl' '*.wav'` to confirm no commit ever added
+biometric data anywhere in the repo's history.
+
+The founder voice fingerprint is biometric data. Even on the founder's dev unit, the verifier
+`.pkl` lives at the on-device state path (outside the repo) and is reachable only via the
+`ARLOWE_WAKE_WORD_VERIFIER` env override during the smoke test.
+
+See research file `.planning/phases/01-runtime-extraction/01-RESEARCH.md` sections R6 and
+EXTRACT-07.
+
+## Duplicate at whisplay package level (deliberately not extracted)
+
+`~/iol-monorepo/packages/whisplay/wake_word/` exists on arlowe-1 alongside the canonical
+`~/wake_word/`. Research Q5 confirmed that `voice_client.py` looks for the verifier under
+`~/wake_word/` -- that is the canonical path. The whisplay-level copy (which has its own
+`record_negative.py`, `record_positive.py`, `test_wake.py`) was an earlier split and is stale.
+Only the canonical `~/wake_word/` scripts were extracted here.
+
+## Env knobs
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `ARLOWE_VENV_SITE_PACKAGES` | unset | Extra `sys.path` entry for training scripts (set in dev or by image build at `/opt/arlowe/venv/lib/python3.X/site-packages`) |
+| `ARLOWE_WAKE_WORD_STATE` | `/var/lib/arlowe/wake-word` | Base dir for samples and verifier |
+| `ARLOWE_WAKE_WORD_VERIFIER` | `${ARLOWE_WAKE_WORD_STATE}/verifier.pkl` | Explicit verifier path |
+| `ARLOWE_SPEAK_BIN` | `/usr/local/bin/speak` | Path to the speak CLI helper used by auto_collect and quick_test |
+| `ARLOWE_ALSA_DEVICE` | `plughw:2,0` | ALSA capture (and playback) device for auto_collect |

--- a/runtime/wake-word/auto_collect.py
+++ b/runtime/wake-word/auto_collect.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Auto-collect wake word samples with voice prompts.
+
+Samples are written to:
+  ARLOWE_WAKE_WORD_STATE/positive/  (wake-word recordings)
+  ARLOWE_WAKE_WORD_STATE/negative/  (ambient/non-wake recordings)
+
+Environment:
+  ARLOWE_WAKE_WORD_STATE — base dir (default /var/lib/arlowe/wake-word)
+  ARLOWE_SPEAK_BIN       — path to speak helper (default /usr/local/bin/speak)
+  ARLOWE_ALSA_DEVICE     — ALSA capture device (default plughw:2,0)
+"""
+import os
+import sys
+import time
+import subprocess
+from pathlib import Path
+
+_STATE_DIR = os.environ.get("ARLOWE_WAKE_WORD_STATE", "/var/lib/arlowe/wake-word")
+_SPEAK_BIN = os.environ.get("ARLOWE_SPEAK_BIN", "/usr/local/bin/speak")
+_ALSA_DEVICE = os.environ.get("ARLOWE_ALSA_DEVICE", "plughw:2,0")
+
+POSITIVE_DIR = Path(_STATE_DIR) / "positive"
+NEGATIVE_DIR = Path(_STATE_DIR) / "negative"
+
+
+def speak(text):
+    if os.path.exists(_SPEAK_BIN):
+        subprocess.run([_SPEAK_BIN, text], capture_output=True)
+
+
+def record_sample(output_path, duration=2):
+    """Record a sample."""
+    subprocess.run([
+        "arecord", "-D", _ALSA_DEVICE, "-f", "S16_LE",
+        "-r", "16000", "-c", "1", "-d", str(duration),
+        str(output_path)
+    ], capture_output=True)
+
+
+def beep():
+    """Short beep sound via speaker."""
+    subprocess.run(
+        f"sox -n -r 48000 -c 2 /tmp/beep.wav synth 0.15 sine 800 vol 0.5 && aplay -D {_ALSA_DEVICE} -q /tmp/beep.wav",
+        shell=True, capture_output=True
+    )
+
+
+def collect_positive(count=50):
+    """Collect positive 'Hey Arlowe' samples."""
+    POSITIVE_DIR.mkdir(parents=True, exist_ok=True)
+    existing = len(list(POSITIVE_DIR.glob("*.wav")))
+
+    speak(f"Recording hey arlowe samples. Say it clearly after each beep. Starting in 3 seconds.")
+    time.sleep(3)
+
+    for i in range(existing, count):
+        print(f"[{i+1}/{count}] Recording...", flush=True)
+        beep()
+        time.sleep(0.3)
+
+        output = POSITIVE_DIR / f"sample_{i:03d}.wav"
+        record_sample(output, duration=2)
+        print(f"  Saved {output.name}", flush=True)
+        time.sleep(0.5)
+
+        if (i + 1) % 10 == 0:
+            speak(f"{i + 1} done. {count - i - 1} to go.")
+            time.sleep(1)
+
+    speak("Positive samples complete!")
+    print(f"\nCollected {count} positive samples")
+
+
+def collect_negative(count=30):
+    """Collect negative (non-wake-word) samples."""
+    NEGATIVE_DIR.mkdir(parents=True, exist_ok=True)
+    existing = len(list(NEGATIVE_DIR.glob("*.wav")))
+
+    speak(f"Recording negative samples. Say anything except hey arlowe. Random words, sentences, anything. Starting in 3 seconds.")
+    time.sleep(3)
+
+    for i in range(existing, count):
+        print(f"[{i+1}/{count}] Recording...", flush=True)
+        beep()
+        time.sleep(0.3)
+
+        output = NEGATIVE_DIR / f"sample_{i:03d}.wav"
+        record_sample(output, duration=2)
+        print(f"  Saved {output.name}", flush=True)
+        time.sleep(0.5)
+
+        if (i + 1) % 10 == 0:
+            speak(f"{i + 1} done. {count - i - 1} to go.")
+            time.sleep(1)
+
+    speak("Negative samples complete!")
+    print(f"\nCollected {count} negative samples")
+
+
+if __name__ == "__main__":
+    mode = sys.argv[1] if len(sys.argv) > 1 else "positive"
+    count = int(sys.argv[2]) if len(sys.argv) > 2 else (50 if mode == "positive" else 30)
+
+    if mode == "positive":
+        collect_positive(count)
+    elif mode == "negative":
+        collect_negative(count)
+    else:
+        print("Usage: auto_collect.py [positive|negative] [count]")

--- a/runtime/wake-word/collect_samples.py
+++ b/runtime/wake-word/collect_samples.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""
+Wake Word Sample Collector
+Collects positive ("Hey Arlowe") and negative (other speech) samples for verifier training.
+
+Usage:
+  ./collect_samples.py positive   # Record wake word samples
+  ./collect_samples.py negative   # Record other speech samples
+  ./collect_samples.py status     # Show current counts
+
+Environment:
+  ARLOWE_WAKE_WORD_STATE -- base dir containing positive/ and negative/ subdirs
+                            (default /var/lib/arlowe/wake-word)
+"""
+import sys
+import os
+import time
+import wave
+import pyaudio
+import numpy as np
+from datetime import datetime
+
+_STATE_DIR = os.environ.get("ARLOWE_WAKE_WORD_STATE", "/var/lib/arlowe/wake-word")
+POSITIVE_DIR = os.path.join(_STATE_DIR, "positive")
+NEGATIVE_DIR = os.path.join(_STATE_DIR, "negative")
+
+# Audio settings (must match openWakeWord expectations)
+SAMPLE_RATE = 16000
+CHANNELS = 1
+CHUNK = 1024
+FORMAT = pyaudio.paInt16
+RECORD_SECONDS = 2.0  # Duration per sample
+
+
+def ensure_dirs():
+    os.makedirs(POSITIVE_DIR, exist_ok=True)
+    os.makedirs(NEGATIVE_DIR, exist_ok=True)
+
+
+def get_next_filename(sample_type: str) -> str:
+    """Get next available filename for the sample type."""
+    directory = POSITIVE_DIR if sample_type == "positive" else NEGATIVE_DIR
+    existing = [f for f in os.listdir(directory) if f.endswith('.wav')]
+    next_num = len(existing) + 1
+    timestamp = datetime.now().strftime("%H%M%S")
+    return os.path.join(directory, f"{sample_type}_{next_num:03d}_{timestamp}.wav")
+
+
+def record_sample(filename: str) -> bool:
+    """Record a single audio sample to file."""
+    pa = pyaudio.PyAudio()
+
+    # Find WM8960 device
+    device_index = None
+    for i in range(pa.get_device_count()):
+        info = pa.get_device_info_by_index(i)
+        if 'wm8960' in info['name'].lower() and info['maxInputChannels'] > 0:
+            device_index = i
+            break
+
+    if device_index is None:
+        device_index = 0  # fallback to default
+
+    try:
+        stream = pa.open(
+            format=FORMAT,
+            channels=CHANNELS,
+            rate=SAMPLE_RATE,
+            input=True,
+            input_device_index=device_index,
+            frames_per_buffer=CHUNK
+        )
+
+        frames = []
+        num_chunks = int(SAMPLE_RATE / CHUNK * RECORD_SECONDS)
+
+        print("Recording...", end="", flush=True)
+        for _ in range(num_chunks):
+            data = stream.read(CHUNK, exception_on_overflow=False)
+            frames.append(data)
+        print(" Done!")
+
+        stream.stop_stream()
+        stream.close()
+        pa.terminate()
+
+        # Save to WAV file
+        with wave.open(filename, 'wb') as wf:
+            wf.setnchannels(CHANNELS)
+            wf.setsampwidth(pa.get_sample_size(FORMAT))
+            wf.setframerate(SAMPLE_RATE)
+            wf.writeframes(b''.join(frames))
+
+        return True
+
+    except Exception as e:
+        print(f"\nError: {e}")
+        pa.terminate()
+        return False
+
+
+def collect_positive():
+    """Collect positive wake word samples."""
+    print("=" * 50)
+    print("POSITIVE SAMPLE COLLECTION")
+    print("=" * 50)
+    print("\nSay 'Hey Arlowe' clearly when prompted.")
+    print("Vary your tone, distance from mic, and speaking speed.")
+    print("Press Enter to record, 'q' to quit.\n")
+
+    count = len([f for f in os.listdir(POSITIVE_DIR) if f.endswith('.wav')])
+    target = 50
+
+    while count < target:
+        remaining = target - count
+        print(f"[{count}/{target}] {remaining} samples remaining")
+
+        user_input = input("Press Enter to record (or 'q' to quit): ").strip().lower()
+        if user_input == 'q':
+            break
+
+        filename = get_next_filename("positive")
+        if record_sample(filename):
+            count += 1
+            print(f"Saved: {os.path.basename(filename)}\n")
+        else:
+            print("Recording failed, try again.\n")
+
+    print(f"\nCollection complete! {count} positive samples in {POSITIVE_DIR}")
+
+
+def collect_negative():
+    """Collect negative (non-wake-word) speech samples."""
+    print("=" * 50)
+    print("NEGATIVE SAMPLE COLLECTION")
+    print("=" * 50)
+    print("\nSay random phrases that are NOT 'Hey Arlowe'.")
+    print("Examples: 'Hello', 'What time is it', 'Play some music'")
+    print("Press Enter to record, 'q' to quit.\n")
+
+    count = len([f for f in os.listdir(NEGATIVE_DIR) if f.endswith('.wav')])
+    target = 30
+
+    while count < target:
+        remaining = target - count
+        print(f"[{count}/{target}] {remaining} samples remaining")
+
+        user_input = input("Press Enter to record (or 'q' to quit): ").strip().lower()
+        if user_input == 'q':
+            break
+
+        filename = get_next_filename("negative")
+        if record_sample(filename):
+            count += 1
+            print(f"Saved: {os.path.basename(filename)}\n")
+        else:
+            print("Recording failed, try again.\n")
+
+    print(f"\nCollection complete! {count} negative samples in {NEGATIVE_DIR}")
+
+
+def show_status():
+    """Show current sample counts."""
+    pos_count = len([f for f in os.listdir(POSITIVE_DIR) if f.endswith('.wav')])
+    neg_count = len([f for f in os.listdir(NEGATIVE_DIR) if f.endswith('.wav')])
+
+    print("\nCurrent Sample Status:")
+    print(f"  Positive ('Hey Arlowe'): {pos_count}/50")
+    print(f"  Negative (other speech): {neg_count}/30")
+
+    if pos_count >= 50 and neg_count >= 30:
+        print("\nReady to train! Run: ./train_verifier.py")
+    else:
+        print("\nNeed more samples before training.")
+
+
+def main():
+    ensure_dirs()
+
+    if len(sys.argv) < 2:
+        print("Usage: ./collect_samples.py [positive|negative|status]")
+        show_status()
+        return
+
+    action = sys.argv[1].lower()
+
+    if action == "positive":
+        collect_positive()
+    elif action == "negative":
+        collect_negative()
+    elif action == "status":
+        show_status()
+    else:
+        print(f"Unknown action: {action}")
+        print("Usage: ./collect_samples.py [positive|negative|status]")
+
+if __name__ == "__main__":
+    main()

--- a/runtime/wake-word/quick_test.py
+++ b/runtime/wake-word/quick_test.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Quick wake word test with audio confirmation.
+
+Loads the base model and optionally a verifier, then listens for ~30 seconds.
+If no verifier is found at ARLOWE_WAKE_WORD_VERIFIER the test runs in
+base-model-only mode (higher false-positive rate, no speaker gating).
+
+Environment:
+  ARLOWE_VENV_SITE_PACKAGES — extra sys.path entry (set in dev / image build)
+  ARLOWE_WAKE_WORD_STATE    — base dir (default /var/lib/arlowe/wake-word)
+  ARLOWE_WAKE_WORD_VERIFIER — verifier .pkl path (default STATE_DIR/verifier.pkl)
+  ARLOWE_SPEAK_BIN          — path to speak helper (default /usr/local/bin/speak)
+"""
+import os
+import sys
+
+_extra = os.environ.get("ARLOWE_VENV_SITE_PACKAGES")
+if _extra and _extra not in sys.path:
+    sys.path.insert(0, _extra)
+
+import pickle
+import subprocess
+import pyaudio
+import numpy as np
+import openwakeword
+from openwakeword.model import Model
+
+_STATE_DIR = os.environ.get("ARLOWE_WAKE_WORD_STATE", "/var/lib/arlowe/wake-word")
+VERIFIER_MODEL = os.environ.get("ARLOWE_WAKE_WORD_VERIFIER",
+                                os.path.join(_STATE_DIR, "verifier.pkl"))
+_SPEAK_BIN = os.environ.get("ARLOWE_SPEAK_BIN", "/usr/local/bin/speak")
+
+
+def speak(text):
+    if os.path.exists(_SPEAK_BIN):
+        subprocess.run([_SPEAK_BIN, text], capture_output=True)
+
+
+def main():
+    print("Loading models...", flush=True)
+
+    # Load base model
+    models = [p for p in openwakeword.get_pretrained_model_paths() if 'jarvis' in p]
+    oww_model = Model(wakeword_model_paths=models)
+
+    # Load verifier if present; fall back to base-model-only
+    verifier = None
+    if os.path.exists(VERIFIER_MODEL):
+        with open(VERIFIER_MODEL, 'rb') as f:
+            verifier = pickle.load(f)
+        print(f"Verifier loaded: {VERIFIER_MODEL}", flush=True)
+    else:
+        print(f"No verifier at {VERIFIER_MODEL} -- base-model-only mode (threshold 0.7).", flush=True)
+
+    print("Models loaded!", flush=True)
+
+    # Audio setup
+    pa = pyaudio.PyAudio()
+    stream = pa.open(
+        format=pyaudio.paInt16,
+        channels=1,
+        rate=16000,
+        input=True,
+        frames_per_buffer=1280,
+        input_device_index=0
+    )
+
+    speak("Listening for hey arlowe")
+    print("Listening... say 'Hey Arlowe'", flush=True)
+
+    detected = False
+    loops = 0
+    max_loops = 300  # ~30 seconds
+
+    while not detected and loops < max_loops:
+        loops += 1
+        audio = np.frombuffer(stream.read(1280, exception_on_overflow=False), dtype=np.int16)
+        prediction = oww_model.predict(audio)
+
+        for wake_word, score in prediction.items():
+            # Base-model-only path (no verifier)
+            if verifier is None:
+                if score > 0.7:
+                    print(f"Base score: {score:.3f} DETECTED!", flush=True)
+                    speak("I heard you! Hey Arlowe works!")
+                    detected = True
+                    break
+                continue
+
+            # Verifier path
+            if score > 0.25:
+                print(f"Base score: {score:.3f}", flush=True)
+
+                # Get verifier score
+                features = oww_model.preprocessor.get_features(oww_model.model_inputs[wake_word])
+                verifier_score = verifier.predict_proba([features.flatten()])[0][1]
+                print(f"Verifier score: {verifier_score:.3f}", flush=True)
+
+                if verifier_score > 0.5:
+                    print("DETECTED!", flush=True)
+                    speak("I heard you! Hey Arlowe works!")
+                    detected = True
+                    break
+
+    stream.close()
+    pa.terminate()
+
+    if not detected:
+        print("Timeout - didn't detect wake word", flush=True)
+        speak("Didn't hear the wake word. Let's try again.")
+
+if __name__ == "__main__":
+    main()

--- a/runtime/wake-word/requirements.txt
+++ b/runtime/wake-word/requirements.txt
@@ -1,0 +1,9 @@
+# runtime/wake-word -- training + testing deps
+# Pinned from arlowe-1 ~/venvs/voice/
+# Note: shared with runtime/voice -- keep versions in sync if both import openwakeword.
+joblib==1.5.3
+numpy==2.3.5
+openwakeword==0.4.0
+PyAudio==0.2.14
+scikit-learn==1.8.0
+scipy==1.17.0

--- a/runtime/wake-word/test_verifier.py
+++ b/runtime/wake-word/test_verifier.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""
+Test the custom "Hey Arlowe" wake word verifier.
+
+Listens for wake word detections using the base model + verifier combination.
+
+State is read from environment:
+  ARLOWE_WAKE_WORD_STATE    — base dir (default /var/lib/arlowe/wake-word)
+  ARLOWE_WAKE_WORD_VERIFIER — verifier .pkl path (default STATE_DIR/verifier.pkl)
+"""
+import os
+import sys
+
+_extra = os.environ.get("ARLOWE_VENV_SITE_PACKAGES")
+if _extra and _extra not in sys.path:
+    sys.path.insert(0, _extra)
+
+import pickle
+import pyaudio
+import numpy as np
+import openwakeword
+from openwakeword.model import Model
+
+_STATE_DIR = os.environ.get("ARLOWE_WAKE_WORD_STATE", "/var/lib/arlowe/wake-word")
+VERIFIER_MODEL = os.environ.get("ARLOWE_WAKE_WORD_VERIFIER",
+                                os.path.join(_STATE_DIR, "verifier.pkl"))
+BASE_MODEL = "hey_jarvis"
+
+# Detection thresholds
+BASE_THRESHOLD = 0.3       # Threshold for base model detection
+VERIFIER_THRESHOLD = 0.6   # Threshold for verifier confirmation
+
+def main():
+    # Check for verifier model
+    if not os.path.exists(VERIFIER_MODEL):
+        print(f"Verifier model not found: {VERIFIER_MODEL}")
+        print("Run train_verifier.py first!")
+        return 1
+
+    print("=" * 50)
+    print("HEY ARLOWE WAKE WORD TEST")
+    print("=" * 50)
+
+    # Load models
+    print("\nLoading base model...", end=" ", flush=True)
+    models = [p for p in openwakeword.get_pretrained_model_paths() if 'jarvis' in p]
+    oww_model = Model(wakeword_model_paths=models)
+    print("OK")
+
+    print("Loading verifier model...", end=" ", flush=True)
+    with open(VERIFIER_MODEL, 'rb') as f:
+        verifier = pickle.load(f)
+    print("OK")
+
+    # Audio setup
+    pa = pyaudio.PyAudio()
+
+    # Find WM8960 device
+    device_index = 0
+    for i in range(pa.get_device_count()):
+        info = pa.get_device_info_by_index(i)
+        if 'wm8960' in info['name'].lower() and info['maxInputChannels'] > 0:
+            device_index = i
+            break
+
+    stream = pa.open(
+        format=pyaudio.paInt16,
+        channels=1,
+        rate=16000,
+        input=True,
+        frames_per_buffer=1280,
+        input_device_index=device_index
+    )
+
+    print(f"\nListening for 'Hey Arlowe'...")
+    print("Press Ctrl+C to stop\n")
+
+    try:
+        while True:
+            # Get audio chunk
+            audio = np.frombuffer(
+                stream.read(1280, exception_on_overflow=False),
+                dtype=np.int16
+            )
+
+            # Get base model prediction
+            prediction = oww_model.predict(audio)
+
+            for wake_word, score in prediction.items():
+                # Show activity
+                if score > 0.1:
+                    print(f"Base: {score:.3f}", end="")
+
+                # Check if base model triggered
+                if score > BASE_THRESHOLD:
+                    # Get features for verifier
+                    features = oww_model.preprocessor.get_features(
+                        oww_model.model_inputs[wake_word]
+                    )
+
+                    # Run verifier
+                    verifier_score = verifier.predict_proba([features.flatten()])[0][1]
+                    print(f" -> Verifier: {verifier_score:.3f}", end="")
+
+                    if verifier_score > VERIFIER_THRESHOLD:
+                        print(f" WAKE WORD DETECTED!")
+                        oww_model.reset()
+                    else:
+                        print(" (rejected)")
+                elif score > 0.1:
+                    print()  # newline for activity display
+
+    except KeyboardInterrupt:
+        print("\n\nStopped.")
+    finally:
+        stream.close()
+        pa.terminate()
+
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/runtime/wake-word/train_verifier.py
+++ b/runtime/wake-word/train_verifier.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""
+Train a custom verifier model for "Hey Arlowe" wake word detection.
+
+This uses openWakeWord's verifier system to train a speaker-specific model
+on top of the hey_jarvis base model (phonetically similar to "Hey Arlowe").
+
+The verifier learns to recognize YOUR voice saying the wake word, reducing
+false positives from other speakers or similar-sounding words.
+
+Usage: ./train_verifier.py
+Requires: At least 50 positive and 30 negative samples in the appropriate dirs.
+"""
+import os
+import sys
+
+_extra = os.environ.get("ARLOWE_VENV_SITE_PACKAGES")
+if _extra and _extra not in sys.path:
+    sys.path.insert(0, _extra)
+
+import glob
+import openwakeword
+from openwakeword.custom_verifier_model import train_custom_verifier
+
+_STATE_DIR = os.environ.get("ARLOWE_WAKE_WORD_STATE", "/var/lib/arlowe/wake-word")
+POSITIVE_DIR = os.path.join(_STATE_DIR, "positive")
+NEGATIVE_DIR = os.path.join(_STATE_DIR, "negative")
+OUTPUT_MODEL = os.environ.get("ARLOWE_WAKE_WORD_VERIFIER",
+                              os.path.join(_STATE_DIR, "verifier.pkl"))
+
+# Base model - hey_jarvis is phonetically close to "hey arlowe"
+BASE_MODEL = "hey_jarvis"
+
+def main():
+    # Check sample counts
+    positive_samples = glob.glob(os.path.join(POSITIVE_DIR, "*.wav"))
+    negative_samples = glob.glob(os.path.join(NEGATIVE_DIR, "*.wav"))
+    
+    print("=" * 50)
+    print("HEY ARLOWE VERIFIER TRAINING")
+    print("=" * 50)
+    print(f"\nPositive samples: {len(positive_samples)}")
+    print(f"Negative samples: {len(negative_samples)}")
+    
+    if len(positive_samples) < 50:
+        print(f"\nNeed at least 50 positive samples (have {len(positive_samples)})")
+        print("Run: ./collect_samples.py positive")
+        return 1
+
+    if len(negative_samples) < 30:
+        print(f"\nNeed at least 30 negative samples (have {len(negative_samples)})")
+        print("Run: ./collect_samples.py negative")
+        return 1
+    
+    print(f"\nBase model: {BASE_MODEL}")
+    print(f"Output: {OUTPUT_MODEL}")
+    print("\nStarting training...\n")
+
+    try:
+        train_custom_verifier(
+            positive_reference_clips=positive_samples,
+            negative_reference_clips=negative_samples,
+            output_path=OUTPUT_MODEL,
+            model_name=BASE_MODEL
+        )
+
+        print(f"\nTraining complete!")
+        print(f"Model saved to: {OUTPUT_MODEL}")
+        print("\nTest it with: ./test_verifier.py")
+        return 0
+
+    except Exception as e:
+        print(f"\nTraining failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return 1
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Extracts the 5 wake-word training scripts from `~/wake_word/` on arlowe-1 into `runtime/wake-word/` with full sanitization
- Reroutes all `/home/focal55/...` literals to env-overridable paths defaulting to `/var/lib/arlowe/wake-word/`
- Adds `requirements.txt` pinned from arlowe-1 `~/venvs/voice/` pip freeze
- Authors `README.md` (107 lines) documenting the generic-model swap path, personalization deferral to v1.1, and R6 enforcement rationale

## Biometric data: confirmed absent

No biometric data included. Verified via:
1. Dry-run rsync excludes (`--exclude='*.pkl' --exclude='positive/' --exclude='negative/'` in `scripts/dev-pull-from-pi.sh`)
2. Filesystem check: `find runtime/wake-word/ -name '*.pkl' -o -name '*.wav' ...` -- empty
3. Git-history sweep: `git log --all --diff-filter=A --name-only -- '*.pkl' '*.wav'` -- empty

## Sanitization changes

| Script | Changes |
|---|---|
| `train_verifier.py` | venv hack -> `ARLOWE_VENV_SITE_PACKAGES`; SAMPLE_DIR-relative state paths -> `ARLOWE_WAKE_WORD_STATE` / `ARLOWE_WAKE_WORD_VERIFIER` env |
| `test_verifier.py` | Same venv + state path sanitization |
| `quick_test.py` | Venv + state paths; `/home/focal55/bin/speak` -> `ARLOWE_SPEAK_BIN`; added graceful no-verifier fallback at threshold 0.7 |
| `auto_collect.py` | `/home/focal55/bin/speak` -> `ARLOWE_SPEAK_BIN`; hardcoded `plughw:2,0` -> `ARLOWE_ALSA_DEVICE`; state paths -> env |
| `collect_samples.py` | SAMPLE_DIR-relative state paths -> `ARLOWE_WAKE_WORD_STATE` env |

## Test plan

- [ ] Confirm `runtime/wake-word/` contains exactly the 5 scripts, `requirements.txt`, `README.md`
- [ ] Confirm zero `.pkl` files, zero `.wav` files, no `positive/` or `negative/` directories
- [ ] Confirm `git log --all --diff-filter=A -- '*.pkl' '*.wav'` is empty
- [ ] Confirm zero `focal55`/`/home/focal55` references in `runtime/wake-word/`
- [ ] Confirm `train_verifier.py` uses `ARLOWE_WAKE_WORD_STATE` and `ARLOWE_WAKE_WORD_VERIFIER`
- [ ] Confirm `quick_test.py` handles missing verifier gracefully (no crash)
- [ ] Confirm README >= 50 lines, mentions `hey_jarvis`, biometric/R6, and personalization deferral

Closes #9

---
Generated with [Claude Code](https://claude.com/claude-code)