### PR TITLE
chore(dashboard): add pages and top-level components; strip workforce imports [2/3]

### DIFF
--- a/runtime/dashboard/app/api/logs/route.ts
+++ b/runtime/dashboard/app/api/logs/route.ts
@@ -1,0 +1,326 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { readFile, readdir } from 'fs/promises';
+import { existsSync } from 'fs';
+import { execSync } from 'child_process';
+
+// TODO(plan-08): repoint to /var/lib/arlowe/logs/ and drop SESSION_DIR/CRON_RUNS_DIR (workforce paths)
+const VOICE_LOG_DIR = '/home/focal55/whisplay/logs';
+const OPENCLAW_LOG_DIR = '/home/focal55/.openclaw/logs';
+const SESSION_DIR = '/home/focal55/.openclaw/agents/main/sessions';
+const CRON_RUNS_DIR = '/home/focal55/.openclaw/cron/runs';
+
+export interface LogEntry {
+  timestamp: string;
+  type: 'voice' | 'command' | 'session' | 'subagent' | 'cron' | 'service';
+  content: string;
+  metadata?: Record<string, unknown>;
+}
+
+// ─── Voice logs ───
+function parseVoiceLogs(content: string, dateStr: string): LogEntry[] {
+  const logs: LogEntry[] = [];
+  const lines = content.split('\n');
+  let currentEntry: Record<string, unknown> | null = null;
+  let entryStartTime: Date | null = null;
+  let collectingResponse = false;
+  let responseLines: string[] = [];
+  let responseProvider = '';
+  let responseModel = '';
+
+  const flush = (timestamp: string) => {
+    if (!currentEntry || responseLines.length === 0) return;
+    const fullResponse = responseLines.join('\n').trim();
+    if (entryStartTime) currentEntry.latencyMs = new Date(timestamp).getTime() - entryStartTime.getTime();
+    if (currentEntry.transcript && fullResponse) {
+      logs.push({
+        timestamp: String(currentEntry.timestamp) || timestamp,
+        type: 'voice',
+        content: `"${currentEntry.transcript}" → "${fullResponse.slice(0, 80)}..."`,
+        metadata: {
+          transcript: String(currentEntry.transcript),
+          response: fullResponse.slice(0, 500),
+          provider: responseProvider || 'local',
+          model: responseModel || (responseProvider === 'cloud' ? 'claude' : 'qwen'),
+          latencyMs: Number(currentEntry.latencyMs) || 0,
+        },
+      });
+    }
+    collectingResponse = false;
+    responseLines = [];
+    currentEntry = null;
+    entryStartTime = null;
+  };
+
+  for (const line of lines) {
+    const timeMatch = line.match(/^(\d{2}:\d{2}:\d{2})\s+(.+)/);
+    if (timeMatch) {
+      const [, time, rest] = timeMatch;
+      const timestamp = `${dateStr}T${time}`;
+      if (collectingResponse) flush(timestamp);
+
+      if (rest.includes('🔔 Wake word')) {
+        currentEntry = { timestamp };
+        entryStartTime = new Date(timestamp);
+      } else if (rest.includes('🎤 Heard:') && currentEntry) {
+        const m = rest.match(/🎤 Heard:\s*(.+)/);
+        if (m) currentEntry.transcript = m[1].trim();
+      } else if (rest.includes('🔊 Response') && currentEntry) {
+        const m = rest.match(/🔊 Response \(([^)|]+)(?:\|([^)]+))?\):\s*(.*)/);
+        if (m) {
+          responseProvider = m[1] === 'local' ? 'local' : 'claude';
+          responseModel = m[2] || (m[1] === 'local' ? 'qwen2.5-1.5b' : 'claude-opus');
+          responseLines = [m[3] || ''];
+          collectingResponse = true;
+        }
+      }
+    } else if (collectingResponse && line.trim()) {
+      responseLines.push(line);
+    }
+  }
+  if (collectingResponse && currentEntry) flush(`${dateStr}T23:59:59`);
+  return logs;
+}
+
+// ─── Command logs ───
+function parseCommandLogs(content: string): LogEntry[] {
+  const logs: LogEntry[] = [];
+  for (const line of content.split('\n').filter(l => l.trim())) {
+    try {
+      const e = JSON.parse(line);
+      logs.push({
+        timestamp: e.timestamp,
+        type: 'command',
+        content: `/${e.action} from ${e.source || 'unknown'}`,
+        metadata: { action: e.action, sessionKey: e.sessionKey, source: e.source },
+      });
+    } catch { /* skip */ }
+  }
+  return logs;
+}
+
+// ─── OpenClaw session messages ───
+async function parseSessionLogs(start: Date, end: Date): Promise<LogEntry[]> {
+  const logs: LogEntry[] = [];
+  if (!existsSync(SESSION_DIR)) return logs;
+
+  const files = await readdir(SESSION_DIR);
+  // Sort by modification time descending, take recent
+  const sorted = files.filter(f => f.endsWith('.jsonl')).slice(-30);
+
+  for (const file of sorted) {
+    try {
+      const content = await readFile(`${SESSION_DIR}/${file}`, 'utf-8');
+      const lines = content.split('\n').filter(l => l.trim());
+
+      // Check first line for session metadata
+      let sessionLabel = '';
+      let isSubagent = false;
+      const firstLine = lines[0] ? JSON.parse(lines[0]) : null;
+      if (firstLine?.type === 'session') {
+        // Sub-agent sessions have 'subagent' in their id path typically
+        const sessionId = firstLine.id || '';
+        // Check for label in spawn metadata or session key pattern
+        isSubagent = content.includes('"subagent"') || content.includes('agent:main:subagent');
+      }
+
+      // Track current model for this session
+      let currentModel = '';
+      let currentProvider = '';
+
+      for (const line of lines) {
+        try {
+          const d = JSON.parse(line);
+          const ts = d.timestamp ? new Date(d.timestamp) : null;
+          
+          // Track model changes even outside date range
+          if (d.type === 'model_change') {
+            currentProvider = d.provider || '';
+            currentModel = d.modelId || '';
+          }
+          
+          if (!ts || ts < start || ts > end) continue;
+
+          if (d.type === 'message' && d.message) {
+            const role = d.message.role;
+            let msgContent = d.message.content;
+
+            // Get model from message or tracked state
+            const msgProvider = d.message.provider || currentProvider || '';
+            const msgModel = d.message.model || currentModel || '';
+
+            if (Array.isArray(msgContent)) {
+              const textBlock = msgContent.find((c: Record<string, unknown>) => c.type === 'text');
+              if (textBlock) msgContent = String(textBlock.text);
+              else {
+                const toolCall = msgContent.find((c: Record<string, unknown>) => c.type === 'toolCall');
+                if (toolCall) msgContent = `🔧 ${toolCall.name}(${String(JSON.stringify(toolCall.arguments) || '').slice(0, 60)})`;
+                else continue;
+              }
+            }
+
+            if (typeof msgContent !== 'string') msgContent = String(msgContent || '');
+            if (!msgContent.trim() || msgContent.length < 3) continue;
+            if (role === 'user' && msgContent.startsWith('Read HEARTBEAT')) continue;
+
+            if (role === 'user' || role === 'assistant') {
+              const isAssistant = role === 'assistant';
+              logs.push({
+                timestamp: d.timestamp,
+                type: isSubagent ? 'subagent' : 'session',
+                content: msgContent.slice(0, 200),
+                metadata: {
+                  role,
+                  sessionId: file.replace('.jsonl', ''),
+                  provider: isAssistant ? msgProvider : undefined,
+                  model: isAssistant ? msgModel : undefined,
+                  label: sessionLabel || undefined,
+                },
+              });
+            }
+          } else if (d.type === 'model_change' && ts >= start && ts <= end) {
+            logs.push({
+              timestamp: d.timestamp,
+              type: isSubagent ? 'subagent' : 'session',
+              content: `Model → ${d.provider}/${d.modelId}`,
+              metadata: { role: 'system', event: 'model_change', provider: d.provider, model: d.modelId },
+            });
+          }
+        } catch { /* skip bad line */ }
+      }
+    } catch { /* skip bad file */ }
+  }
+  return logs;
+}
+
+// ─── Cron run logs ───
+async function parseCronLogs(start: Date, end: Date): Promise<LogEntry[]> {
+  const logs: LogEntry[] = [];
+  if (!existsSync(CRON_RUNS_DIR)) return logs;
+
+  const files = await readdir(CRON_RUNS_DIR);
+  for (const file of files.filter(f => f.endsWith('.jsonl'))) {
+    try {
+      const content = await readFile(`${CRON_RUNS_DIR}/${file}`, 'utf-8');
+      for (const line of content.split('\n').filter(l => l.trim())) {
+        try {
+          const d = JSON.parse(line);
+          const ts = d.ts ? new Date(d.ts) : null;
+          if (!ts || ts < start || ts > end) continue;
+
+          logs.push({
+            timestamp: ts.toISOString(),
+            type: 'cron',
+            content: `Cron ${d.action || 'run'}: ${d.status || 'unknown'}${d.error ? ' — ' + String(d.error).slice(0, 100) : ''}`,
+            metadata: { jobId: d.jobId, action: d.action, status: d.status, error: d.error },
+          });
+        } catch { /* skip */ }
+      }
+    } catch { /* skip */ }
+  }
+  return logs;
+}
+
+// ─── Service events (systemd) ───
+function parseServiceLogs(start: Date, end: Date): LogEntry[] {
+  const logs: LogEntry[] = [];
+  try {
+    const since = start.toISOString();
+    const until = end.toISOString();
+    // TODO(plan-08): expand journalctl filters to product services (qwen-*, arlowe-*, whisper-stt)
+    const output = execSync(
+      `journalctl --user -u arlowe-voice -u arlowe-face -u arlowe-dashboard -u qwen-api -u qwen-openai -u whisper-stt --since "${since}" --until "${until}" --no-pager -o json 2>/dev/null | tail -200`,
+      { encoding: 'utf-8', timeout: 5000 }
+    );
+    for (const line of output.split('\n').filter(l => l.trim())) {
+      try {
+        const d = JSON.parse(line);
+        const ts = d.__REALTIME_TIMESTAMP ? new Date(Number(d.__REALTIME_TIMESTAMP) / 1000) : null;
+        if (!ts) continue;
+        const unit = (d._SYSTEMD_USER_UNIT || '').replace('.service', '');
+        const msg = d.MESSAGE || '';
+        if (!msg || msg.includes('ALSA lib') || msg.includes('jack server')) continue;
+        logs.push({
+          timestamp: ts.toISOString(),
+          type: 'service',
+          content: `[${unit}] ${String(msg).slice(0, 200)}`,
+          metadata: { unit, priority: d.PRIORITY },
+        });
+      } catch { /* skip */ }
+    }
+  } catch { /* journalctl might fail */ }
+  return logs;
+}
+
+// ─── Main handler ───
+export async function GET(request: NextRequest) {
+  const sp = request.nextUrl.searchParams;
+  const logType = sp.get('type') || 'all';
+  const startDate = sp.get('start');
+  const endDate = sp.get('end');
+  const search = sp.get('q') || '';
+  const limit = parseInt(sp.get('limit') || '200');
+
+  const now = new Date();
+  const start = startDate ? new Date(startDate) : new Date(now.getTime() - 7 * 86400000);
+  const end = endDate ? new Date(endDate + 'T23:59:59') : now;
+  const all: LogEntry[] = [];
+
+  try {
+    const types = logType === 'all' ? ['voice', 'command', 'session', 'cron', 'service'] : [logType];
+
+    // Voice
+    if (types.includes('voice') && existsSync(VOICE_LOG_DIR)) {
+      const files = await readdir(VOICE_LOG_DIR);
+      for (const file of files.filter(f => /^voice_\d{4}-\d{2}-\d{2}\.log(\.\d+)?$/.test(f)).sort().reverse()) {
+        const dm = file.match(/voice_(\d{4}-\d{2}-\d{2})\.log/);
+        if (!dm) continue;
+        const fd = new Date(dm[1]);
+        if (fd < start || fd > end) continue;
+        const content = await readFile(`${VOICE_LOG_DIR}/${file}`, 'utf-8');
+        all.push(...parseVoiceLogs(content, dm[1]));
+      }
+    }
+
+    // Commands
+    if (types.includes('command') && existsSync(`${OPENCLAW_LOG_DIR}/commands.log`)) {
+      const content = await readFile(`${OPENCLAW_LOG_DIR}/commands.log`, 'utf-8');
+      all.push(...parseCommandLogs(content).filter(l => {
+        const d = new Date(l.timestamp);
+        return d >= start && d <= end;
+      }));
+    }
+
+    // Sessions
+    if (types.includes('session')) {
+      all.push(...await parseSessionLogs(start, end));
+    }
+
+    // Cron
+    if (types.includes('cron')) {
+      all.push(...await parseCronLogs(start, end));
+    }
+
+    // Services
+    if (types.includes('service')) {
+      all.push(...parseServiceLogs(start, end));
+    }
+
+    all.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+
+    const filtered = search
+      ? all.filter(l => {
+          const q = search.toLowerCase();
+          return l.content.toLowerCase().includes(q)
+            || JSON.stringify(l.metadata || {}).toLowerCase().includes(q);
+        })
+      : all;
+
+    return NextResponse.json({
+      logs: filtered.slice(0, limit),
+      meta: { total: filtered.length, start: start.toISOString(), end: end.toISOString(), type: logType, search: search || null },
+    });
+  } catch (error) {
+    console.error('Log fetch error:', error);
+    return NextResponse.json({ error: String(error) }, { status: 500 });
+  }
+}

