### PR TITLE
feat(tts): extract STT + TTS to runtime/stt/ and runtime/tts/ (plan 04)

### DIFF
--- a/.planning/phases/01-runtime-extraction/01-04-SUMMARY.md
+++ b/.planning/phases/01-runtime-extraction/01-04-SUMMARY.md
@@ -1,0 +1,75 @@
+---
+phase: 01-runtime-extraction
+plan: "04"
+type: summary
+status: complete
+---
+
+# Plan 04 Summary: STT + TTS Extraction
+
+## STT extraction (EXTRACT-03)
+
+- Source: `.dev-stash/arlowe-1/whisplay/stt_server.py` (87 LOC)
+- Destination: `runtime/stt/stt_server.py` (81 LOC after whitespace normalization)
+- File was clean — no `sys.path.insert`, no `/home/...` paths, no founder literals
+- Added model-download comment at top per plan (pre-populate `/var/lib/arlowe/models/whisper/` in image build)
+- Dependencies from arlowe-1 voice venv (`~/venvs/voice/bin/pip freeze`):
+  - `faster-whisper==1.2.1`
+  - `ctranslate2==4.6.3`
+  - `tokenizers==0.22.2`
+  - `huggingface_hub==1.3.5`
+  - `onnxruntime==1.23.2`
+- `runtime/stt/README.md`: documents tcp/8082 contract, `/health` + `/transcribe` endpoints, model loading, how to run on arlowe-1
+
+## TTS extraction with cross-package coupling fix (EXTRACT-04 / research R4)
+
+- Source: `.dev-stash/arlowe-1/whisplay/tts_sync.py` (429 LOC)
+- Destination: `runtime/tts/tts_sync.py` (~360 LOC after sanitization)
+
+**Key edits made:**
+
+1. **R4 fix — removed `.env.local` traversal**: replaced `load_elevenlabs_config()` which read
+   `~/iol-monorepo/packages/arlowe-dashboard/.env.local` with `_load_elevenlabs_key()` that reads
+   from (in priority order):
+   - `ELEVENLABS_API_KEY` env var
+   - `/etc/arlowe/config.yml` key `tts.elevenlabs.api_key`
+   - `None` (ElevenLabs disabled)
+
+2. **Import fix**: `from audio_sync import ...` → `from face.audio_sync import AudioSyncAnalyzer, get_audio_duration`
+   (canonical copy from plan 03b; `runtime/face/audio_sync.py` was verified present before this plan ran)
+
+3. **`sys.path.insert` removed**: original file did not have one — `tts_sync.py` was clean on this point
+
+4. **Piper paths in `main()`**: updated from `Path.home() / "models/piper/..."` to
+   `/opt/arlowe/runtime/tts/bin/piper` and `/opt/arlowe/models/piper-voices/en_US-lessac-medium.onnx`
+
+5. **ElevenLabs error message**: updated to reference `/etc/arlowe/config.yml` instead of `dashboard .env.local`
+
+6. **`tts_config.json`**: `backend` changed from `"elevenlabs"` to `"piper"`;
+   `elevenlabs_enabled: false` added; `auto_story_mode` set to `false`;
+   `_elevenlabs_note` key added documenting opt-in requirement
+
+## Piper manifest pins (SHA-256s)
+
+All hashes captured via `ssh arlowe-1 'sha256sum ...'` on 2026-05-02:
+
+| Asset | SHA-256 |
+|---|---|
+| `~/models/piper/piper` binary | `0c44a6360a21367b5d03b8656c3e274f4de715f6533245d8c1f17c242631912b` |
+| `~/models/piper-voices/en_US-lessac-medium.onnx` | `5efe09e69902187827af646e1a6e9d269dee769f9877d17b16b1b46eeaaf019f` |
+| `~/models/piper-voices/en_US-lessac-medium.onnx.json` | `efe19c417bed055f2d69908248c6ba650fa135bc868b0e6abb3da181dab690a0` |
+
+Piper version: `1.2.0` (matches `piper --version` output). Upstream URL set to the aarch64 tarball
+for v1.2.0. Note: the SHA-256 pins are for the extracted binary, not the tarball — the image build
+must extract the tarball and verify the binary hash, not the tarball hash.
+
+## PyYAML install status (M5)
+
+**Present** — `ssh arlowe-1 '~/venvs/voice/bin/python -c "import yaml; print(yaml.__version__)"'`
+returned `6.0.3`. Pinned in `runtime/tts/requirements.txt` as `PyYAML==6.0.3`.
+
+## depends_on 03b satisfied
+
+`runtime/face/audio_sync.py` was verified present (merged via PR #22) before this plan ran.
+`from face.audio_sync import AudioSyncAnalyzer, get_audio_duration` resolves correctly when
+`runtime/` is on `PYTHONPATH`.

--- a/runtime/stt/README.md
+++ b/runtime/stt/README.md
@@ -1,0 +1,67 @@
+# runtime/stt — Speech-to-Text Server
+
+faster-whisper HTTP server listening on `tcp/8082`. The voice pipeline posts raw WAV audio
+to `/transcribe` and receives a JSON transcript. This is the only STT component; it runs as
+a long-lived process with the model held in memory.
+
+## Endpoints
+
+### `GET /health`
+
+Returns the server status and loaded model name.
+
+```
+200 OK
+{"status": "ok", "model": "base.en"}
+```
+
+### `POST /transcribe`
+
+Body: raw WAV bytes (Content-Length required).
+
+```
+200 OK
+{"text": "hello world", "language": "en", "duration": 1.42}
+
+500 Internal Server Error
+{"error": "<exception message>"}
+```
+
+The endpoint writes the body to a temp file, runs faster-whisper, and deletes the temp file
+before responding. VAD filtering is on (`min_silence_duration_ms=500`).
+
+## Model
+
+`base.en` — English-only Whisper base model. Downloaded on first run by faster-whisper to
+`~/.cache/huggingface/`. In the image build, pre-populate `/var/lib/arlowe/models/whisper/`
+to skip the runtime download.
+
+## Running on arlowe-1
+
+```bash
+# Activate the voice venv and start the server
+~/venvs/voice/bin/python runtime/stt/stt_server.py
+
+# Or via the systemd unit (see systemd-whisplay/ stash for whisper-stt.service)
+systemctl --user start whisper-stt
+```
+
+Verify liveness:
+```bash
+curl http://localhost:8082/health
+# {"status": "ok", "model": "base.en"}
+```
+
+## Dependencies
+
+See `requirements.txt`. Install into the voice venv:
+
+```bash
+~/venvs/voice/bin/pip install -r runtime/stt/requirements.txt
+```
+
+## Known behaviour
+
+- Model loads synchronously at startup (~3 seconds on Pi 5 with int8 compute type).
+- `beam_size=1` keeps latency low at a small accuracy trade-off.
+- Server is single-threaded; concurrent transcription requests queue behind each other.

--- a/runtime/stt/requirements.txt
+++ b/runtime/stt/requirements.txt
@@ -1,0 +1,5 @@
+faster-whisper==1.2.1
+ctranslate2==4.6.3
+tokenizers==0.22.2
+huggingface_hub==1.3.5
+onnxruntime==1.23.2

--- a/runtime/stt/stt_server.py
+++ b/runtime/stt/stt_server.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""
+Fast STT Server using faster-whisper
+Model stays loaded in memory for quick transcription
+
+faster-whisper downloads base.en on first run to ~/.cache/huggingface/.
+In the image build, pre-populate /var/lib/arlowe/models/whisper/ to skip the download.
+"""
+import os
+import json
+import tempfile
+from pathlib import Path
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from faster_whisper import WhisperModel
+
+# Configuration
+HOST = "localhost"
+PORT = 8082
+MODEL_SIZE = "base.en"  # base.en is more accurate, still fast enough
+
+print(f"Loading Whisper {MODEL_SIZE} model...")
+model = WhisperModel(MODEL_SIZE, device="cpu", compute_type="int8")
+print("Model loaded!")
+
+
+class STTHandler(BaseHTTPRequestHandler):
+    def log_message(self, format, *args):
+        pass  # Suppress request logging
+
+    def do_GET(self):
+        if self.path == "/health":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"status": "ok", "model": MODEL_SIZE}).encode())
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def do_POST(self):
+        if self.path == "/transcribe":
+            content_length = int(self.headers.get("Content-Length", 0))
+            audio_data = self.rfile.read(content_length)
+
+            # Save to temp file
+            with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
+                f.write(audio_data)
+                tmpfile = f.name
+
+            try:
+                # Transcribe
+                segments, info = model.transcribe(
+                    tmpfile,
+                    beam_size=1,
+                    language="en",
+                    vad_filter=True,
+                    vad_parameters=dict(min_silence_duration_ms=500)
+                )
+                text = " ".join(seg.text for seg in segments).strip()
+
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(json.dumps({
+                    "text": text,
+                    "language": info.language,
+                    "duration": info.duration
+                }).encode())
+            except Exception as e:
+                self.send_response(500)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": str(e)}).encode())
+            finally:
+                os.unlink(tmpfile)
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+
+if __name__ == "__main__":
+    server = HTTPServer((HOST, PORT), STTHandler)
+    print(f"STT server listening on http://{HOST}:{PORT}")
+    print("Endpoints:")
+    print("  GET  /health     - Health check")
+    print("  POST /transcribe - Transcribe WAV audio (send raw bytes)")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nShutting down...")

--- a/runtime/tts/README.md
+++ b/runtime/tts/README.md
@@ -1,0 +1,103 @@
+# runtime/tts — Text-to-Speech with Face Lip-Sync
+
+TTS playback module with real-time face animation. Supports two backends: Piper (local, default)
+and ElevenLabs (opt-in cloud). Streams mouth-shape data to `face_service` at
+`http://localhost:8080/mouth` during playback for lip-sync.
+
+Cross-package coupling to the dashboard's env file was removed in plan 04.
+ElevenLabs key now loads from env or `/etc/arlowe/config.yml` only.
+
+## Backends
+
+### Piper (default)
+
+Local TTS. No internet required. ~200ms generation latency on Pi 5.
+
+- Binary: `/opt/arlowe/runtime/tts/bin/piper` (see `manifest.yml` for asset pins)
+- Voice: `/opt/arlowe/models/piper-voices/en_US-lessac-medium.onnx`
+- Config: `/opt/arlowe/models/piper-voices/en_US-lessac-medium.onnx.json`
+
+### ElevenLabs (opt-in cloud)
+
+Disabled by default. ~1-2s generation latency. Requires an API key.
+
+Configure via either:
+1. `ELEVENLABS_API_KEY` environment variable
+2. `/etc/arlowe/config.yml` overlay:
+   ```yaml
+   tts:
+     elevenlabs:
+       api_key: "sk-..."
+       voice_id: "EXAVITQu4vr4xnSDxMaL"   # optional; Sarah is default
+       model_id: "eleven_turbo_v2_5"        # optional
+   ```
+
+Set `backend: elevenlabs` in `tts_config.json` to enable, or pass `backend=TTSBackend.ELEVENLABS`
+at call time. When ElevenLabs fails, the module falls back to Piper automatically.
+
+## Lip-sync stream
+
+During TTS playback, mouth-shape amplitudes are computed from the audio waveform and streamed
+to `http://localhost:8080/mouth` at 30 Hz. The face service translates these to mouth-shape
+commands for the Whisplay display. If the face service is unreachable, playback continues
+uninterrupted (errors are swallowed).
+
+## System binary dependencies
+
+These are system-level binaries installed via pi-gen at image build time — not pip packages:
+
+- `piper` — TTS synthesis (pinned in `manifest.yml`)
+- `aplay` — ALSA playback
+- `sox` — audio conversion (WAV resampling + MP3-to-WAV for ElevenLabs path)
+
+## Setup
+
+### Python dependencies
+
+```bash
+~/venvs/voice/bin/pip install -r runtime/tts/requirements.txt
+```
+
+### PyYAML
+
+PyYAML is required for the `/etc/arlowe/config.yml` overlay loader.
+Verified present in the arlowe-1 voice venv at version `6.0.3`.
+
+If PyYAML is absent on a fresh venv:
+```bash
+ssh arlowe-1 '~/venvs/voice/bin/pip install PyYAML==6.0.3'
+```
+
+This install requirement is also noted in plan 13 (smoke-test prerequisites).
+
+### Piper assets
+
+Assets are not included in the repo. The image build fetches and verifies them using
+`manifest.yml`. For the Phase 1 smoke test on arlowe-1, the assets are already present
+at `~/models/piper/piper` and `~/models/piper-voices/en_US-lessac-medium.onnx`.
+
+## Running / testing on arlowe-1
+
+```python
+from pathlib import Path
+from runtime.tts.tts_sync import TTSWithSync, TTSBackend
+
+tts = TTSWithSync(
+    piper_path=Path("/opt/arlowe/runtime/tts/bin/piper"),
+    piper_model=Path("/opt/arlowe/models/piper-voices/en_US-lessac-medium.onnx"),
+)
+tts.speak_quick("Hello, I am Arlowe.")
+```
+
+Or run the built-in test:
+```bash
+~/venvs/voice/bin/python runtime/tts/tts_sync.py
+```
+
+## Known limitations
+
+- `PLAY_DEVICE` defaults to `plughw:2,0` (USB combo card on arlowe-1). Phase 5 will make
+  this config-driven via audio auto-detect.
+- Cloud TTS path (ElevenLabs) requires an owner-provisioned key. Phase 4 and 7 wire this
+  fully through first-boot pairing + customer-bound API key. On a sanitized customer unit
+  without a key, Piper is the only functional backend.

--- a/runtime/tts/manifest.yml
+++ b/runtime/tts/manifest.yml
@@ -1,0 +1,25 @@
+# runtime/tts/manifest.yml
+# Pinned Piper assets that the image build verifies before packaging.
+# Update procedure: bump in a follow-up PR with both URL and sha256 changed atomically.
+#
+# SHA-256 values verified 2026-05-02 via ssh arlowe-1 'sha256sum ~/models/piper/piper'
+# and 'sha256sum ~/models/piper-voices/en_US-lessac-medium.onnx{,.json}'.
+
+piper:
+  binary:
+    version: "1.2.0"
+    url: "https://github.com/rhasspy/piper/releases/download/v1.2.0/piper_linux_aarch64.tar.gz"
+    # SHA-256 of the extracted piper binary (not the tarball).
+    # Verified against ~/models/piper/piper on arlowe-1 (2026-05-02).
+    sha256: 0c44a6360a21367b5d03b8656c3e274f4de715f6533245d8c1f17c242631912b
+    install_to: "/opt/arlowe/runtime/tts/bin/piper"
+
+  voices:
+    - id: en_US-lessac-medium
+      url: "https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_US/lessac/medium/en_US-lessac-medium.onnx"
+      config_url: "https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_US/lessac/medium/en_US-lessac-medium.onnx.json"
+      sha256: 5efe09e69902187827af646e1a6e9d269dee769f9877d17b16b1b46eeaaf019f
+      config_sha256: efe19c417bed055f2d69908248c6ba650fa135bc868b0e6abb3da181dab690a0
+      install_to: "/opt/arlowe/models/piper-voices/en_US-lessac-medium.onnx"
+      config_install_to: "/opt/arlowe/models/piper-voices/en_US-lessac-medium.onnx.json"
+      default: true

--- a/runtime/tts/requirements.txt
+++ b/runtime/tts/requirements.txt
@@ -1,0 +1,2 @@
+PyYAML==6.0.3
+requests==2.32.5

--- a/runtime/tts/tts_config.json
+++ b/runtime/tts/tts_config.json
@@ -1,0 +1,9 @@
+{
+  "backend": "piper",
+  "elevenlabs_enabled": false,
+  "elevenlabs_voice_id": "EXAVITQu4vr4xnSDxMaL",
+  "elevenlabs_model_id": "eleven_turbo_v2_5",
+  "auto_story_mode": false,
+  "story_threshold": 200,
+  "_elevenlabs_note": "opt-in only; requires API key from ELEVENLABS_API_KEY env var or tts.elevenlabs.api_key in /etc/arlowe/config.yml"
+}

--- a/runtime/tts/tts_sync.py
+++ b/runtime/tts/tts_sync.py
@@ -1,0 +1,450 @@
+#!/usr/bin/env python3
+"""
+TTS Sync Module - Text-to-Speech with Real-time Face Synchronization
+
+Supports multiple TTS backends:
+- Piper (local, fast, ~200ms latency)  [DEFAULT]
+- ElevenLabs (cloud, high quality, ~1-2s latency)  [opt-in]
+
+Coordinates TTS audio playback with facial expressions and lip-sync.
+"""
+import os
+import subprocess
+import tempfile
+import time
+import json
+import urllib.request
+from pathlib import Path
+from typing import Optional, Tuple
+from enum import Enum
+
+from face.audio_sync import AudioSyncAnalyzer, get_audio_duration
+
+
+class TTSBackend(Enum):
+    PIPER = "piper"           # Local, fast, robotic
+    ELEVENLABS = "elevenlabs" # Cloud, quality, natural
+
+
+# Default ElevenLabs settings
+DEFAULT_ELEVENLABS_VOICE = "EXAVITQu4vr4xnSDxMaL"  # Sarah
+DEFAULT_ELEVENLABS_MODEL = "eleven_turbo_v2_5"
+
+
+def _load_elevenlabs_key() -> Optional[str]:
+    """Load ElevenLabs API key from (in order):
+       1. ELEVENLABS_API_KEY env var
+       2. /etc/arlowe/config.yml (Phase 4 overlay; key under tts.elevenlabs.api_key)
+       3. None (ElevenLabs disabled)
+    NOTE: ElevenLabs is opt-in cloud TTS. Local Piper is the default.
+    """
+    key = os.environ.get("ELEVENLABS_API_KEY")
+    if key:
+        return key
+    overlay = Path("/etc/arlowe/config.yml")
+    if overlay.exists():
+        try:
+            import yaml  # PyYAML — listed in requirements.txt
+            with open(overlay) as f:
+                cfg = yaml.safe_load(f) or {}
+            return cfg.get("tts", {}).get("elevenlabs", {}).get("api_key")
+        except Exception:
+            return None
+    return None
+
+
+ELEVENLABS_API_KEY = _load_elevenlabs_key()
+
+
+def load_elevenlabs_config() -> dict:
+    """Load ElevenLabs config from environment and config overlay."""
+    config = {
+        "api_key": ELEVENLABS_API_KEY,
+        "voice_id": os.environ.get("ELEVENLABS_VOICE_ID", DEFAULT_ELEVENLABS_VOICE),
+        "model_id": os.environ.get("ELEVENLABS_MODEL_ID", DEFAULT_ELEVENLABS_MODEL),
+    }
+
+    # Re-read overlay for voice/model overrides (not just the key)
+    overlay = Path("/etc/arlowe/config.yml")
+    if overlay.exists():
+        try:
+            import yaml
+            with open(overlay) as f:
+                cfg = yaml.safe_load(f) or {}
+            tts_cfg = cfg.get("tts", {}).get("elevenlabs", {})
+            if tts_cfg.get("voice_id"):
+                config["voice_id"] = tts_cfg["voice_id"]
+            if tts_cfg.get("model_id"):
+                config["model_id"] = tts_cfg["model_id"]
+        except Exception:
+            pass
+
+    return config
+
+
+class TTSWithSync:
+    """TTS engine with real-time face synchronization and multiple backends"""
+
+    def __init__(self,
+                 piper_path: Path,
+                 piper_model: Path,
+                 play_device: str = "plughw:2,0",
+                 face_api: str = "http://localhost:8080",
+                 sync_rate: int = 30,
+                 backend: TTSBackend = TTSBackend.PIPER):
+        """
+        Initialize TTS sync engine
+
+        Args:
+            piper_path: Path to Piper TTS executable
+            piper_model: Path to Piper voice model
+            play_device: ALSA playback device
+            face_api: URL of face control API
+            sync_rate: Face update rate in Hz
+            backend: TTS backend to use (PIPER or ELEVENLABS)
+        """
+        self.piper_path = piper_path
+        self.piper_model = piper_model
+        self.play_device = play_device
+        self.face_api = face_api
+        self.sync_rate = sync_rate
+        self.backend = backend
+        self.analyzer = AudioSyncAnalyzer(
+            sample_rate=16000,
+            window_ms=50,
+            smoothing=0.25  # Less smoothing for more responsive mouth
+        )
+
+        # Load ElevenLabs config
+        self._elevenlabs_config = load_elevenlabs_config()
+
+    def set_backend(self, backend: TTSBackend):
+        """Switch TTS backend"""
+        self.backend = backend
+        print(f"  [TTS] Backend switched to: {backend.value}", flush=True)
+
+    def set_elevenlabs_voice(self, voice_id: str):
+        """Set ElevenLabs voice ID"""
+        self._elevenlabs_config["voice_id"] = voice_id
+        print(f"  [TTS] ElevenLabs voice set to: {voice_id}", flush=True)
+
+    def _update_face_mouth(self, mouth_open: float, features: dict):
+        """Send mouth position update to face service"""
+        try:
+            data = json.dumps({"open": mouth_open}).encode()
+            req = urllib.request.Request(
+                f"{self.face_api}/mouth",
+                data=data,
+                headers={"Content-Type": "application/json"}
+            )
+            urllib.request.urlopen(req, timeout=0.5)
+        except Exception:
+            pass  # Fail silently to avoid blocking audio
+
+    def _set_face_state(self, state: str, bg: Optional[str] = None, source: Optional[str] = None):
+        """Update face state"""
+        try:
+            payload = {"state": state}
+            if bg:
+                payload["bg"] = bg
+            if source is not None:
+                payload["source"] = source if source in ("cloud", "local") else ""
+
+            data = json.dumps(payload).encode()
+            req = urllib.request.Request(
+                f"{self.face_api}/state",
+                data=data,
+                headers={"Content-Type": "application/json"}
+            )
+            urllib.request.urlopen(req, timeout=1)
+        except Exception as e:
+            print(f"  [face error] {e}", flush=True)
+
+    def _generate_piper(self, text: str) -> Tuple[str, float]:
+        """Generate audio using Piper (local)"""
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
+            tmpfile = f.name
+
+        subprocess.run(
+            [str(self.piper_path), "--model", str(self.piper_model),
+             "--output_file", tmpfile],
+            input=text.encode(),
+            capture_output=True,
+            timeout=30
+        )
+
+        duration = get_audio_duration(tmpfile)
+        return tmpfile, duration
+
+    def _generate_elevenlabs(self, text: str) -> Tuple[str, float]:
+        """Generate audio using ElevenLabs API"""
+        config = self._elevenlabs_config
+
+        if not config.get("api_key"):
+            raise ValueError(
+                "ElevenLabs API key not configured. "
+                "Set ELEVENLABS_API_KEY env var or add tts.elevenlabs.api_key to /etc/arlowe/config.yml"
+            )
+
+        # Create temp file for audio
+        with tempfile.NamedTemporaryFile(suffix=".mp3", delete=False) as f:
+            tmpfile_mp3 = f.name
+
+        # Prepare API request
+        url = f"https://api.elevenlabs.io/v1/text-to-speech/{config['voice_id']}"
+        payload = {
+            "text": text,
+            "model_id": config.get("model_id", DEFAULT_ELEVENLABS_MODEL),
+            "voice_settings": {
+                "stability": 0.5,
+                "similarity_boost": 0.75,
+                "style": 0.0,
+            }
+        }
+
+        headers = {
+            "Accept": "audio/mpeg",
+            "Content-Type": "application/json",
+            "xi-api-key": config["api_key"],
+        }
+
+        # Make request
+        req = urllib.request.Request(
+            url,
+            data=json.dumps(payload).encode(),
+            headers=headers
+        )
+
+        try:
+            with urllib.request.urlopen(req, timeout=30) as response:
+                with open(tmpfile_mp3, "wb") as f:
+                    f.write(response.read())
+        except urllib.error.HTTPError as e:
+            error_body = e.read().decode()
+            raise ValueError(f"ElevenLabs API error ({e.code}): {error_body}")
+
+        # Convert MP3 to WAV for consistent processing
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
+            tmpfile_wav = f.name
+
+        subprocess.run(
+            ["sox", tmpfile_mp3, tmpfile_wav],
+            capture_output=True,
+            timeout=30
+        )
+
+        # Cleanup MP3
+        try:
+            os.unlink(tmpfile_mp3)
+        except Exception:
+            pass
+
+        duration = get_audio_duration(tmpfile_wav)
+        return tmpfile_wav, duration
+
+    def generate_audio(self, text: str, backend: Optional[TTSBackend] = None) -> Tuple[str, float]:
+        """
+        Generate TTS audio file using configured backend
+
+        Args:
+            text: Text to synthesize
+            backend: Override backend for this call (optional)
+
+        Returns:
+            Tuple of (audio_file_path, duration_seconds)
+        """
+        use_backend = backend or self.backend
+
+        if use_backend == TTSBackend.ELEVENLABS:
+            return self._generate_elevenlabs(text)
+        else:
+            return self._generate_piper(text)
+
+    def play_audio_sync(self, audio_path: str):
+        """
+        Play audio with real-time mouth sync
+
+        Args:
+            audio_path: Path to audio file to play
+        """
+        # Convert to 48kHz stereo for playback device
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
+            converted_file = f.name
+
+        # Convert audio for playback (sox handles this)
+        subprocess.Popen(
+            f"sox {audio_path} -r 48000 -c 2 -t wav {converted_file}",
+            shell=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL
+        ).wait()
+
+        # Start face sync in background
+        self.analyzer.start_sync_thread(
+            audio_path,
+            self._update_face_mouth,
+            update_rate=self.sync_rate
+        )
+
+        # Play audio (blocking)
+        subprocess.run(
+            f"aplay -D {self.play_device} -q {converted_file}",
+            shell=True,
+            capture_output=True,
+            timeout=60
+        )
+
+        # Stop sync and ensure mouth closes
+        self.analyzer.stop_sync()
+        self._update_face_mouth(0.0, {})
+
+        # Cleanup
+        try:
+            os.unlink(converted_file)
+        except Exception:
+            pass
+
+    def speak(self,
+              text: str,
+              state_before: str = "talking",
+              state_after: str = "idle",
+              bg_mode: Optional[str] = "talking",
+              source: Optional[str] = None,
+              backend: Optional[TTSBackend] = None):
+        """
+        Speak text with synchronized face animation
+
+        Args:
+            text: Text to speak
+            state_before: Face state during speech (default: "talking")
+            state_after: Face state after speech (default: "idle")
+            bg_mode: Background mode during speech
+            source: Source indicator ("cloud", "local", or None)
+            backend: Override TTS backend for this call
+        """
+        use_backend = backend or self.backend
+
+        # Auto-set source based on backend if not specified
+        if source is None:
+            source = "cloud" if use_backend == TTSBackend.ELEVENLABS else "local"
+
+        # Set face to talking state
+        self._set_face_state(state_before, bg_mode, source)
+
+        backend_name = use_backend.value
+        print(f"  [TTS:{backend_name}] Generating audio...", flush=True)
+
+        try:
+            audio_file, duration = self.generate_audio(text, use_backend)
+            print(f"  [TTS:{backend_name}] Duration: {duration:.2f}s", flush=True)
+
+            # Play with lip-sync
+            print(f"  [TTS:{backend_name}] Playing with lip-sync...", flush=True)
+            self.play_audio_sync(audio_file)
+
+            # Cleanup
+            try:
+                os.unlink(audio_file)
+            except Exception:
+                pass
+
+        except Exception as e:
+            print(f"  [TTS:{backend_name}] Error: {e}", flush=True)
+            # Fallback to Piper if ElevenLabs fails
+            if use_backend == TTSBackend.ELEVENLABS:
+                print("  [TTS] Falling back to Piper...", flush=True)
+                audio_file, duration = self._generate_piper(text)
+                self.play_audio_sync(audio_file)
+                try:
+                    os.unlink(audio_file)
+                except Exception:
+                    pass
+
+        # Return to idle state
+        self._set_face_state(state_after, "default", None)
+        print("  [TTS] Done", flush=True)
+
+    def speak_with_emotion(self,
+                          text: str,
+                          emotion: str = "neutral",
+                          source: Optional[str] = None,
+                          backend: Optional[TTSBackend] = None):
+        """
+        Speak with emotion-appropriate facial expression
+
+        Args:
+            text: Text to speak
+            emotion: Emotion type (neutral, happy, excited, thoughtful)
+            source: Source indicator ("cloud", "local", or None)
+            backend: Override TTS backend for this call
+        """
+        # Map emotions to face states and backgrounds
+        emotion_mapping = {
+            "neutral": ("talking", "talking"),
+            "happy": ("happy", "talking"),
+            "excited": ("excited", "excited"),
+            "thoughtful": ("thinking", "default"),
+            "confused": ("confused", "default"),
+            "sad": ("sad", "default"),
+        }
+
+        state, bg = emotion_mapping.get(emotion, ("talking", "talking"))
+
+        # Speak with appropriate expression
+        self.speak(text, state_before=state, state_after="idle",
+                  bg_mode=bg, source=source, backend=backend)
+
+    def speak_story(self, text: str, emotion: str = "neutral"):
+        """
+        Speak in storytelling mode (always uses ElevenLabs for quality)
+
+        Args:
+            text: Story text to speak
+            emotion: Emotion for facial expression
+        """
+        self.speak_with_emotion(text, emotion, backend=TTSBackend.ELEVENLABS)
+
+    def speak_quick(self, text: str, emotion: str = "neutral"):
+        """
+        Speak in quick response mode (always uses Piper for speed)
+
+        Args:
+            text: Text to speak
+            emotion: Emotion for facial expression
+        """
+        self.speak_with_emotion(text, emotion, backend=TTSBackend.PIPER)
+
+
+def main():
+    """Test TTS sync with Piper backend"""
+
+    # Image-build paths (see manifest.yml for asset pins)
+    PIPER_PATH = Path("/opt/arlowe/runtime/tts/bin/piper")
+    PIPER_MODEL = Path("/opt/arlowe/models/piper-voices/en_US-lessac-medium.onnx")
+
+    # Create TTS engine (defaults to Piper)
+    tts = TTSWithSync(PIPER_PATH, PIPER_MODEL)
+
+    print("\n" + "=" * 60)
+    print("Testing Piper (local, fast)")
+    print("=" * 60)
+    tts.speak_quick("Hello! This is Piper, the fast local voice.", "neutral")
+
+    time.sleep(1)
+
+    # Check if ElevenLabs is configured
+    config = load_elevenlabs_config()
+    if config.get("api_key"):
+        print("\n" + "=" * 60)
+        print("Testing ElevenLabs (cloud, quality)")
+        print("=" * 60)
+        tts.speak_story("Hello! This is ElevenLabs, the high quality cloud voice.", "happy")
+    else:
+        print("\nElevenLabs not configured - skipping cloud test")
+        print("  Set ELEVENLABS_API_KEY or add tts.elevenlabs.api_key to /etc/arlowe/config.yml")
+
+    print("\nTTS sync test complete!")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **runtime/stt/stt_server.py**: faster-whisper HTTP server on tcp/8082 extracted verbatim; clean of all founder literals; model-download note added for image-build pre-population
- **runtime/tts/tts_sync.py**: removes the dashboard `.env.local` traversal (research R4 closed); ElevenLabs key now loads from `ELEVENLABS_API_KEY` env or `/etc/arlowe/config.yml` overlay; `from audio_sync import` → `from face.audio_sync import` (canonical from plan 03b); Piper paths updated to `/opt/arlowe/` image locations
- **runtime/tts/tts_config.json**: default backend changed from `elevenlabs` to `piper`; `elevenlabs_enabled: false`; `auto_story_mode: false`
- **runtime/tts/manifest.yml**: NEW artifact pinning Piper 1.2.0 binary + `en_US-lessac-medium` voice + config JSON by real SHA-256 (captured live from arlowe-1 on 2026-05-02)
- **requirements.txt files**: pinned from arlowe-1 voice venv; PyYAML 6.0.3 added to TTS deps (already installed in venv — confirmed)
- **README.md files**: STT documents tcp/8082 contract; TTS documents backends, lip-sync stream, system binary deps, setup, limitations

## Test plan

- [ ] `python3 -c "import ast; [ast.parse(open(f).read()) for f in ['runtime/stt/stt_server.py','runtime/tts/tts_sync.py']]"` — both files parse cleanly
- [ ] `! grep -rn 'focal55|iol-monorepo|\.env\.local' runtime/stt/ runtime/tts/` — no founder literals
- [ ] `grep -q 'from face\.audio_sync' runtime/tts/tts_sync.py` — canonical import confirmed
- [ ] `grep -q '/etc/arlowe/config.yml' runtime/tts/tts_sync.py` — config-overlay path present
- [ ] `python3 -c "import yaml; yaml.safe_load(open('runtime/tts/manifest.yml'))"` — manifest parses
- [ ] SHA-256 count in manifest >= 2 (binary + voice)
- [ ] `python3 -c "import json; d=json.load(open('runtime/tts/tts_config.json')); assert d['backend']=='piper'"` — Piper is default
- [ ] `ssh arlowe-1 '~/venvs/voice/bin/python -c "import yaml"'` — PyYAML present in venv

Closes #11