### PR TITLE
fix: env-overrides sweep for remaining hardcoded /var/lib/arlowe paths

### DIFF
--- a/runtime/face/sentiment_classifier.py
+++ b/runtime/face/sentiment_classifier.py
@@ -5,22 +5,22 @@ Uses local NPU (Qwen model) for real-time sentiment analysis.
 Maps sentiment to facial expressions.
 """
 import json
+import os
 import urllib.request
 import urllib.error
 from enum import Enum
 from pathlib import Path
 from typing import Tuple, Optional
 
-# localhost:8001 is the OpenAI-compat shim. See research notes / plan 13:
-# the path may be replumbed to localhost:8000 (ax-llm native) once the
-# qwen-openai resolution lands. Heuristic fallback handles the broken case.
-QWEN_URL = "http://localhost:8001/v1/chat/completions"
+# Resolved per ADR-0001 §Resolution (option-2, plan 13): query ax-llm
+# native OpenAI surface on :8000 directly. The openai_wrapper.py shim is gone.
+QWEN_URL = "http://localhost:8000/v1/chat/completions"
 
 # Load order: /etc/arlowe/config.yml (post-pairing overlay, Phase 4),
-# falling back to /var/lib/arlowe/state/whisplay-config.json for dev.
+# falling back to <state>/whisplay-config.json for dev.
 # During Phase 1 we accept the fallback path; Phase 4 wires the overlay.
-CONFIG_OVERLAY = Path("/etc/arlowe/config.yml")
-CONFIG_PATH = Path("/var/lib/arlowe/state/whisplay-config.json")
+CONFIG_OVERLAY = Path(os.environ.get("ARLOWE_CONFIG_PATH", "/etc/arlowe/config.yml"))
+CONFIG_PATH = Path(os.environ.get("ARLOWE_STATE_DIR", "/var/lib/arlowe/state")) / "whisplay-config.json"
 
 
 class Sentiment(Enum):

--- a/runtime/llm/router.py
+++ b/runtime/llm/router.py
@@ -22,10 +22,12 @@ from face.sentiment_classifier import analyze_and_express, Sentiment
 
 # Usage stats file — whisplay local bookkeeping; not shared with any other
 # service. Writes to the arlowe state directory instead of the old developer
-# workspace location. See ADR-0001.
-USAGE_STATS_PATH = Path("/var/lib/arlowe/state/usage-stats.json")
-USAGE_STATS_PATH.parent.mkdir(parents=True, exist_ok=True)
+# workspace location. See ADR-0001. State dir overridable for tests + dev.
+_STATE_DIR = Path(os.environ.get("ARLOWE_STATE_DIR", "/var/lib/arlowe/state"))
+USAGE_STATS_PATH = _STATE_DIR / "usage-stats.json"
 USAGE_LOCK_PATH = USAGE_STATS_PATH.with_suffix(".lock")
+# Lazy mkdir — at write time, not import time. Import must not require
+# write permission to the state dir (smoke-test runtimes mount /tmp paths).
 
 # Local Qwen API
 # Resolved per ADR-0001 §Resolution (option-2, plan 13): point directly at
@@ -127,6 +129,8 @@ def log_usage(provider: str, input_tokens: int = 0, output_tokens: int = 0,
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
 
     try:
+        # Ensure the state dir exists before FileLock tries to create its lockfile.
+        _STATE_DIR.mkdir(parents=True, exist_ok=True)
         lock = FileLock(str(USAGE_LOCK_PATH), timeout=5)
         with lock:
             # Read existing stats

--- a/runtime/voice/voice_log.py
+++ b/runtime/voice/voice_log.py
@@ -8,7 +8,7 @@ import sys
 from datetime import datetime, timedelta
 from pathlib import Path
 
-LOG_DIR = Path("/var/lib/arlowe/logs/voice")
+LOG_DIR = Path(os.environ.get("ARLOWE_LOGS_DIR", "/var/lib/arlowe/logs")) / "voice"
 KEEP_DAYS = 7
 
 def cleanup_old_logs():


### PR DESCRIPTION
## Summary

Three follow-up env-override fixes surfaced by Plan 13 smoke-test staging:

- `router.py` USAGE_STATS_PATH → `ARLOWE_STATE_DIR` + lazy mkdir (import no longer requires write perms)
- `sentiment_classifier.py` CONFIG_PATH → `ARLOWE_STATE_DIR`, CONFIG_OVERLAY → `ARLOWE_CONFIG_PATH`, QWEN_URL aligned to option-2 (:8000)
- `voice_log.py` LOG_DIR → `ARLOWE_LOGS_DIR`

## Why

Same root cause as #45 — extraction agents kept hardcoded prod paths instead of env-overridable ones. The voice fix only got one file.

Closes #49
Refs #15 (unblocks smoke test)

## Test plan

- [ ] CI green
- [ ] Plan 13 voice unit imports cleanly with /var/lib/arlowe read-only
- [ ] All three files parse