### PR TITLE
ci: raise PR-size hard cap to 1500 during Phase 1

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -45,8 +45,11 @@ jobs:
           NET=$(git diff --shortstat "$BASE_SHA..$HEAD_SHA" | awk '{print $4 + $6}')
           NET=${NET:-0}
           echo "Net lines changed: $NET"
-          if [ "$NET" -gt 600 ]; then
-            echo "::error::PR is too large ($NET net lines). Atomic PRs are <400 lines net. Please split."
+          # Hard cap raised to 1500 during Phase 1 (runtime extraction): pulling whole
+          # Python files out of a monorepo is monolithic by nature; voice_client.py
+          # alone is 543 LOC. Restore to 600 once Phase 1 closes and surgical work resumes.
+          if [ "$NET" -gt 1500 ]; then
+            echo "::error::PR is too large ($NET net lines). Hard cap is 1500 during Phase 1. Please split."
             exit 1
           fi
           if [ "$NET" -gt 400 ]; then


### PR DESCRIPTION
## Summary

- Raises hard fail in `pr-checks.yml` size-check from 600 → 1500 net lines
- Keeps 400-line warning unchanged
- Comment in the workflow notes the temporary nature

## Why

Phase 1 extracts monolithic Python files from `iol-monorepo`. Wave 2 fan-out hit the cap on 4 correctly-scoped PRs (#21, #23, #25, #26). The cap was generic-template default and is the wrong shape for extraction work.

Closes #28

## Test plan

- [ ] CI on this PR: `PR size` passes (5 net lines added)
- [ ] After merge: PRs #21, #23, #25, #26 re-run CI and unblock