--- a/runtime/dashboard/app/components/Header.tsx
+++ b/runtime/dashboard/app/components/Header.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import React from 'react';
+
+export default function Header() {
+  const pathname = usePathname();
+
+  const getTitle = () => {
+    switch (pathname) {
+      case '/':
+        return 'Arlowe Dashboard';
+      case '/config':
+        return 'Configuration';
+      case '/cron':
+        return 'Scheduled Tasks';
+      case '/logs':
+        return 'System Logs';
+      case '/stats':
+        return 'Usage Statistics';
+      case '/connectivity':
+        return 'Connectivity Management';
+      case '/testing':
+        return 'E2E Testing';
+      default:
+        return 'Dashboard';
+    }
+  };
+
+  const getSubtitle = () => {
+    switch (pathname) {
+      case '/':
+        return 'System overview and controls';
+      case '/config':
+        return 'Manage OpenClaw settings';
+      case '/cron':
+        return 'Automated jobs and reminders';
+      case '/logs':
+        return 'Review system events and messages';
+      case '/stats':
+        return 'Monitor model usage and costs';
+      case '/connectivity':
+        return 'Manage network connections';
+      case '/testing':
+        return 'View and run Playwright E2E tests';
+      default:
+        return 'Welcome back!';
+    }
+  };
+
+  return (
+    <div className="mb-6">
+      <h1 className="text-2xl font-bold">{getTitle()}</h1>
+      <p className="text-[var(--muted)] text-sm mt-1">{getSubtitle()}</p>
+    </div>
+  );
+}

