### PR TITLE
ci: exclude lockfiles from PR-size measurement

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -42,9 +42,21 @@ jobs:
         run: |
           BASE_SHA="${{ github.event.pull_request.base.sha }}"
           HEAD_SHA="${{ github.event.pull_request.head.sha }}"
-          NET=$(git diff --shortstat "$BASE_SHA..$HEAD_SHA" | awk '{print $4 + $6}')
+          # Exclude generated lockfiles from the size measurement — they bloat
+          # PRs that just add a single dependency and aren't human-reviewed.
+          NET=$(git diff --shortstat "$BASE_SHA..$HEAD_SHA" -- \
+            ':(exclude)**/pnpm-lock.yaml' \
+            ':(exclude)**/package-lock.json' \
+            ':(exclude)**/yarn.lock' \
+            ':(exclude)**/Cargo.lock' \
+            ':(exclude)**/poetry.lock' \
+            ':(exclude)**/uv.lock' \
+            ':(exclude)**/Gemfile.lock' \
+            ':(exclude)**/composer.lock' \
+            ':(exclude)**/go.sum' \
+            | awk '{print $4 + $6}')
           NET=${NET:-0}
-          echo "Net lines changed: $NET"
+          echo "Net lines changed (excluding lockfiles): $NET"
           # Hard cap raised to 1500 during Phase 1 (runtime extraction): pulling whole
           # Python files out of a monorepo is monolithic by nature; voice_client.py
           # alone is 543 LOC. Restore to 600 once Phase 1 closes and surgical work resumes.


### PR DESCRIPTION
## Summary

- Excludes generated lockfiles from `git diff --shortstat` size measurement via git pathspec
- Covers JS, Rust, Python, Ruby, PHP, Go ecosystems

## Why

PR #37 is correct (-175 LOC) but failed the 1500 cap because adding js-yaml regenerated 6000 lines of pnpm-lock.yaml. Lockfiles aren't review-effort.

Closes #38

## Test plan

- [ ] CI on this PR: `PR size` passes
- [ ] After merge: re-run #37 CI and verify size check passes