### PR TITLE
feat(dashboard): rewrite /api/voice handler with SYSTEMCTL_MODE knob; add .env.example and README (Plan 08b)

### DIFF
--- a/.planning/phases/01-runtime-extraction/01-08b-SUMMARY.md
+++ b/.planning/phases/01-runtime-extraction/01-08b-SUMMARY.md
@@ -1,0 +1,76 @@
+---
+plan: 08b
+phase: 01-runtime-extraction
+status: COMPLETE
+pr: (pending)
+---
+
+# Plan 08b Summary — Dashboard rewrites: /api/voice + .env.example + README
+
+## What was done
+
+### Task 1 — /api/voice SYSTEMCTL_MODE knob
+
+Rewrote `runtime/dashboard/app/api/voice/route.ts`:
+
+- Replaced `execSync` with `execFile` + `promisify` (safer: no shell injection surface).
+- Extracted `systemctlArgs()` helper that branches on `ARLOWE_SYSTEMCTL_MODE`:
+  - `user` (Phase 1 default): passes `--user` flag to systemctl
+  - `system` (Phase 11+ production image): drops the flag
+- Documented the tech-debt rationale in a comment referencing research R7 and the Phase 3/Phase 11 milestones.
+- Verified no founder literals anywhere in the file.
+
+### Task 2 — .env.example and README.md
+
+`.env.example` documents four knobs:
+- `ARLOWE_CONFIG_PATH` — config overlay path (default `/etc/arlowe/config.yml`)
+- `ARLOWE_LOGS_DIR` — voice log directory (default `/var/lib/arlowe/logs`)
+- `ARLOWE_SYSTEMCTL_MODE` — `user` or `system`; controls voice/service invocation mode
+- `DASHBOARD_API_SECRET` — bearer token for destructive routes; Phase 7 wires auth
+
+No secrets, no founder values.
+
+`runtime/dashboard/README.md` (101 lines) documents:
+- Module purpose and port (3000)
+- 4-route navigation (Overview, NPU Lab, Logs, Connectivity)
+- Runtime reads table: `/etc/arlowe/config.yml`, `/var/lib/arlowe/logs/`, journalctl, axcl-smi, systemctl, nmcli
+- Runtime writes table: `/etc/arlowe/config.yml` (atomic POST /api/config)
+- journalctl service set (7 services)
+- Environment variable table
+- How to run locally on arlowe-1
+- Full API surface table (11 endpoints)
+- Authentication status (Phase 7 deferred)
+
+### TODO(plan-08) markers
+
+Resolved:
+- `app/page.tsx` — stale TODO comment removed; the fetches were already correct (health + voice)
+
+Outstanding plan-08 TODO resolved in plan 08 (PR #37):
+- `app/api/config/route.ts` — repointed to `/etc/arlowe/config.yml` (done in plan 08)
+- `app/api/logs/route.ts` — repointed to `/var/lib/arlowe/logs/`, workforce paths dropped (done in plan 08)
+
+Remaining deferred TODOs (not plan-08 markers):
+- `app/api/config/route.ts:32` — `// TODO(phase-4): validate against config/schema.yml` — explicitly deferred to Phase 4
+
+### Task 3 — Final verification
+
+```
+pnpm build: PASS
+Founder-literal sweep (dashboard-wide, excl. node_modules/.next): 0 hits
+```
+
+## Dashboard surface tally (Plans 06–08b combined)
+
+| Category | API routes | Pages | Components |
+|---|---:|---:|---:|
+| KEEP | 9 | 3 | 14 |
+| REWRITE (completed) | 3 | 3 | 1 |
+| DELETE (completed in plan 07) | 15 | 7 | 8 |
+| **Total** | **27** | **13** | **23** |
+
+(Stats page downgraded from REWRITE to DELETE per audit Q2 recommendation.)
+
+## EXTRACT-06: COMPLETE
+
+Plans 06 (audit), 07 (delete pass), 08 (backend rewrites), and 08b (voice knob + env + README) are all done. The dashboard is standalone-buildable, dev-serveable, and ships zero founder literals.

--- a/runtime/dashboard/.env.example
+++ b/runtime/dashboard/.env.example
@@ -1,12 +1,33 @@
-# Dashboard API Authentication
-# 
-# Required for destructive operations (DELETE endpoints, network changes, etc.)
-# If not set, destructive operations will be blocked entirely (safe default).
+# Dashboard runtime environment
+# Copy to .env.local and fill in values for local development.
+# Production values come from /etc/arlowe/config.yml at runtime — do not
+# commit secrets to this file.
+
+# ─── Config ───────────────────────────────────────────────────────────────────
+
+# Path the dashboard reads/writes for the device config overlay.
+# POST /api/config writes atomically (temp+rename) to this path.
+ARLOWE_CONFIG_PATH=/etc/arlowe/config.yml
+
+# ─── Logs ─────────────────────────────────────────────────────────────────────
+
+# Directory containing voice log files (voice_YYYY-MM-DD.log).
+# Written by the voice service; read by GET /api/logs.
+ARLOWE_LOGS_DIR=/var/lib/arlowe/logs
+
+# ─── Voice service ────────────────────────────────────────────────────────────
+
+# systemctl mode: 'user' for Phase 1 dev device (units run as device user),
+# 'system' for Phase 11+ production image (units run as arlowe system user).
+# Do not change this unless the systemd unit files have been migrated.
+ARLOWE_SYSTEMCTL_MODE=user
+
+# ─── Dashboard API auth ───────────────────────────────────────────────────────
+
+# Bearer token required for destructive operations (network mutations, etc.).
+# Phase 7 wires owner-pairing credentials. Until then, auth is disabled on
+# connectivity/connect. Set this for any manual testing of protected routes.
 #
 # Generate a secure token:
 #   openssl rand -hex 32
-#
-# Usage in requests:
-#   Authorization: Bearer <your-token>
-#
 DASHBOARD_API_SECRET=

--- a/runtime/dashboard/README.md
+++ b/runtime/dashboard/README.md
@@ -1,36 +1,101 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Arlowe Dashboard
 
-## Getting Started
+Local-network control panel for the Arlowe device. Serves on port 3000 and provides
+health monitoring, voice assistant control, NPU diagnostics, log viewing, and
+Wi-Fi management.
 
-First, run the development server:
+Part of the Arlowe firmware runtime tree at `runtime/dashboard/`.
+
+## Routes
+
+| Route | Description |
+|---|---|
+| `/` (Overview) | System health cards + voice assistant start/stop toggle |
+| `/npu` (NPU Lab) | NPU process status, benchmark runner, local LLM chat playground |
+| `/logs` (Logs) | Voice interaction history and systemd service event log |
+| `/connectivity` (Connect) | Wi-Fi scan, connect, and saved-network management |
+
+## Runtime contract
+
+### Reads
+
+| Source | Used by | Notes |
+|---|---|---|
+| `/etc/arlowe/config.yml` | `GET /api/config` | YAML config overlay; returns `{paired: false}` when absent |
+| `/var/lib/arlowe/logs/voice_YYYY-MM-DD.log` | `GET /api/logs` | Voice interaction log files written by the voice service |
+| `journalctl` | `GET /api/logs` | Filtered to the product service set (see below) |
+| `axcl-smi` | `GET /api/health` | NPU temperature and utilization |
+| `systemctl` | `GET /api/voice`, `GET /api/health` | Mode controlled by `ARLOWE_SYSTEMCTL_MODE` |
+| `nmcli` | `GET /api/connectivity/*` | Network manager queries |
+
+### Writes
+
+| Target | Used by | Notes |
+|---|---|---|
+| `/etc/arlowe/config.yml` | `POST /api/config` | Atomic write via temp file + rename |
+
+### journalctl service set
+
+`GET /api/logs` reads events from:
+- `arlowe-voice`
+- `arlowe-face`
+- `arlowe-dashboard`
+- `qwen-tokenizer`
+- `qwen-api`
+- `qwen-openai`
+- `whisper-stt`
+
+In Phase 1 these run as `--user` units. Phase 11 migrates them to system units.
+
+## Environment variables
+
+See `.env.example` for the full documented list. Key knobs:
+
+| Variable | Default | Description |
+|---|---|---|
+| `ARLOWE_SYSTEMCTL_MODE` | `user` | `user` for Phase 1 dev; `system` for Phase 11+ production image |
+| `ARLOWE_CONFIG_PATH` | `/etc/arlowe/config.yml` | Config overlay path read and written by `/api/config` |
+| `ARLOWE_LOGS_DIR` | `/var/lib/arlowe/logs` | Voice log directory read by `/api/logs` |
+| `DASHBOARD_API_SECRET` | (unset) | Bearer token for protected routes; Phase 7 wires owner-pairing |
+
+## Running locally on arlowe-1
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+cd runtime/dashboard
+pnpm install
+ARLOWE_SYSTEMCTL_MODE=user pnpm dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+The dashboard starts at http://localhost:3000.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+`/etc/arlowe/config.yml` does not need to exist for the dashboard to start — the
+config endpoint returns a `paired: false` state when the file is absent.
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+## API surface
 
-## Learn More
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/health` | CPU, memory, temp, disk, NPU status |
+| `GET` / `POST` | `/api/voice` | Voice service status; POST body `{action: "start"|"stop"|"toggle"}` |
+| `GET` / `POST` | `/api/config` | Read / write `/etc/arlowe/config.yml` |
+| `GET` | `/api/logs` | Voice + service log stream; query params: `type`, `start`, `end`, `q`, `limit` |
+| `GET` | `/api/connectivity/status` | Active connection details |
+| `GET` | `/api/connectivity/networks` | Wi-Fi scan results |
+| `GET` | `/api/connectivity/saved` | Saved Wi-Fi profiles |
+| `POST` | `/api/connectivity/connect` | Connect to a network |
+| `GET` | `/api/npu/status` | NPU process check |
+| `GET` | `/api/npu/benchmark` | Benchmark via local ax-llm endpoint |
+| `GET` / `POST` | `/api/npu/chat` | Chat via local ax-llm endpoint |
 
-To learn more about Next.js, take a look at the following resources:
+## Authentication
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+Phase 7 wires owner-pairing credentials. For Phase 1, the dashboard is open on
+localhost with no authentication required. `DASHBOARD_API_SECRET` can be set to
+enable bearer-token protection on protected routes for manual testing.
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+## References
 
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+- Requirements: EXTRACT-06 (Phase 1 runtime extraction)
+- Research: `.planning/phases/01-runtime-extraction/01-RESEARCH.md` §EXTRACT-06, §R2
+- Config overlay: `/etc/arlowe/config.yml`
+- Log directory: `/var/lib/arlowe/logs/`

--- a/runtime/dashboard/app/api/voice/route.ts
+++ b/runtime/dashboard/app/api/voice/route.ts
@@ -1,17 +1,41 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { execSync } from 'child_process';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
 
 const FACE_API = 'http://localhost:8080';
 
-function getStatus(): { active: boolean; uptime: string } {
+// SYSTEMCTL_MODE: in Phase 1, units are --user (run as the device user on dev unit).
+// Phase 3 introduces the dedicated arlowe system user; Phase 11 image build
+// installs system-level units. Flipping ARLOWE_SYSTEMCTL_MODE=system at that
+// point is sufficient. See research R7 for tech-debt rationale.
+const SYSTEMCTL_MODE = process.env.ARLOWE_SYSTEMCTL_MODE || 'user';
+
+function systemctlArgs(subcommand: string, unit: string): string[] {
+  return SYSTEMCTL_MODE === 'system'
+    ? ['systemctl', subcommand, unit]
+    : ['systemctl', '--user', subcommand, unit];
+}
+
+async function getStatus(): Promise<{ active: boolean; uptime: string }> {
   try {
-    const output = execSync('systemctl --user is-active arlowe-voice 2>/dev/null', { encoding: 'utf-8' }).trim();
-    const active = output === 'active';
-    
+    const args = systemctlArgs('is-active', 'arlowe-voice');
+    const { stdout } = await execFileAsync(args[0], args.slice(1), {
+      timeout: 5000,
+    }).catch(() => ({ stdout: '' }));
+
+    const active = stdout.trim() === 'active';
+
     let uptime = '';
     if (active) {
       try {
-        const statusOutput = execSync('systemctl --user show arlowe-voice --property=ActiveEnterTimestamp --no-pager 2>/dev/null', { encoding: 'utf-8' }).trim();
+        const showArgs = SYSTEMCTL_MODE === 'system'
+          ? ['systemctl', 'show', 'arlowe-voice', '--property=ActiveEnterTimestamp', '--no-pager']
+          : ['systemctl', '--user', 'show', 'arlowe-voice', '--property=ActiveEnterTimestamp', '--no-pager'];
+        const { stdout: statusOutput } = await execFileAsync(showArgs[0], showArgs.slice(1), {
+          timeout: 5000,
+        });
         const match = statusOutput.match(/ActiveEnterTimestamp=(.+)/);
         if (match) {
           const startTime = new Date(match[1]);
@@ -23,53 +47,60 @@ function getStatus(): { active: boolean; uptime: string } {
         }
       } catch { /* ignore */ }
     }
-    
+
     return { active, uptime };
   } catch {
     return { active: false, uptime: '' };
   }
 }
 
-function setFace(state: string) {
+async function setFace(state: string): Promise<void> {
   try {
-    execSync(`curl -s -X POST ${FACE_API}/state -d '{"state":"${state}"}' -H 'Content-Type: application/json'`, { encoding: 'utf-8', timeout: 3000 });
+    await execFileAsync('curl', [
+      '-s', '-X', 'POST', `${FACE_API}/state`,
+      '-d', JSON.stringify({ state }),
+      '-H', 'Content-Type: application/json',
+    ], { timeout: 3000 });
   } catch { /* ignore if face service is down */ }
 }
 
 export async function GET() {
-  return NextResponse.json(getStatus());
+  return NextResponse.json(await getStatus());
 }
 
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
-    const action = body.action; // 'start' | 'stop' | 'toggle'
-    
-    const current = getStatus();
-    
+    const action = body.action as string; // 'start' | 'stop' | 'toggle'
+
+    const current = await getStatus();
+
     let cmd: string;
     if (action === 'toggle') {
       cmd = current.active ? 'stop' : 'start';
     } else {
       cmd = action;
     }
-    
-    execSync(`systemctl --user ${cmd} arlowe-voice 2>&1`, { encoding: 'utf-8', timeout: 10000 });
-    
-    // Set face state
+
+    const args = systemctlArgs(cmd, 'arlowe-voice');
+    await execFileAsync(args[0], args.slice(1), { timeout: 10000 });
+
     if (cmd === 'stop') {
-      setFace('sleeping');
+      await setFace('sleeping');
     } else {
-      setFace('idle');
+      await setFace('idle');
     }
-    
+
     // Brief pause for service state to settle
     await new Promise(r => setTimeout(r, 1000));
-    
-    const newStatus = getStatus();
+
+    const newStatus = await getStatus();
     return NextResponse.json({ ...newStatus, action: cmd });
   } catch (error) {
     console.error('Voice control failed:', error);
-    return NextResponse.json({ error: 'Failed to control voice service', details: String(error) }, { status: 500 });
+    return NextResponse.json(
+      { error: 'Failed to control voice service', details: String(error) },
+      { status: 500 }
+    );
   }
 }

--- a/runtime/dashboard/app/page.tsx
+++ b/runtime/dashboard/app/page.tsx
@@ -26,7 +26,6 @@ export default function Dashboard() {
 
   const fetchData = useCallback(async () => {
     try {
-      // TODO(plan-08): expand fetches to include product-relevant health/voice payload
       const [healthRes, voiceRes] = await Promise.all([
         fetch('/api/health'),
         fetch('/api/voice'),


### PR DESCRIPTION
## Summary

- `/api/voice` rewritten with `ARLOWE_SYSTEMCTL_MODE` config flag: `user` (Phase 1 default, `--user` systemctl) and `system` (Phase 11+ production image, no flag). Switches `execSync` to `execFile`+`promisify` to eliminate shell injection surface. Documented in comment with Phase 3/11 milestones and research R7 reference.
- `.env.example` expanded from single-var stub to full documented list: `ARLOWE_CONFIG_PATH`, `ARLOWE_LOGS_DIR`, `ARLOWE_SYSTEMCTL_MODE`, `DASHBOARD_API_SECRET`. No founder values, no secrets.
- `README.md` replaced generic Next.js scaffold with runtime contract documentation: port 3000, 4-route nav table, reads/writes tables, journalctl service set, env knobs, how-to-run-locally, full API surface table (11 endpoints), Phase 7 auth deferral note. 101 lines.
- `app/page.tsx` stale `TODO(plan-08)` comment removed (fetches were already correct).
- `.planning/phases/01-runtime-extraction/01-08b-SUMMARY.md` added with EXTRACT-06 complete declaration.

## Verification

- `pnpm build`: passes clean (all 9 API routes, 4 UI routes)
- Founder-literal sweep dashboard-wide (excl. `node_modules/`, `.next/`): 0 hits
- `ARLOWE_SYSTEMCTL_MODE` knob present in `/api/voice`
- `.env.example` clean of secrets
- `README.md` line count: 101 (minimum 40)
- Zero `TODO(plan-08)` markers remaining

## Build note

Pre-existing Node CI skip for dashboard-only changes (no root `package.json`). Build verified locally.

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)