--- a/runtime/dashboard/app/components/MarkdownPreview.tsx
+++ b/runtime/dashboard/app/components/MarkdownPreview.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+interface MarkdownPreviewProps {
+  content: string;
+}
+
+export default function MarkdownPreview({ content }: MarkdownPreviewProps) {
+  return (
+    <div className="prose prose-invert prose-sm max-w-none p-4 overflow-auto h-full
+      prose-headings:text-[var(--foreground)] prose-headings:font-semibold prose-headings:border-b prose-headings:border-[var(--border)] prose-headings:pb-2
+      prose-h1:text-2xl prose-h2:text-xl prose-h3:text-lg
+      prose-p:text-[var(--foreground)] prose-p:leading-relaxed
+      prose-a:text-[var(--accent)] prose-a:no-underline hover:prose-a:underline
+      prose-strong:text-[var(--foreground)] prose-strong:font-semibold
+      prose-em:text-[var(--foreground)]
+      prose-code:text-[var(--accent)] prose-code:bg-[var(--card)] prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-code:text-sm prose-code:before:content-none prose-code:after:content-none
+      prose-pre:bg-[var(--card)] prose-pre:border prose-pre:border-[var(--border)] prose-pre:rounded-lg
+      prose-ul:text-[var(--foreground)] prose-ol:text-[var(--foreground)]
+      prose-li:text-[var(--foreground)] prose-li:marker:text-[var(--muted)]
+      prose-blockquote:border-l-[var(--accent)] prose-blockquote:text-[var(--muted)] prose-blockquote:bg-[var(--card)] prose-blockquote:py-1 prose-blockquote:px-4 prose-blockquote:rounded-r-lg
+      prose-hr:border-[var(--border)]
+      prose-table:border-collapse
+      prose-th:border prose-th:border-[var(--border)] prose-th:bg-[var(--card)] prose-th:px-3 prose-th:py-2 prose-th:text-left
+      prose-td:border prose-td:border-[var(--border)] prose-td:px-3 prose-td:py-2
+    ">
+      <ReactMarkdown remarkPlugins={[remarkGfm]}>
+        {content}
+      </ReactMarkdown>
+    </div>
+  );
+}

