### PR TITLE
fix(voice): add env-var overrides for hardcoded paths and URLs

### DIFF
--- a/runtime/voice/README.md
+++ b/runtime/voice/README.md
@@ -13,12 +13,12 @@ Runs as a single Python process under the `arlowe` system user (currently the de
 
 ## Outbound HTTP calls
 
-| Target | URL | Used for |
+| Target | URL (default; env override) | Used for |
 |---|---|---|
-| face service | `http://localhost:8080/state` | render face expression and background during each pipeline stage |
-| STT server | `http://localhost:8082/transcribe` | transcribe wake-window audio via faster-whisper |
-| LLM router | via `llm.router` (delegates internally to `localhost:8001` or `claude` CLI) | generate response text |
-| dashboard | `http://localhost:3000` | rules engine fetches orchestration config; stub does not call this today |
+| face service | `http://localhost:8080/state` (`ARLOWE_FACE_URL`) | render face expression and background during each pipeline stage |
+| STT server | `http://localhost:8082/transcribe` (`ARLOWE_STT_URL`) | transcribe wake-window audio via faster-whisper |
+| LLM router | via `llm.router` (delegates internally to `localhost:8000` or `claude` CLI) | generate response text |
+| dashboard | `http://localhost:3000` (`ARLOWE_DASHBOARD_URL`) | rules engine fetches orchestration config; stub does not call this today |
 
 ## How to run locally on arlowe-1
 
@@ -46,6 +46,23 @@ The process streams diagnostic output to stdout. Structured voice logs go to `/v
 ## Dependencies
 
 See `requirements.txt`. Run from `/opt/arlowe/venv/` at image time or from the dev venv during development.
+
+## Environment overrides
+
+All filesystem paths and sibling-service URLs are configurable via environment variables. Defaults match the product layout (`/opt/arlowe/...`, `/var/lib/arlowe/...`).
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `ARLOWE_PIPER_PATH` | `/opt/arlowe/runtime/tts/bin/piper` | Piper TTS binary |
+| `ARLOWE_PIPER_MODEL` | `/opt/arlowe/models/piper-voices/en_US-lessac-medium.onnx` | Piper voice model |
+| `ARLOWE_VERIFIER_MODEL` | `/var/lib/arlowe/wake-word/verifier.pkl` | Wake-word verifier `.pkl` |
+| `ARLOWE_ALSA_DEVICE` | `plughw:2,0` | ALSA record + play device |
+| `ARLOWE_FACE_URL` | `http://localhost:8080` | Face service base URL |
+| `ARLOWE_STT_URL` | `http://localhost:8082/transcribe` | STT endpoint |
+| `ARLOWE_DASHBOARD_URL` | `http://localhost:3000` | Dashboard base URL |
+| `ARLOWE_LOGS_DIR` | `/var/lib/arlowe/logs` | Base logs dir (`voice/` subdir created here) |
+
+Set these via the systemd unit's `Environment=` lines on dev/test units, or globally in the image build for production.
 
 ## Known limitations
 

--- a/runtime/voice/voice_client.py
+++ b/runtime/voice/voice_client.py
@@ -35,29 +35,38 @@ from openwakeword.model import Model as WakeWordModel
 import pyaudio
 from face.sentiment_classifier import Sentiment
 
-# Paths
-PIPER_PATH = Path("/opt/arlowe/runtime/tts/bin/piper")
-PIPER_MODEL = Path("/opt/arlowe/models/piper-voices/en_US-lessac-medium.onnx")
-VERIFIER_MODEL = Path("/var/lib/arlowe/wake-word/verifier.pkl")
+# Paths — defaults match product layout; overridable for tests and dev units.
+PIPER_PATH = Path(os.environ.get("ARLOWE_PIPER_PATH", "/opt/arlowe/runtime/tts/bin/piper"))
+PIPER_MODEL = Path(os.environ.get(
+    "ARLOWE_PIPER_MODEL",
+    "/opt/arlowe/models/piper-voices/en_US-lessac-medium.onnx",
+))
+VERIFIER_MODEL = Path(os.environ.get(
+    "ARLOWE_VERIFIER_MODEL",
+    "/var/lib/arlowe/wake-word/verifier.pkl",
+))
 # TODO(phase-5): Replace plughw:2,0 with config-driven audio device selection.
-RECORD_DEVICE = "plughw:2,0"
-PLAY_DEVICE = "plughw:2,0"
+RECORD_DEVICE = os.environ.get("ARLOWE_ALSA_DEVICE", "plughw:2,0")
+PLAY_DEVICE = os.environ.get("ARLOWE_ALSA_DEVICE", "plughw:2,0")
 
 # Wake word detection thresholds
 BASE_THRESHOLD = 0.20
 VERIFIER_THRESHOLD = 0.30
 
 # Face control
-FACE_API = "http://localhost:8080"
+FACE_API = os.environ.get("ARLOWE_FACE_URL", "http://localhost:8080")
+
+# STT server
+STT_URL = os.environ.get("ARLOWE_STT_URL", "http://localhost:8082/transcribe")
 
 # Orchestration Dashboard
-DASHBOARD_URL = "http://localhost:3000"
+DASHBOARD_URL = os.environ.get("ARLOWE_DASHBOARD_URL", "http://localhost:3000")
 
 # Fan control
 FAN_PWM = "/sys/class/hwmon/hwmon2/pwm1"
 
-# Logging
-LOG_DIR = Path("/var/lib/arlowe/logs/voice")
+# Logging — ARLOWE_LOGS_DIR is the shared base; voice subdir lives under it.
+LOG_DIR = Path(os.environ.get("ARLOWE_LOGS_DIR", "/var/lib/arlowe/logs")) / "voice"
 LOG_DIR.mkdir(parents=True, exist_ok=True)
 
 
@@ -294,7 +303,7 @@ def transcribe(audio_path: str) -> str:
             audio_data = f.read()
         
         req = urllib.request.Request(
-            "http://localhost:8082/transcribe",
+            STT_URL,
             data=audio_data,
             headers={"Content-Type": "application/octet-stream"}
         )


### PR DESCRIPTION
## Summary

- Adds env overrides to `runtime/voice/voice_client.py` for every hardcoded path and sibling-service URL
- Promotes the inline STT URL literal to a constant
- README documents the env knobs in a new section

## Why

PR #21 (voice extraction) replaced founder paths with product paths but didn't make them env-overridable. Other runtime modules (cli, llm) did. This blocks Plan 13 smoke-test staging where the runtime is at `/tmp/arlowe-runtime-test/` and state is at `/tmp/arlowe-test-state/` — currently no way to redirect voice_client.py to those locations.

All defaults preserved → zero behavior change in production.

Closes #45
Refs #15 (unblocks smoke test)

## Test plan

- [ ] CI green
- [ ] voice_client.py parses cleanly
- [ ] Smoke test (Plan 13 task 4) staging proceeds once this lands