### PR TITLE
fix(llm): import sentiment_classifier from face package, not bare

### DIFF
--- a/runtime/llm/router.py
+++ b/runtime/llm/router.py
@@ -17,10 +17,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from filelock import FileLock
 
-# Import sentiment classifier
-import sys
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from sentiment_classifier import analyze_and_express, Sentiment
+# Sentiment classifier lives in the sibling face/ package after extraction.
+from face.sentiment_classifier import analyze_and_express, Sentiment
 
 # Usage stats file — whisplay local bookkeeping; not shared with any other
 # service. Writes to the arlowe state directory instead of the old developer


### PR DESCRIPTION
## Summary

`runtime/llm/router.py` imported `sentiment_classifier` via a bare name + sys.path hack pointing at `runtime/llm/`. The module is actually in `runtime/face/`. Broken since the LLM extraction landed.

## Fix

`from face.sentiment_classifier import analyze_and_express, Sentiment` — package-qualified, drop the sys.path.insert hack.

Closes #47
Refs #15 (unblocks smoke test)

## Test plan

- [ ] CI green
- [ ] `from llm.router import` resolves when `PYTHONPATH=runtime`
- [ ] Plan 13 voice unit starts past the import without error