--- a/runtime/dashboard/app/components/Navigation.tsx
+++ b/runtime/dashboard/app/components/Navigation.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+const navItems = [
+  { href: '/', label: 'Overview', icon: '📊' },
+  { href: '/npu', label: 'NPU Lab', icon: '🧠' },
+  { href: '/logs', label: 'Logs', icon: '📋' },
+  { href: '/connectivity', label: 'Connect', icon: '📶' },
+];
+
+export default function Navigation() {
+  const pathname = usePathname();
+
+  return (
+    <nav className="glass fixed bottom-0 left-0 right-0 z-50 border-t border-[var(--border)] safe-area-pb md:relative md:bottom-auto md:border-t-0 md:border-r md:h-screen md:w-20">
+      <div className="flex justify-around items-center h-16 md:flex-col md:h-full md:justify-start md:pt-6 md:gap-2 overflow-x-auto md:overflow-x-visible">
+        {navItems.map((item) => {
+          const isActive = pathname === item.href;
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={`flex flex-col items-center justify-center p-2 rounded-xl transition-smooth md:w-14 md:h-14 min-w-[3rem] ${
+                isActive
+                  ? 'bg-[var(--accent)] text-white'
+                  : 'text-[var(--muted)] hover:text-[var(--foreground)] hover:bg-[var(--card)]'
+              }`}
+            >
+              <span className="text-xl">{item.icon}</span>
+              <span className="text-[10px] mt-0.5 font-medium">{item.label}</span>
+            </Link>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}

--- a/runtime/dashboard/app/components/ProviderBadge.tsx
+++ b/runtime/dashboard/app/components/ProviderBadge.tsx
@@ -1,0 +1,42 @@
+interface ProviderBadgeProps {
+  provider: string;
+  size?: 'sm' | 'md';
+}
+
+const providerInfo: Record<string, { label: string; icon: string; className: string }> = {
+  // Exact matches
+  local: { label: 'Local', icon: '🏠', className: 'badge-local' },
+  gemini: { label: 'Gemini', icon: '💎', className: 'badge-gemini' },
+  claude: { label: 'Claude', icon: '🅰️', className: 'badge-claude' },
+  // API provider names
+  'qwen-local': { label: 'Qwen', icon: '🏠', className: 'badge-local' },
+  'google-gemini': { label: 'Gemini', icon: '💎', className: 'badge-gemini' },
+  anthropic: { label: 'Claude', icon: '🅰️', className: 'badge-claude' },
+  // Fallbacks for partial matches
+  qwen: { label: 'Qwen', icon: '🏠', className: 'badge-local' },
+};
+
+const fallback = { label: 'Unknown', icon: '❓', className: 'badge-local' };
+
+function getProviderInfo(provider: string) {
+  // Direct match
+  if (providerInfo[provider]) return providerInfo[provider];
+  // Partial match
+  const lc = provider.toLowerCase();
+  if (lc.includes('qwen') || lc.includes('local')) return providerInfo.local;
+  if (lc.includes('gemini') || lc.includes('google')) return providerInfo.gemini;
+  if (lc.includes('anthropic') || lc.includes('claude')) return providerInfo.anthropic;
+  return fallback;
+}
+
+export default function ProviderBadge({ provider, size = 'sm' }: ProviderBadgeProps) {
+  const info = getProviderInfo(provider);
+  const sizeClasses = size === 'sm' ? 'text-xs px-2 py-1' : 'text-sm px-3 py-1.5';
+
+  return (
+    <span className={`inline-flex items-center gap-1 rounded-full font-medium flex-shrink-0 ${info.className} ${sizeClasses}`}>
+      <span>{info.icon}</span>
+      <span>{info.label}</span>
+    </span>
+  );
+}

--- a/runtime/dashboard/app/components/RetroActivityMonitor.tsx
+++ b/runtime/dashboard/app/components/RetroActivityMonitor.tsx
@@ -1,0 +1,235 @@
+'use client';
+
+import { useEffect, useState, useCallback, useRef } from 'react';
+
+interface HealthData {
+  cpu: number;
+  memory: number;
+  temp: number;
+  disk: number;
+  npuStatus: string;
+}
+
+interface HistoryPoint {
+  cpu: number;
+  memory: number;
+  timestamp: number;
+}
+
+const HISTORY_LENGTH = 30; // 30 data points for the graph
+const POLL_INTERVAL = 2000; // Poll every 2 seconds
+
+// Pixel art characters for the bar graph
+const BLOCK_FULL = '█';
+const BLOCK_MEDIUM = '▓';
+const BLOCK_LIGHT = '░';
+
+export default function RetroActivityMonitor() {
+  const [health, setHealth] = useState<HealthData | null>(null);
+  const [history, setHistory] = useState<HistoryPoint[]>([]);
+  const [blinkOn, setBlinkOn] = useState(true);
+  const [scanlineOffset, setScanlineOffset] = useState(0);
+  const terminalRef = useRef<HTMLDivElement>(null);
+
+  const fetchHealth = useCallback(async () => {
+    try {
+      const res = await fetch('/api/health');
+      if (res.ok) {
+        const data = await res.json();
+        setHealth(data);
+        setHistory(prev => {
+          const newHistory = [...prev, {
+            cpu: data.cpu,
+            memory: data.memory,
+            timestamp: Date.now(),
+          }];
+          // Keep only the last HISTORY_LENGTH points
+          return newHistory.slice(-HISTORY_LENGTH);
+        });
+      }
+    } catch (err) {
+      console.error('Failed to fetch health:', err);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchHealth();
+    const interval = setInterval(fetchHealth, POLL_INTERVAL);
+    return () => clearInterval(interval);
+  }, [fetchHealth]);
+
+  // Cursor blink effect
+  useEffect(() => {
+    const blinkInterval = setInterval(() => {
+      setBlinkOn(prev => !prev);
+    }, 530);
+    return () => clearInterval(blinkInterval);
+  }, []);
+
+  // Subtle scanline animation
+  useEffect(() => {
+    const scanlineInterval = setInterval(() => {
+      setScanlineOffset(prev => (prev + 1) % 4);
+    }, 100);
+    return () => clearInterval(scanlineInterval);
+  }, []);
+
+  // Generate ASCII bar for a percentage value
+  const generateBar = (value: number, maxWidth: number = 20): string => {
+    const filled = Math.round((value / 100) * maxWidth);
+    const empty = maxWidth - filled;
+    return BLOCK_FULL.repeat(filled) + BLOCK_LIGHT.repeat(empty);
+  };
+
+  // Generate mini sparkline from history
+  const generateSparkline = (metric: 'cpu' | 'memory'): string => {
+    if (history.length === 0) return '▁'.repeat(HISTORY_LENGTH);
+    
+    const chars = ['▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'];
+    const values = history.map(h => h[metric]);
+    
+    // Pad with empty values if not enough history
+    while (values.length < HISTORY_LENGTH) {
+      values.unshift(0);
+    }
+    
+    return values.map(v => {
+      const index = Math.min(Math.floor((v / 100) * chars.length), chars.length - 1);
+      return chars[index];
+    }).join('');
+  };
+
+  // Get status indicator
+  const getStatusColor = (value: number, type: 'cpu' | 'mem' | 'temp'): string => {
+    if (type === 'temp') {
+      if (value > 70) return 'text-retro-red';
+      if (value > 60) return 'text-retro-amber';
+      return 'text-retro-green';
+    }
+    if (value > 80) return 'text-retro-red';
+    if (value > 60) return 'text-retro-amber';
+    return 'text-retro-green';
+  };
+
+  const currentTime = new Date().toLocaleTimeString('en-US', { 
+    hour12: false, 
+    hour: '2-digit', 
+    minute: '2-digit', 
+    second: '2-digit' 
+  });
+
+  return (
+    <div className="retro-monitor">
+      {/* CRT Frame */}
+      <div className="retro-crt-frame">
+        {/* Scanlines overlay */}
+        <div 
+          className="retro-scanlines" 
+          style={{ backgroundPositionY: `${scanlineOffset}px` }}
+        />
+        
+        {/* Screen glow */}
+        <div className="retro-glow" />
+        
+        {/* Terminal content */}
+        <div ref={terminalRef} className="retro-terminal">
+          {/* Header */}
+          <div className="retro-header">
+            <span className="text-retro-amber">╔══════════════════════════════════════╗</span>
+            <span className="text-retro-amber">║</span>
+            <span className="text-retro-green"> ARLOWE-1 SYSTEM MONITOR </span>
+            <span className="text-retro-amber">║</span>
+            <span className="text-retro-amber">║</span>
+            <span className="text-retro-green"> {currentTime} </span>
+            <span className="text-retro-amber">║</span>
+            <span className="text-retro-amber">╠══════════════════════════════════════╣</span>
+          </div>
+
+          {/* CPU Section */}
+          <div className="retro-section">
+            <div className="retro-row">
+              <span className="text-retro-amber">CPU: </span>
+              <span className={getStatusColor(health?.cpu || 0, 'cpu')}>
+                [{generateBar(health?.cpu || 0, 16)}]
+              </span>
+              <span className="text-retro-green ml-1">
+                {health?.cpu?.toFixed(1).padStart(5)}%
+              </span>
+            </div>
+            <div className="retro-row text-retro-green-dim">
+              <span className="text-retro-amber">     </span>
+              {generateSparkline('cpu')}
+            </div>
+          </div>
+
+          {/* Memory Section */}
+          <div className="retro-section">
+            <div className="retro-row">
+              <span className="text-retro-amber">MEM: </span>
+              <span className={getStatusColor(health?.memory || 0, 'mem')}>
+                [{generateBar(health?.memory || 0, 16)}]
+              </span>
+              <span className="text-retro-green ml-1">
+                {(health?.memory || 0).toString().padStart(5)}%
+              </span>
+            </div>
+            <div className="retro-row text-retro-green-dim">
+              <span className="text-retro-amber">     </span>
+              {generateSparkline('memory')}
+            </div>
+          </div>
+
+          {/* Disk Section */}
+          <div className="retro-section">
+            <div className="retro-row">
+              <span className="text-retro-amber">DSK: </span>
+              <span className={getStatusColor(health?.disk || 0, 'mem')}>
+                [{generateBar(health?.disk || 0, 16)}]
+              </span>
+              <span className="text-retro-green ml-1">
+                {(health?.disk || 0).toString().padStart(5)}%
+              </span>
+            </div>
+          </div>
+
+          {/* Temperature */}
+          <div className="retro-section">
+            <div className="retro-row">
+              <span className="text-retro-amber">TMP: </span>
+              <span className={getStatusColor(health?.temp || 0, 'temp')}>
+                {health?.temp || 0}°C
+              </span>
+              <span className="text-retro-green-dim ml-2">
+                {health?.temp && health.temp > 60 ? '⚠ WARM' : health?.temp && health.temp > 70 ? '🔥 HOT!' : '✓ OK'}
+              </span>
+            </div>
+          </div>
+
+          {/* NPU Status */}
+          <div className="retro-section">
+            <div className="retro-row">
+              <span className="text-retro-amber">NPU: </span>
+              <span className={health?.npuStatus === 'Online' ? 'text-retro-green' : 'text-retro-red'}>
+                {health?.npuStatus === 'Online' ? '● ONLINE ' : '○ OFFLINE'}
+              </span>
+              <span className="text-retro-green-dim ml-2">
+                {health?.npuStatus === 'Online' ? 'AX8850 READY' : 'DISCONNECTED'}
+              </span>
+            </div>
+          </div>
+
+          {/* Footer */}
+          <div className="retro-footer">
+            <span className="text-retro-amber">╚══════════════════════════════════════╝</span>
+            <div className="retro-row mt-1">
+              <span className="text-retro-green-dim">
+                &gt; POLLING: {POLL_INTERVAL/1000}s
+              </span>
+              <span className={`retro-cursor ${blinkOn ? 'opacity-100' : 'opacity-0'}`}>█</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/runtime/dashboard/app/components/StatusCard.tsx
+++ b/runtime/dashboard/app/components/StatusCard.tsx
@@ -1,0 +1,40 @@
+interface StatusCardProps {
+  title: string;
+  value: string | number;
+  subtitle?: string;
+  icon?: string;
+  trend?: 'up' | 'down' | 'neutral';
+  color?: 'default' | 'success' | 'warning' | 'error' | 'local' | 'gemini' | 'claude';
+}
+
+const colorClasses = {
+  default: 'text-[var(--foreground)]',
+  success: 'text-[var(--success)]',
+  warning: 'text-[var(--warning)]',
+  error: 'text-[var(--error)]',
+  local: 'text-[var(--local)]',
+  gemini: 'text-[var(--gemini)]',
+  claude: 'text-[var(--claude)]',
+};
+
+export default function StatusCard({ title, value, subtitle, icon, trend, color = 'default' }: StatusCardProps) {
+  return (
+    <div className="card p-4">
+      <div className="flex items-start justify-between">
+        <div className="flex-1">
+          <p className="text-[var(--muted)] text-sm font-medium">{title}</p>
+          <p className={`text-2xl font-semibold mt-1 ${colorClasses[color]}`}>
+            {value}
+            {trend && (
+              <span className={`text-sm ml-2 ${trend === 'up' ? 'text-[var(--success)]' : trend === 'down' ? 'text-[var(--error)]' : 'text-[var(--muted)]'}`}>
+                {trend === 'up' ? '↑' : trend === 'down' ? '↓' : '→'}
+              </span>
+            )}
+          </p>
+          {subtitle && <p className="text-[var(--muted)] text-xs mt-1">{subtitle}</p>}
+        </div>
+        {icon && <span className="text-2xl">{icon}</span>}
+      </div>
+    </div>
+  );
+}

--- a/runtime/dashboard/app/connectivity/page.tsx
+++ b/runtime/dashboard/app/connectivity/page.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import React, { useState } from 'react';
+import ConnectionStatus from './components/ConnectionStatus';
+import NetworkList from './components/NetworkList';
+import SavedNetworksList from './components/SavedNetworksList';
+import PasswordModal from './components/PasswordModal';
+
+interface Network {
+  ssid: string;
+  signal: number;
+  security: string;
+}
+
+export default function ConnectivityPage() {
+  const [selectedNetwork, setSelectedNetwork] = useState<Network | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSelectNetwork = (network: Network) => {
+    setSelectedNetwork(network);
+    setIsModalOpen(true);
+  };
+
+  const handleConnect = async (ssid: string, password: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/connectivity/connect', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ssid, password }),
+      });
+      if (!res.ok) {
+        const errorData = await res.json();
+        throw new Error(errorData.message || 'Connection failed');
+      }
+      setIsModalOpen(false);
+      setSelectedNetwork(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCancel = () => {
+    setIsModalOpen(false);
+    setSelectedNetwork(null);
+    setError(null);
+  };
+
+  return (
+    <>
+      <header className="mb-6">
+        <h1 className="text-2xl font-bold flex items-center gap-2">
+          <span>📶</span> WiFi Connectivity
+        </h1>
+        <p className="text-[var(--muted)] text-sm mt-1">Manage and connect to wireless networks.</p>
+      </header>
+      
+      <div className="space-y-6">
+        <ConnectionStatus />
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <NetworkList onSelectNetwork={handleSelectNetwork} />
+          <SavedNetworksList />
+        </div>
+      </div>
+
+      {isModalOpen && (
+        <PasswordModal
+          network={selectedNetwork}
+          onConnect={handleConnect}
+          onCancel={handleCancel}
+          loading={loading}
+        />
+      )}
+      
+      {error && (
+        <div className="fixed bottom-4 right-4 bg-[var(--error)] text-white p-4 rounded-lg shadow-lg">
+          <p className="font-bold">Connection Error</p>
+          <p>{error}</p>
+        </div>
+      )}
+    </>
+  );
+}

--- a/runtime/dashboard/app/logs/page.tsx
+++ b/runtime/dashboard/app/logs/page.tsx
@@ -1,0 +1,280 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import ProviderBadge from '../components/ProviderBadge';
+
+interface LogEntry {
+  timestamp: string;
+  type: 'voice' | 'command' | 'session' | 'subagent' | 'cron' | 'service';
+  content: string;
+  metadata?: Record<string, unknown>;
+}
+
+interface LogMeta {
+  total: number;
+  type: string;
+  search: string | null;
+}
+
+type LogType = 'all' | 'voice' | 'command' | 'session' | 'subagent' | 'cron' | 'service';
+
+export default function LogsPage() {
+  const [logs, setLogs] = useState<LogEntry[]>([]);
+  const [meta, setMeta] = useState<LogMeta | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [logType, setLogType] = useState<LogType>('all');
+  const [search, setSearch] = useState('');
+  const [searchInput, setSearchInput] = useState('');
+  const [startDate, setStartDate] = useState(() => {
+    const d = new Date(); d.setDate(d.getDate() - 7);
+    return d.toISOString().split('T')[0];
+  });
+  const [endDate, setEndDate] = useState(() => new Date().toISOString().split('T')[0]);
+  const [expandedIdx, setExpandedIdx] = useState<number | null>(null);
+
+  const fetchLogs = useCallback(async () => {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({ type: logType, start: startDate, end: endDate, limit: '200' });
+      if (search) params.set('q', search);
+      const res = await fetch(`/api/logs?${params}`);
+      if (res.ok) {
+        const data = await res.json();
+        setLogs(data.logs || []);
+        setMeta(data.meta || null);
+      }
+    } catch (err) {
+      console.error('Failed to fetch logs:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, [logType, startDate, endDate, search]);
+
+  useEffect(() => { fetchLogs(); }, [fetchLogs]);
+
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault();
+    setSearch(searchInput);
+  };
+
+  const setQuickRange = (days: number) => {
+    const end = new Date();
+    const start = new Date();
+    start.setDate(start.getDate() - days);
+    setStartDate(start.toISOString().split('T')[0]);
+    setEndDate(end.toISOString().split('T')[0]);
+  };
+
+  const toggleExpand = (idx: number) => {
+    setExpandedIdx(prev => prev === idx ? null : idx);
+  };
+
+  const typeIcon: Record<string, string> = { voice: '🎤', command: '⚡', session: '💬', subagent: '🤖', cron: '⏰', service: '⚙️' };
+
+  return (
+    <>
+      <h1 className="text-2xl font-bold mb-4">Logs</h1>
+
+        {/* Filters — stacked layout */}
+        <div className="card p-3 mb-4 space-y-2">
+          {/* Row 1: Search */}
+          <form onSubmit={handleSearch}>
+            <div className="relative">
+              <input
+                type="text"
+                value={searchInput}
+                onChange={(e) => setSearchInput(e.target.value)}
+                placeholder="Search transcripts, responses, models..."
+                className="w-full px-3 py-2 pl-8 rounded-lg bg-[var(--background)] border border-[var(--border)] text-sm"
+              />
+              <span className="absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--muted)] text-sm">🔍</span>
+              {search && (
+                <button
+                  type="button"
+                  onClick={() => { setSearch(''); setSearchInput(''); }}
+                  className="absolute right-2.5 top-1/2 -translate-y-1/2 text-[var(--muted)] text-xs hover:text-[var(--foreground)]"
+                >
+                  ✕
+                </button>
+              )}
+            </div>
+          </form>
+
+          {/* Row 2: Log type pills */}
+          <div className="flex gap-1.5">
+            {(['all', 'voice', 'session', 'subagent', 'command', 'cron', 'service'] as const).map((t) => (
+              <button
+                key={t}
+                onClick={() => setLogType(t)}
+                className={`px-3 py-1 rounded-full text-xs font-medium transition-smooth ${
+                  logType === t
+                    ? 'bg-[var(--accent)] text-white'
+                    : 'bg-[var(--background)] text-[var(--muted)] hover:text-[var(--foreground)]'
+                }`}
+              >
+                {t === 'all' ? 'All' : `${typeIcon[t] || '📝'} ${t.charAt(0).toUpperCase() + t.slice(1)}`}
+              </button>
+            ))}
+          </div>
+
+          {/* Row 3: Date range + quick picks */}
+          <div className="flex items-center gap-2 flex-wrap">
+            <input
+              type="date"
+              value={startDate}
+              onChange={(e) => setStartDate(e.target.value)}
+              className="px-2 py-1 rounded-lg bg-[var(--background)] border border-[var(--border)] text-xs"
+            />
+            <span className="text-[var(--muted)] text-xs">–</span>
+            <input
+              type="date"
+              value={endDate}
+              onChange={(e) => setEndDate(e.target.value)}
+              className="px-2 py-1 rounded-lg bg-[var(--background)] border border-[var(--border)] text-xs"
+            />
+            <span className="text-[var(--border)]">|</span>
+            {[
+              { label: 'Today', days: 0 },
+              { label: '7d', days: 7 },
+              { label: '30d', days: 30 },
+            ].map(({ label, days }) => (
+              <button
+                key={label}
+                onClick={() => setQuickRange(days)}
+                className="px-2 py-1 rounded-full text-xs bg-[var(--background)] text-[var(--muted)] hover:text-[var(--foreground)] transition-smooth"
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Results count */}
+        {meta && !loading && (
+          <div className="text-[var(--muted)] text-xs mb-3">
+            {meta.total} result{meta.total !== 1 ? 's' : ''}
+            {meta.search && <span> for &ldquo;{meta.search}&rdquo;</span>}
+          </div>
+        )}
+
+        {/* Log entries */}
+        {loading ? (
+          <div className="flex items-center justify-center h-48 text-[var(--muted)]">Loading...</div>
+        ) : logs.length === 0 ? (
+          <div className="card p-8 text-center text-[var(--muted)]">
+            <p>No logs found</p>
+            <p className="text-xs mt-1">Adjust filters or date range</p>
+          </div>
+        ) : (
+          <div className="space-y-1">
+            {logs.map((log, idx) => {
+              const isExpanded = expandedIdx === idx;
+              return (
+                <div
+                  key={idx}
+                  className={`card px-3 py-2 transition-smooth ${isExpanded ? 'bg-[var(--card-hover)]' : ''}`}
+                >
+                  {/* Compact row — always visible */}
+                  <div
+                    className="flex items-center gap-2 cursor-pointer"
+                    onClick={() => toggleExpand(idx)}
+                  >
+                    <span className="text-xs flex-shrink-0">{typeIcon[log.type] || '📝'}</span>
+
+                    {log.metadata?.provider ? (
+                      <ProviderBadge provider={String(log.metadata.provider)} size="sm" />
+                    ) : null}
+
+                    {log.metadata?.model ? (
+                      <span className="text-[10px] px-1.5 py-0.5 rounded bg-[var(--background)] text-[var(--muted)] font-mono flex-shrink-0">
+                        {String(log.metadata.model)}
+                      </span>
+                    ) : null}
+
+                    {log.metadata?.role && log.type === 'session' ? (
+                      <span className={`text-[10px] px-1.5 py-0.5 rounded flex-shrink-0 ${
+                        log.metadata.role === 'user' ? 'bg-[var(--accent)]/20 text-[var(--accent)]' : 'bg-[var(--local)]/20 text-[var(--local)]'
+                      }`}>
+                        {String(log.metadata.role)}
+                      </span>
+                    ) : null}
+
+                    <span className="truncate flex-1 text-xs">
+                      {log.type === 'voice' ? String(log.metadata?.transcript || '') : log.content}
+                    </span>
+
+                    {log.metadata?.latencyMs != null && Number(log.metadata.latencyMs) > 0 ? (
+                      <span className="text-[var(--muted)] text-[10px] flex-shrink-0">
+                        {String(log.metadata.latencyMs)}ms
+                      </span>
+                    ) : null}
+
+                    <span className="text-[var(--muted)] text-[10px] flex-shrink-0 whitespace-nowrap">
+                      {new Date(log.timestamp).toLocaleString('en-US', {
+                        month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit',
+                      })}
+                    </span>
+
+                    <span className={`text-[10px] text-[var(--muted)] transition-transform flex-shrink-0 ${isExpanded ? 'rotate-90' : ''}`}>
+                      ▶
+                    </span>
+                  </div>
+
+                  {/* Expanded detail */}
+                  {isExpanded && (
+                    <div className="mt-2 pt-2 border-t border-[var(--border)] text-xs space-y-2">
+                      {log.type === 'voice' && log.metadata && (
+                        <>
+                          <div>
+                            <span className="text-[var(--muted)] font-medium">You: </span>
+                            <span>{String(log.metadata.transcript || '')}</span>
+                          </div>
+                          <div>
+                            <span className="text-[var(--muted)] font-medium">Arlowe: </span>
+                            <span className="whitespace-pre-wrap">{String(log.metadata.response || '')}</span>
+                          </div>
+                          <div className="flex flex-wrap gap-3 text-[var(--muted)] pt-1">
+                            {log.metadata.provider ? (
+                              <span>Provider: <span className="text-[var(--foreground)]">{String(log.metadata.provider)}</span></span>
+                            ) : null}
+                            {log.metadata.model ? (
+                              <span>Model: <span className="font-mono text-[var(--foreground)]">{String(log.metadata.model)}</span></span>
+                            ) : null}
+                            {log.metadata.latencyMs != null ? (
+                              <span>Latency: <span className="text-[var(--foreground)]">{String(log.metadata.latencyMs)}ms</span></span>
+                            ) : null}
+                          </div>
+                        </>
+                      )}
+                      {log.type === 'command' && log.metadata && (
+                        <div className="text-[var(--muted)]">
+                          <div>Action: <span className="text-[var(--accent)]">/{String(log.metadata.action)}</span></div>
+                          {log.metadata.source ? <div>Source: {String(log.metadata.source)}</div> : null}
+                          {log.metadata.sessionKey ? <div className="truncate">Session: {String(log.metadata.sessionKey)}</div> : null}
+                        </div>
+                      )}
+                      {log.type === 'session' && (
+                        <div className="whitespace-pre-wrap">
+                          {log.content}
+                          {log.metadata?.role ? <div className="text-[var(--muted)] mt-1">Role: {String(log.metadata.role)}</div> : null}
+                        </div>
+                      )}
+                      {log.type === 'cron' && (
+                        <div className="text-[var(--muted)]">
+                          {log.content}
+                          {log.metadata?.jobId ? <div className="truncate mt-1">Job: {String(log.metadata.jobId)}</div> : null}
+                        </div>
+                      )}
+                      {log.type === 'service' && (
+                        <div className="text-[var(--muted)] font-mono text-[11px]">{log.content}</div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+    </>
+  );
+}

--- a/runtime/dashboard/app/page.tsx
+++ b/runtime/dashboard/app/page.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import StatusCard from './components/StatusCard';
+import RetroActivityMonitor from './components/RetroActivityMonitor';
+
+interface SystemHealth {
+  cpu: number;
+  memory: number;
+  temp: number;
+  disk: number;
+  uptime: string;
+  npuStatus: string;
+}
+
+interface VoiceStatus {
+  active: boolean;
+  uptime: string;
+}
+
+export default function Dashboard() {
+  const [health, setHealth] = useState<SystemHealth | null>(null);
+  const [voice, setVoice] = useState<VoiceStatus | null>(null);
+  const [voiceLoading, setVoiceLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  const fetchData = useCallback(async () => {
+    try {
+      // TODO(plan-08): expand fetches to include product-relevant health/voice payload
+      const [healthRes, voiceRes] = await Promise.all([
+        fetch('/api/health'),
+        fetch('/api/voice'),
+      ]);
+
+      if (healthRes.ok) setHealth(await healthRes.json());
+      if (voiceRes.ok) setVoice(await voiceRes.json());
+    } catch (err) {
+      console.error('Failed to fetch data:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData();
+    const interval = setInterval(fetchData, 15000);
+    return () => clearInterval(interval);
+  }, [fetchData]);
+
+  const toggleVoice = async () => {
+    setVoiceLoading(true);
+    try {
+      const res = await fetch('/api/voice', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'toggle' }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setVoice({ active: data.active, uptime: data.uptime });
+      }
+    } catch (err) {
+      console.error('Failed to toggle voice:', err);
+    } finally {
+      setVoiceLoading(false);
+    }
+  };
+
+  return loading ? (
+    <div className="flex items-center justify-center h-64">
+      <div className="text-[var(--muted)]">Loading...</div>
+    </div>
+  ) : (
+    <>
+      {/* Voice Assistant Toggle */}
+      <section className="mb-6">
+        <div className="card p-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <span className="text-2xl">🎤</span>
+              <div>
+                <h2 className="text-base font-semibold">Voice Assistant</h2>
+                <p className="text-[var(--muted)] text-xs">
+                  {voice?.active
+                    ? `Listening for wake word • up ${voice.uptime || '–'}`
+                    : 'Paused — not listening'}
+                </p>
+              </div>
+            </div>
+            <button
+              onClick={toggleVoice}
+              disabled={voiceLoading}
+              className={`relative w-14 h-8 rounded-full transition-all duration-300 ${
+                voiceLoading ? 'opacity-50 cursor-wait' : 'cursor-pointer'
+              } ${voice?.active ? 'bg-[var(--success)]' : 'bg-[var(--border)]'}`}
+            >
+              <div
+                className={`absolute top-1 w-6 h-6 rounded-full bg-white shadow transition-transform duration-300 ${
+                  voice?.active ? 'translate-x-7' : 'translate-x-1'
+                }`}
+              />
+            </button>
+          </div>
+        </div>
+      </section>
+
+      {/* System Health - Retro Activity Monitor */}
+      <section className="mb-6">
+        <h2 className="text-lg font-semibold mb-3 flex items-center gap-2">
+          <span>🖥️</span> System Activity
+        </h2>
+        <RetroActivityMonitor />
+      </section>
+
+      {/* System Health - Card View */}
+      <section className="mb-6">
+        <h2 className="text-lg font-semibold mb-3 flex items-center gap-2">
+          <span>💓</span> System Health
+        </h2>
+        <div className="grid grid-cols-2 gap-3">
+          <StatusCard
+            title="CPU"
+            value={health ? `${health.cpu}%` : '--'}
+            color={health && health.cpu > 80 ? 'warning' : 'default'}
+          />
+          <StatusCard
+            title="Memory"
+            value={health ? `${health.memory}%` : '--'}
+            color={health && health.memory > 80 ? 'warning' : 'default'}
+          />
+          <StatusCard
+            title="Temperature"
+            value={health ? `${health.temp}°C` : '--'}
+            color={health && health.temp > 70 ? 'error' : health && health.temp > 60 ? 'warning' : 'default'}
+          />
+          <StatusCard
+            title="NPU"
+            value={health?.npuStatus || '--'}
+            color={health?.npuStatus === 'Online' ? 'success' : 'error'}
+          />
+        </div>
+      </section>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

Part 2 of 3 for Plan 07 — Dashboard delete pass (issue #12).

Adds the logs API route and surviving pages + top-level components. Key deletions applied:

**Logs route** (`app/api/logs/route.ts` — REWRITE):
- `openclaw-gateway` removed from journalctl filter
- `~/.openclaw/logs`, `~/.openclaw/agents/...`, `~/.openclaw/cron/...` paths annotated with `// TODO(plan-08)`

**Homepage** (`app/page.tsx` — REWRITE):
- `ActiveTasksPanel` import and section removed (component deleted)
- `ProviderBadge` tiles for workforce usage metering removed (Today's Usage + All-Time Routing sections)
- `/api/usage` fetch calls removed (route deleted)
- Remaining: voice toggle + system health cards

**Navigation** (`app/components/Navigation.tsx` — REWRITE):
- `navItems[]` trimmed from 12 routes → 4 surviving: `/`, `/npu`, `/logs`, `/connectivity`

**ProviderBadge** (`app/components/ProviderBadge.tsx` — REWRITE):
- `openclaw:` map entry removed (1 line)

Pages added: homepage, connectivity, logs. Components added: StatusCard, RetroActivityMonitor, Header, Navigation, MarkdownPreview, ProviderBadge.

## Stacked PRs

- PR 1/3: Scaffold + API routes → main (PR #31)
- **PR 2/3 (this PR)**: Pages + top-level components → merges to 07a
- PR 3/3: NPU page + connectivity components + tests + summary → merges to 07b

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)