### PR TITLE
feat(sanitize): plan 02-01 — grep gate runner, allow-list, CI workflow skeleton

### DIFF
--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -25,6 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install ripgrep
+        run: sudo apt-get install -y ripgrep
       - name: Verify ripgrep is available
         run: rg --version
       - name: Run grep gate
@@ -35,5 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install ripgrep
+        run: sudo apt-get install -y ripgrep
       - name: Run deliberate-failure self-test
         run: bash scripts/sanitize/test-check.sh

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -1,0 +1,39 @@
+name: Sanitize
+
+# NO `paths:` filter — required checks + path filtering = "pending forever" trap.
+# A PR that only touches docs/ wouldn't trigger the workflow; the required check
+# would stay in "Expected — Waiting for status" forever, blocking merge.
+# The full scan takes ~2s on the current tree; path-gating is not worth the risk.
+#
+# To promote this to a required check: Settings → Branches → branch protection rule
+# → "Require status checks to pass" → add "Banlist + unit-name block" and
+# "Gate self-test". Do this AFTER the workflow has run green on a few PRs.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: sanitize-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  banlist-and-units:
+    name: Banlist + unit-name block
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify ripgrep is available
+        run: rg --version
+      - name: Run grep gate
+        run: bash scripts/sanitize/check.sh --grep-only
+
+  self-test:
+    name: Gate self-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run deliberate-failure self-test
+        run: bash scripts/sanitize/test-check.sh

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -72,7 +72,13 @@ Plans:
   3. A snapshot test against rendered dashboard UI text (and screenshots from a headless run) fails on any banned literal, including links to founder repos or workforce-internal endpoints.
   4. The current `runtime/` tree passes all sanitization checks: zero references to founder hostname, account, SSID, email, home path, or monorepo path.
 
-**Plans**: TBD
+**Plans**: 4 plans
+
+Plans:
+- [ ] 02-01-PLAN.md — Banlist + grep gate runner + allow-list + CI workflow + self-test (Wave 1, foundational)
+- [ ] 02-02-PLAN.md — Unit-name block extension + `--scan-dir DIR` flag for Phase 6 reuse (Wave 2, depends on 02-01)
+- [ ] 02-03-PLAN.md — Dashboard Playwright sanitize.spec.ts + CI wiring (Wave 2, depends on 02-01; parallel with 02-02)
+- [ ] 02-04-PLAN.md — Runtime/ tree SC4 cleanup sweep + F5 ADR-0001 fix; drives all gates green on main (Wave 3, depends on 02-01, 02-02, 02-03)
 
 ### Phase 3: Service user and filesystem layout
 
@@ -249,7 +255,7 @@ Phases execute in numeric order: 1 -> 2 -> 3 -> 4 -> 5 -> 6 -> 7 -> 8 -> 9 -> 10
 | Phase | Plans Complete | Status | Completed |
 |-------|----------------|--------|-----------|
 | 1. Runtime extraction | 15/15 | Complete (qualified — SC4 hardware loop deferred to Phase 12; see plan 13 SUMMARY F1-F4) | 2026-05-17 |
-| 2. Sanitization gate | 0/TBD | Not started | - |
+| 2. Sanitization gate | 0/4 | Planned | - |
 | 3. Service user and filesystem layout | 0/TBD | Not started | - |
 | 4. Config overlay | 0/TBD | Not started | - |
 | 5. Audio device auto-detection | 0/TBD | Not started | - |

--- a/.planning/phases/02-sanitization-gate/02-01-PLAN.md
+++ b/.planning/phases/02-sanitization-gate/02-01-PLAN.md
@@ -111,6 +111,7 @@ Output: A bash runner script, a banlist data file, a self-test, an allow-list, a
 
     # Architecture decision records and operational docs that capture historical state.
     docs/architecture/**
+    docs/architecture-overview.md
     docs/operations/phase-1-smoke-test.md
 
     # Journey entries (workforce diary; never ships in firmware).
@@ -137,17 +138,18 @@ Output: A bash runner script, a banlist data file, a self-test, an allow-list, a
     scripts/sanitize/unit-prefixes.txt
     scripts/sanitize/test-check.sh
     ```
-    Allow-list scope decision (documented here so future readers know why): workforce plumbing (CODEOWNERS, AGENTS.md.template, README.md) is allow-listed path-wide because none of it ships in firmware — the risk SANIT exists to prevent is founder identity *in customer images*, not in repo-wide developer-facing files. Per CONTEXT deferred ideas, "founder name/brand literals beyond the 6" are explicitly scoped out.
+    Allow-list scope decision (documented here so future readers know why): workforce plumbing (CODEOWNERS, AGENTS.md.template, README.md, docs/architecture-overview.md) is allow-listed path-wide because none of it ships in firmware — the risk SANIT exists to prevent is founder identity *in customer images*, not in repo-wide developer-facing files. `docs/architecture-overview.md` is workforce-protocol prose containing YAML examples like `repo: focal55/8bithomies`; same rationale as README.md / AGENTS.md.template. Per CONTEXT deferred ideas, "founder name/brand literals beyond the 6" are explicitly scoped out.
 
     NOTE: `scripts/sanitize/unit-prefixes.txt` is referenced in the allow-list but will be created in Plan 02. Listing it now is harmless (allow-listing a path that doesn't exist yet is a no-op for `git ls-files`) and avoids a churn-edit when Plan 02 lands.
   </action>
   <verify>
     `cat scripts/sanitize/banlist.txt | wc -l` returns 6.
     `cat .sanitize-allowlist | grep -c '^\.planning'` returns 1.
+    `grep -F 'docs/architecture-overview.md' .sanitize-allowlist` matches.
     `grep -F 'casa_ybarra_chelsea' scripts/sanitize/banlist.txt` matches.
   </verify>
   <done>
-    Both files exist on disk with the contents specified above. The 6 literals are present in banlist.txt with no extra whitespace or comments. The allow-list header comment explains `**` semantics.
+    Both files exist on disk with the contents specified above. The 6 literals are present in banlist.txt with no extra whitespace or comments. The allow-list header comment explains `**` semantics. The allow-list includes `docs/architecture-overview.md` alongside the other workforce-plumbing entries.
   </done>
 </task>
 
@@ -248,7 +250,7 @@ Output: A bash runner script, a banlist data file, a self-test, an allow-list, a
 
 1. **End-to-end self-test passes**: `bash scripts/sanitize/test-check.sh` exits 0.
 2. **Gate currently fails on dirty tree** (expected, Plan 04 cleans it up): `bash scripts/sanitize/check.sh --grep-only` exits non-zero and prints `::error file=...` lines.
-3. **Allow-list is honored**: After (2), confirm that no hit reports a path under `.planning/`, `docs/architecture/`, `docs/journey/`, `.github/CODEOWNERS`, `AGENTS.md.template`, `README.md`, or `scripts/sanitize/banlist.txt` — the allow-list globs should have excluded them.
+3. **Allow-list is honored**: After (2), confirm that no hit reports a path under `.planning/`, `docs/architecture/`, `docs/architecture-overview.md`, `docs/journey/`, `.github/CODEOWNERS`, `AGENTS.md.template`, `README.md`, or `scripts/sanitize/banlist.txt` — the allow-list globs should have excluded them.
 4. **Workflow YAML is valid**: `python -c "import yaml; yaml.safe_load(open('.github/workflows/sanitize.yml'))"` exits 0.
 5. **No `paths:` filter**: `grep -E '^\s+paths:' .github/workflows/sanitize.yml` returns nothing.
 6. **Failure message contains the agent-self-correction hint**: `bash scripts/sanitize/check.sh --grep-only 2>&1 | grep -q '\.sanitize-allowlist'`.
@@ -257,16 +259,17 @@ Output: A bash runner script, a banlist data file, a self-test, an allow-list, a
 <success_criteria>
 - All 3 tasks complete with verify-block passing.
 - `scripts/sanitize/check.sh` is the single bash entry point; `--grep-only` works in this plan; `--units-only` is a placeholder for Plan 02.
-- `.sanitize-allowlist` covers .planning, docs/architecture, docs/journey, workforce plumbing (CODEOWNERS, AGENTS.md.template, README.md), and the gate's own data files.
+- `.sanitize-allowlist` covers .planning, docs/architecture, docs/architecture-overview.md, docs/journey, workforce plumbing (CODEOWNERS, AGENTS.md.template, README.md), and the gate's own data files.
 - `.github/workflows/sanitize.yml` runs on every PR with no `paths:` filter.
 - The gate's failure output includes inline GitHub annotations + the `.sanitize-allowlist` self-correction hint.
-- PR-size budget: estimated ~250 net lines (script ~120, allow-list ~30, banlist 6, test-check ~30, workflow ~30). Well under 400.
+- PR-size budget: estimated ~250 net lines (script ~120, allow-list ~31, banlist 6, test-check ~30, workflow ~30). Well under 400.
 </success_criteria>
 
 <output>
 After completion, create `.planning/phases/02-sanitization-gate/02-01-SUMMARY.md` documenting:
 - What landed (script flags, allow-list initial entries, workflow job names)
-- Why workforce plumbing (CODEOWNERS, AGENTS.md.template, README.md) was allow-listed path-wide (per CONTEXT deferred-ideas rationale, this resolves RESEARCH Open Questions 1 & 2)
+- Why workforce plumbing (CODEOWNERS, AGENTS.md.template, README.md, docs/architecture-overview.md) was allow-listed path-wide (per CONTEXT deferred-ideas rationale, this resolves RESEARCH Open Questions 1 & 2)
 - Verification snapshot: count of hits the gate reports on current main (the number Plan 04 needs to drive to zero)
 - Pointer to Plan 02 for the unit-name extension and Plan 03 for the dashboard gate
+</output>
 </output>

--- a/.planning/phases/02-sanitization-gate/02-01-PLAN.md
+++ b/.planning/phases/02-sanitization-gate/02-01-PLAN.md
@@ -1,0 +1,272 @@
+---
+phase: 02-sanitization-gate
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - scripts/sanitize/check.sh
+  - scripts/sanitize/banlist.txt
+  - scripts/sanitize/test-check.sh
+  - .sanitize-allowlist
+  - .github/workflows/sanitize.yml
+autonomous: true
+
+must_haves:
+  truths:
+    - "A PR introducing any of the 6 banned identity literals into a tracked, non-allow-listed file fails CI"
+    - "CI failure output includes the path, line, and column of each hit in agent-parseable format (path:line:col:literal)"
+    - "CI failure surfaces as inline GitHub Actions error annotations on the offending lines of the PR diff"
+    - "The failure message tells the reader to add the path to .sanitize-allowlist if the reference is legitimate"
+    - "The gate script self-tests in CI: a planted banned literal in a temp tree is caught"
+    - "The gate script does NOT match its own banlist.txt (self-allow-listed) or other scripts/sanitize/ data files"
+    - "The sanitize.yml workflow runs on every PR without a `paths:` filter (avoiding the required-check pending-forever trap)"
+  artifacts:
+    - path: "scripts/sanitize/check.sh"
+      provides: "Grep-gate runner; bash; <150 LOC; supports --grep-only and --units-only flags for selective invocation"
+      min_lines: 50
+    - path: "scripts/sanitize/banlist.txt"
+      provides: "The 6 banned literals, one per line, no comments inside the data"
+      contains: "focal55"
+    - path: "scripts/sanitize/test-check.sh"
+      provides: "Self-test that plants a banned literal in a temp git tree and asserts check.sh exits non-zero"
+      min_lines: 20
+    - path: ".sanitize-allowlist"
+      provides: "Path globs (gitignore-style) of files allowed to contain banned literals; documented with a header comment explaining `**` semantics"
+      min_lines: 15
+    - path: ".github/workflows/sanitize.yml"
+      provides: "GitHub Actions workflow with banlist-and-units job + self-test job; NO paths: filter; runs on pull_request and push to main"
+      contains: "scripts/sanitize/check.sh"
+  key_links:
+    - from: ".github/workflows/sanitize.yml"
+      to: "scripts/sanitize/check.sh"
+      via: "bash invocation"
+      pattern: "bash scripts/sanitize/check\\.sh"
+    - from: "scripts/sanitize/check.sh"
+      to: ".sanitize-allowlist"
+      via: "reads path globs, converts to `:(exclude,glob)PATTERN` pathspecs passed to git ls-files"
+      pattern: "exclude,glob"
+    - from: "scripts/sanitize/check.sh"
+      to: "scripts/sanitize/banlist.txt"
+      via: "ripgrep -f flag reads patterns from this file"
+      pattern: "rg .*-f .*banlist"
+    - from: "scripts/sanitize/test-check.sh"
+      to: "scripts/sanitize/check.sh"
+      via: "invokes check.sh against a temp tree containing a planted literal"
+      pattern: "check\\.sh"
+---
+
+<objective>
+Stand up the grep-style CI sanitization gate that fails any PR introducing one of the 6 banned identity literals into a tracked, non-allow-listed file.
+
+Purpose: Make founder-identity regressions mechanically impossible going forward. Phase 1 just landed a freshly extracted runtime; every subsequent phase will add code on top. This gate catches strings *before* they merge so each later phase doesn't need a manual re-audit.
+
+Output: A bash runner script, a banlist data file, a self-test, an allow-list, and a GitHub Actions workflow wired as a required check. Plan 02 will extend the runner with a unit-name block; Plan 03 will add the Playwright-based rendered-HTML gate; Plan 04 will sanitize the existing runtime/ tree and prove the gate stays green on main.
+</objective>
+
+<execution_context>
+@~/.claude/get-shit-done/workflows/execute-plan.md
+@~/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/02-sanitization-gate/02-CONTEXT.md
+@.planning/phases/02-sanitization-gate/02-RESEARCH.md
+
+# Existing CI workflows (for pattern consistency)
+@.github/workflows/ci.yml
+@.github/workflows/pr-checks.yml
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Create banlist data file + allow-list with documented globs</name>
+  <files>scripts/sanitize/banlist.txt, .sanitize-allowlist</files>
+  <action>
+    Create `scripts/sanitize/banlist.txt` with the 6 banned literals from ROADMAP SC1, exactly one per line, no comments or blank lines inside the data:
+    ```
+    focal55
+    arlowe-1
+    casa_ybarra_chelsea
+    /home/focal55
+    joe@focal55
+    iol-monorepo
+    ```
+    These are passed to `rg -f banlist.txt -iF` so each line is treated as a case-insensitive fixed string. Order does not matter.
+
+    Create `.sanitize-allowlist` at the repo root containing path globs (gitignore-style, `**` for recursive) of files allowed to contain banned literals. Lead with a header comment explaining glob semantics (single `*` does NOT cross `/`, use `**` for recursive). Entries:
+    ```
+    # .sanitize-allowlist
+    # Path globs (gitignore-style) of tracked files allowed to contain banned identity literals.
+    # Single `*` does NOT cross `/`; use `**` for recursive matching.
+    # If you're tempted to add a new entry, ask: does this file ship in the firmware image?
+    # If yes, fix the literal instead of allow-listing.
+
+    # Planning artifacts that document banned literals as part of their purpose.
+    .planning/**
+
+    # Architecture decision records and operational docs that capture historical state.
+    docs/architecture/**
+    docs/operations/phase-1-smoke-test.md
+
+    # Journey entries (workforce diary; never ships in firmware).
+    docs/journey/**
+
+    # Workforce / template plumbing — references @focal55 the GitHub username, not founder
+    # identity in the firmware sense. None of these files ship in the image.
+    .github/CODEOWNERS
+    .github/ISSUE_TEMPLATE/config.yml
+    AGENTS.md.template
+    README.md
+
+    # Dev pull script: references arlowe-1 because that's the dev unit it pulls from.
+    scripts/dev-pull-from-pi.sh
+
+    # Third-party distribution paperwork.
+    third_party/axcl/DISTRIBUTION-RIGHTS.md
+    third_party/axcl/INSTALL.md
+    third_party/whisplay-driver/PROVENANCE.md
+
+    # Sanitize gate self-references (the data files contain the literals by design).
+    .sanitize-allowlist
+    scripts/sanitize/banlist.txt
+    scripts/sanitize/unit-prefixes.txt
+    scripts/sanitize/test-check.sh
+    ```
+    Allow-list scope decision (documented here so future readers know why): workforce plumbing (CODEOWNERS, AGENTS.md.template, README.md) is allow-listed path-wide because none of it ships in firmware — the risk SANIT exists to prevent is founder identity *in customer images*, not in repo-wide developer-facing files. Per CONTEXT deferred ideas, "founder name/brand literals beyond the 6" are explicitly scoped out.
+
+    NOTE: `scripts/sanitize/unit-prefixes.txt` is referenced in the allow-list but will be created in Plan 02. Listing it now is harmless (allow-listing a path that doesn't exist yet is a no-op for `git ls-files`) and avoids a churn-edit when Plan 02 lands.
+  </action>
+  <verify>
+    `cat scripts/sanitize/banlist.txt | wc -l` returns 6.
+    `cat .sanitize-allowlist | grep -c '^\.planning'` returns 1.
+    `grep -F 'casa_ybarra_chelsea' scripts/sanitize/banlist.txt` matches.
+  </verify>
+  <done>
+    Both files exist on disk with the contents specified above. The 6 literals are present in banlist.txt with no extra whitespace or comments. The allow-list header comment explains `**` semantics.
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Implement scripts/sanitize/check.sh grep-gate runner</name>
+  <files>scripts/sanitize/check.sh</files>
+  <action>
+    Implement the bash runner that scans tracked files for banlist literals and emits GitHub Actions annotations on hits. Based on the skeleton in 02-RESEARCH.md §"Pattern 1: Grep gate runner", with these specifics:
+
+    - Shebang `#!/usr/bin/env bash`, `set -euo pipefail`.
+    - Compute `SCRIPT_DIR` (dirname of self) and `REPO_ROOT` (from `git rev-parse --show-toplevel`); `cd "$REPO_ROOT"`.
+    - Accept three flags so Plan 02 can compose with this script and Plan 04 can debug:
+      - `--grep-only` (default behavior; runs the banlist scan)
+      - `--units-only` (placeholder for Plan 02 — for now, exit 0 with a "not implemented yet" stderr message; Plan 02 will fill this in)
+      - No flag = run grep-only (sane default). When Plan 02 lands, no-flag will run both gates.
+    - Read `.sanitize-allowlist`: strip `#` comments, strip blank lines, trim whitespace, build a bash array of `:(exclude,glob)LINE` pathspecs.
+    - Enumerate scan-target files via `git ls-files -- "${PATHSPECS[@]+${PATHSPECS[@]}}"` (the `${VAR[@]+${VAR[@]}}` expansion is the `set -u`-safe way to expand a possibly-empty array).
+    - Invoke `rg -iFn --column --no-heading -f "$SCRIPT_DIR/banlist.txt" -- "${FILES[@]}"` and capture HITS. Use `|| true` after the rg call because rg exits non-zero on no-matches and we want to keep going.
+    - If HITS is empty: print `sanitize: clean (${#FILES[@]} tracked files scanned)` and exit 0.
+    - Otherwise, loop over HITS lines, split on `:` into path/line/col/rest, and emit BOTH:
+      - GitHub annotation: `::error file=PATH,line=LINE,col=COL,title=Banned identity literal::banned identity literal at PATH:LINE:COL — if this is a legitimate historical reference, add the path to .sanitize-allowlist`
+      - stderr human-readable: `PATH:LINE:COL: REST` (matches the vimgrep-ish format agents/humans can copy-paste).
+    - Exit 1 if any hits were emitted.
+
+    Failure-message hint text (agent-parseable, calibrated against the global memory note that workforce agents need self-correction hints without a human round-trip): exact wording must include the literal substring `.sanitize-allowlist` so an agent reading the error knows the file name to edit.
+
+    Implementation notes:
+    - Use `mapfile -t FILES < <(git ls-files ...)` to populate the file array safely.
+    - Use a `while IFS= read -r hit; do ... done <<< "$HITS"` loop to iterate the rg output.
+    - Splitting on `:` is safe for our 6 literals (none contain colons) and for tracked paths in this repo (no path component contains a colon).
+    - Make the script executable: `chmod +x scripts/sanitize/check.sh` (done after Write — verify with `ls -l`).
+
+    DO NOT add: `--json` parsing (the per-event JSON shape from rg is painful per RESEARCH Pitfall 4), `find`-based fallbacks (git ls-files is authoritative), pre-commit hook plumbing (CONTEXT explicitly defers), or per-literal allow-list precision (CONTEXT explicitly defers v1).
+  </action>
+  <verify>
+    `bash -n scripts/sanitize/check.sh` parses cleanly.
+    `chmod +x scripts/sanitize/check.sh && ls -l scripts/sanitize/check.sh | grep -q 'x'` — executable bit set.
+    Run from repo root: `bash scripts/sanitize/check.sh --grep-only` exits non-zero on the current tree (because runtime/ still has the 16 dirty files Plan 04 will clean up) AND outputs `::error file=...` lines AND each error message contains the literal `.sanitize-allowlist`.
+    Run with `--units-only`: exits 0 with a stderr note like "units gate not implemented in plan 01; landing in plan 02".
+  </verify>
+  <done>
+    Script exists, is executable, parses cleanly under `bash -n`, exits non-zero on the current dirty tree, emits GitHub-annotation-formatted errors, and includes the `.sanitize-allowlist` hint in its message text.
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Implement self-test + wire CI workflow</name>
+  <files>scripts/sanitize/test-check.sh, .github/workflows/sanitize.yml</files>
+  <action>
+    **Self-test (`scripts/sanitize/test-check.sh`)**:
+
+    Implement a bash script that proves `check.sh` correctly catches a planted banned literal in a temp tree. Skeleton:
+    - Shebang `#!/usr/bin/env bash`, `set -euo pipefail`.
+    - Determine `REPO_ROOT` from `git rev-parse --show-toplevel`.
+    - `TMP=$(mktemp -d)`; `trap "rm -rf $TMP" EXIT`.
+    - In TMP, `git init -q`, write a file containing the literal `focal55` (e.g., `echo "user: focal55" > $TMP/planted.txt`), `git add .`, `git -c user.email=t@t -c user.name=t commit -qm test`.
+    - Copy `scripts/sanitize/banlist.txt` and `.sanitize-allowlist` into TMP (the allow-list will be effectively empty for this test tree since none of the tracked paths match the real-repo globs).
+    - Run `(cd $TMP && bash $REPO_ROOT/scripts/sanitize/check.sh --grep-only)` and capture the exit code via `if/else` (don't let `set -e` kill the test).
+    - Assert exit code is non-zero. If zero, print `FAIL: gate did not catch planted focal55` to stderr and exit 1.
+    - On success, print `PASS: gate correctly blocked planted focal55` and exit 0.
+    - `chmod +x` the script.
+
+    The test-check.sh file is itself in the allow-list (Task 1) so it can contain the literal `focal55` without tripping the production gate.
+
+    **CI workflow (`.github/workflows/sanitize.yml`)**:
+
+    Based on 02-RESEARCH.md §"Pattern 4: GitHub Actions workflow" with these specifics:
+    - `name: Sanitize`
+    - `on: pull_request: branches: [main]` AND `push: branches: [main]`. NO `paths:` filter — required-check + path-filter trap is documented in RESEARCH §Pitfall 1.
+    - `concurrency: group: sanitize-${{ github.ref }}; cancel-in-progress: true`.
+    - Two jobs in this plan (Plan 03 adds the dashboard-rendered-text job; do not include it here):
+      - `banlist-and-units`: `runs-on: ubuntu-latest`; steps = `actions/checkout@v4`, `rg --version` (sanity-check the runner has ripgrep), `bash scripts/sanitize/check.sh --grep-only`. The `--grep-only` flag is explicit so Plan 02's `--units-only` step is a clean add without re-numbering.
+      - `self-test`: `runs-on: ubuntu-latest`; steps = `actions/checkout@v4`, `bash scripts/sanitize/test-check.sh`.
+
+    Do NOT mark the workflow as a required check at this stage — that's a branch-protection rule the repo owner toggles in GitHub settings, not a workflow-file setting. The workflow needs to land first, run green on a few PRs, then the owner promotes it to required. Document this in the workflow file's top comment.
+
+    Naming consistency: existing workflows use lowercase-hyphenated job names (`build-test`, `pr-size`); follow that pattern.
+  </action>
+  <verify>
+    `bash -n scripts/sanitize/test-check.sh` parses cleanly.
+    `chmod +x scripts/sanitize/test-check.sh && ls -l scripts/sanitize/test-check.sh | grep -q 'x'` — executable bit set.
+    `bash scripts/sanitize/test-check.sh` exits 0 and prints `PASS:` (proves the gate catches the planted literal end-to-end).
+    `cat .github/workflows/sanitize.yml | grep -c '^jobs:'` returns 1.
+    `grep -c '^  banlist-and-units:' .github/workflows/sanitize.yml` returns 1.
+    `grep -c '^  self-test:' .github/workflows/sanitize.yml` returns 1.
+    `grep -E '^\s+paths:' .github/workflows/sanitize.yml` returns nothing (no paths filter, per RESEARCH §Pitfall 1).
+    `yamllint .github/workflows/sanitize.yml` passes (or, if yamllint isn't installed, `python -c "import yaml; yaml.safe_load(open('.github/workflows/sanitize.yml'))"` exits 0).
+  </verify>
+  <done>
+    Self-test script exists, is executable, and proves locally that check.sh catches a planted literal. Workflow file exists with two jobs (no paths filter, no required-check assertion in-file), is valid YAML, and references both check.sh and test-check.sh.
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+**Plan-level verification (run after all 3 tasks complete):**
+
+1. **End-to-end self-test passes**: `bash scripts/sanitize/test-check.sh` exits 0.
+2. **Gate currently fails on dirty tree** (expected, Plan 04 cleans it up): `bash scripts/sanitize/check.sh --grep-only` exits non-zero and prints `::error file=...` lines.
+3. **Allow-list is honored**: After (2), confirm that no hit reports a path under `.planning/`, `docs/architecture/`, `docs/journey/`, `.github/CODEOWNERS`, `AGENTS.md.template`, `README.md`, or `scripts/sanitize/banlist.txt` — the allow-list globs should have excluded them.
+4. **Workflow YAML is valid**: `python -c "import yaml; yaml.safe_load(open('.github/workflows/sanitize.yml'))"` exits 0.
+5. **No `paths:` filter**: `grep -E '^\s+paths:' .github/workflows/sanitize.yml` returns nothing.
+6. **Failure message contains the agent-self-correction hint**: `bash scripts/sanitize/check.sh --grep-only 2>&1 | grep -q '\.sanitize-allowlist'`.
+</verification>
+
+<success_criteria>
+- All 3 tasks complete with verify-block passing.
+- `scripts/sanitize/check.sh` is the single bash entry point; `--grep-only` works in this plan; `--units-only` is a placeholder for Plan 02.
+- `.sanitize-allowlist` covers .planning, docs/architecture, docs/journey, workforce plumbing (CODEOWNERS, AGENTS.md.template, README.md), and the gate's own data files.
+- `.github/workflows/sanitize.yml` runs on every PR with no `paths:` filter.
+- The gate's failure output includes inline GitHub annotations + the `.sanitize-allowlist` self-correction hint.
+- PR-size budget: estimated ~250 net lines (script ~120, allow-list ~30, banlist 6, test-check ~30, workflow ~30). Well under 400.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/02-sanitization-gate/02-01-SUMMARY.md` documenting:
+- What landed (script flags, allow-list initial entries, workflow job names)
+- Why workforce plumbing (CODEOWNERS, AGENTS.md.template, README.md) was allow-listed path-wide (per CONTEXT deferred-ideas rationale, this resolves RESEARCH Open Questions 1 & 2)
+- Verification snapshot: count of hits the gate reports on current main (the number Plan 04 needs to drive to zero)
+- Pointer to Plan 02 for the unit-name extension and Plan 03 for the dashboard gate
+</output>

--- a/.planning/phases/02-sanitization-gate/02-01-SUMMARY.md
+++ b/.planning/phases/02-sanitization-gate/02-01-SUMMARY.md
@@ -1,0 +1,69 @@
+---
+phase: 02-sanitization-gate
+plan: 01
+status: complete
+date: 2026-05-26
+---
+
+# Plan 02-01 Summary — Grep gate runner, allow-list, CI workflow skeleton
+
+## What landed
+
+### `scripts/sanitize/check.sh`
+- Flags: `--grep-only` (active; runs the banlist scan), `--units-only` (placeholder, exits 0 with a note — Plan 02 implements it), `--scan-dir DIR` (placeholder, exits 0 — reserved for Plan 06 image-build hook).
+- No-flag default: `--grep-only`. When Plan 02 lands, no-flag will run both gates.
+- Emits `::error file=PATH,line=LINE,col=COL,title=Banned identity literal::...` annotations for inline PR marks.
+- Each failure message includes `.sanitize-allowlist` so an agent can self-correct without a human round-trip.
+- Exit 0 on clean tree; exit 1 if any hits.
+- Uses `git ls-files -- :(exclude,glob)PATTERN...` pathspec engine for allow-list filtering — no extra dependency.
+
+### `scripts/sanitize/banlist.txt`
+Six case-insensitive fixed-string literals: `focal55`, `arlowe-1`, `casa_ybarra_chelsea`, `/home/focal55`, `joe@focal55`, `iol-monorepo`. No comments, no blank lines inside data (rg `-f` treats each line as a pattern).
+
+### `.sanitize-allowlist`
+Initial 24 entries. Globs are gitignore-style (`**` required for recursive — documented in header comment).
+
+### `scripts/sanitize/test-check.sh`
+Plants `user: focal55` in a `mktemp -d` git tree; asserts `check.sh --grep-only` exits non-zero; prints `PASS:` on success. The file is itself allow-listed so the literal doesn't trip the production gate.
+
+### `.github/workflows/sanitize.yml`
+Two jobs:
+- `banlist-and-units`: checkout → `rg --version` sanity → `bash scripts/sanitize/check.sh --grep-only`
+- `self-test`: checkout → `bash scripts/sanitize/test-check.sh`
+
+No `paths:` filter (required-check + path filter = pending-forever trap per RESEARCH §Pitfall 1). Workflow runs on every PR and push to `main`.
+
+## Why workforce plumbing is allow-listed path-wide
+
+`.github/CODEOWNERS`, `AGENTS.md.template`, `README.md`, and `docs/architecture-overview.md` reference `@focal55` and `github.com/focal55/...` for legitimate workforce-protocol purposes. None of these files ship in any firmware image. The risk SANIT exists to prevent is founder-identity strings in customer images, not in developer-facing repo files. This resolves RESEARCH Open Questions 1 and 2.
+
+The `.planning/**` wildcard covers all planning artifacts including `02-RESEARCH.md` and `02-CONTEXT.md`, which contain every banned literal as documentation by design.
+
+## Verification snapshot (current `main` before Plan 04)
+
+`bash scripts/sanitize/check.sh --grep-only` reports **25 hits** across **runtime/** files. These are the dirty-tree hits Plan 04 will drive to zero:
+
+- `runtime/dashboard/app/layout.tsx` — 1 hit
+- `runtime/dashboard/app/components/RetroActivityMonitor.tsx` — 1 hit
+- `runtime/dashboard/README.md` — 1 hit
+- `runtime/face/README.md` — 3 hits
+- `runtime/face/requirements.txt` — 3 hits
+- `runtime/llm/README.md` — 1 hit
+- `runtime/llm/requirements.txt` — 1 hit
+- `runtime/llm/router.py` — 1 hit
+- `runtime/llm/run_api.sh` — 1 hit
+- `runtime/stt/README.md` — 1 hit
+- `runtime/tts/manifest.yml` — 2 hits
+- `runtime/tts/README.md` — 4 hits
+- `runtime/voice/README.md` — 1 hit
+- `runtime/voice/requirements.txt` — 1 hit
+- `runtime/wake-word/README.md` — 1 hit
+- `runtime/wake-word/requirements.txt` — 1 hit
+
+No hits in allow-listed paths (`.planning/`, `docs/`, `README.md`, `scripts/sanitize/`, etc.).
+
+## Next steps
+
+- **Plan 02**: Implements `--units-only` (the unit-name block for `openclaw-*`, `trace-*`, `workforce-metrics-snapshot.*` systemd units) and extends `check.sh`.
+- **Plan 03**: Adds the Playwright dashboard rendered-text gate (`runtime/dashboard/tests/sanitize.spec.ts`) and a third job in `sanitize.yml`.
+- **Plan 04**: Sanitizes the current `runtime/` tree (25 hits above) to drive the gate green on `main`.

--- a/.planning/phases/02-sanitization-gate/02-02-PLAN.md
+++ b/.planning/phases/02-sanitization-gate/02-02-PLAN.md
@@ -1,0 +1,234 @@
+---
+phase: 02-sanitization-gate
+plan: 02
+type: execute
+wave: 2
+depends_on: [02-01]
+files_modified:
+  - scripts/sanitize/check.sh
+  - scripts/sanitize/unit-prefixes.txt
+  - scripts/sanitize/test-check.sh
+  - .github/workflows/sanitize.yml
+autonomous: true
+
+must_haves:
+  truths:
+    - "A PR adding a tracked systemd unit file whose basename matches `openclaw-*`, `trace-*`, or `workforce-metrics-snapshot.*` fails CI"
+    - "The unit-name block scans all six tracked systemd-unit extensions: *.service, *.timer, *.socket, *.target, *.mount, *.path"
+    - "The CI self-test job proves the unit-name block catches a planted unit file in a temp tree"
+    - "scripts/sanitize/check.sh supports a `--scan-dir DIR` flag that runs the unit-name block against `find DIR -name '*.service' ...` instead of `git ls-files` — this is the Phase 6 reuse hook against a mounted pi-gen rootfs"
+    - "Phase 6 can run `check.sh --units-only --scan-dir /mnt/img/etc/systemd/system` against an assembled image and get a clean pass/fail signal"
+  artifacts:
+    - path: "scripts/sanitize/unit-prefixes.txt"
+      provides: "The 3 banned unit prefixes, one per line, no comments inside the data"
+      contains: "openclaw-*"
+      min_lines: 3
+    - path: "scripts/sanitize/check.sh"
+      provides: "Updated runner — --units-only now implemented; --scan-dir DIR supported for both grep and units gates; no-flag invocation runs both gates back-to-back and aggregates exit codes"
+    - path: "scripts/sanitize/test-check.sh"
+      provides: "Extended self-test that ALSO plants a fake openclaw-test.service in a temp tree and asserts --units-only catches it"
+    - path: ".github/workflows/sanitize.yml"
+      provides: "Updated workflow — banlist-and-units job runs check.sh with no flag (both gates); self-test job exercises both planted-literal and planted-unit cases"
+  key_links:
+    - from: "scripts/sanitize/check.sh"
+      to: "scripts/sanitize/unit-prefixes.txt"
+      via: "reads prefixes from this file via while-loop"
+      pattern: "unit-prefixes"
+    - from: "scripts/sanitize/check.sh"
+      to: "git ls-files / find DIR"
+      via: "enumerates unit files; default uses git ls-files, --scan-dir DIR switches to find"
+      pattern: "(git ls-files|find )"
+    - from: ".github/workflows/sanitize.yml"
+      to: "scripts/sanitize/check.sh"
+      via: "banlist-and-units job invokes check.sh with no flag (runs both gates)"
+      pattern: "bash scripts/sanitize/check\\.sh"
+---
+
+<objective>
+Extend the sanitization runner from Plan 01 with the systemd-unit-name block: fail CI on any tracked unit file whose basename matches `openclaw-*`, `trace-*`, or `workforce-metrics-snapshot.*`.
+
+Purpose: Founder-only services (`openclaw-*`, `trace-*`, `workforce-metrics-snapshot.*`) phone home to founder infrastructure. The grep gate from Plan 01 catches string occurrences, but the unit-name block specifically catches the *files* that, if shipped, would cause a customer's device to reach founder endpoints. Per CONTEXT, this is the surveillance-vector gate, not just a label check.
+
+Phase 6 reuse: This plan adds a `--scan-dir DIR` flag so Phase 6's pi-gen pipeline can run the same gate against an assembled rootfs (`/mnt/img/etc/systemd/system/`) before finalizing the .img — closing the loop from "tracked-file check" to "shipped-image check" with a single script.
+
+Output: Updated `check.sh` with `--units-only` implemented and `--scan-dir DIR` supported, new `unit-prefixes.txt` data file, extended `test-check.sh` with a planted-unit case, and updated `sanitize.yml` workflow.
+</objective>
+
+<execution_context>
+@~/.claude/get-shit-done/workflows/execute-plan.md
+@~/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/phases/02-sanitization-gate/02-CONTEXT.md
+@.planning/phases/02-sanitization-gate/02-RESEARCH.md
+@.planning/phases/02-sanitization-gate/02-01-SUMMARY.md
+
+# Files this plan extends (created by Plan 01)
+@scripts/sanitize/check.sh
+@scripts/sanitize/test-check.sh
+@.github/workflows/sanitize.yml
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Create unit-prefixes data + implement --units-only and --scan-dir in check.sh</name>
+  <files>scripts/sanitize/unit-prefixes.txt, scripts/sanitize/check.sh</files>
+  <action>
+    **Create `scripts/sanitize/unit-prefixes.txt`** with the 3 banned unit prefixes from ROADMAP SC2, one per line, no comments inside the data:
+    ```
+    openclaw-*
+    trace-*
+    workforce-metrics-snapshot.*
+    ```
+    Each line is a bash glob pattern that will be tested against unit-file basenames via `[[ basename == $prefix ]]` (unquoted RHS triggers glob matching). The file is already in the `.sanitize-allowlist` (added pre-emptively in Plan 01) so it does not trip the grep gate.
+
+    **Extend `scripts/sanitize/check.sh`** with these changes:
+
+    1. **Parse `--scan-dir DIR` flag** (in addition to `--grep-only` and `--units-only` from Plan 01). Use a simple `while (( $# > 0 ))` loop. Store `SCAN_DIR` as a variable, default empty (meaning "use git ls-files"). Invalid combinations (e.g., `--grep-only --units-only`) should print an error and exit 2.
+
+    2. **Replace the Plan 01 placeholder `--units-only` stub** with the real implementation. Skeleton (based on RESEARCH §"Pattern 2"):
+       ```bash
+       run_units_gate() {
+         local units=()
+         if [[ -n "$SCAN_DIR" ]]; then
+           mapfile -t units < <(find "$SCAN_DIR" -type f \
+             \( -name '*.service' -o -name '*.timer' -o -name '*.socket' \
+                -o -name '*.target' -o -name '*.mount' -o -name '*.path' \))
+         else
+           mapfile -t units < <(git ls-files \
+             -- '*.service' '*.timer' '*.socket' '*.target' '*.mount' '*.path')
+         fi
+
+         local exit_code=0
+         while IFS= read -r prefix; do
+           prefix="${prefix%%#*}"
+           prefix="${prefix#"${prefix%%[![:space:]]*}"}"
+           prefix="${prefix%"${prefix##*[![:space:]]}"}"
+           [[ -z "$prefix" ]] && continue
+           for unit in "${units[@]+${units[@]}}"; do
+             local base
+             base="$(basename "$unit")"
+             # Unquoted RHS = glob match. The 3 banned prefixes ARE bash globs.
+             if [[ "$base" == $prefix ]]; then
+               printf '::error file=%s,line=1,title=Banned systemd unit::banned systemd unit name %s (matches pattern %s); founder-only service must not ship in firmware\n' \
+                 "$unit" "$base" "$prefix"
+               printf '%s: banned unit basename (matches %s)\n' "$unit" "$prefix" >&2
+               exit_code=1
+             fi
+           done
+         done < "$SCRIPT_DIR/unit-prefixes.txt"
+         return "$exit_code"
+       }
+       ```
+
+    3. **Extend `--scan-dir DIR` to also work for `--grep-only`** (for Phase 6 reuse symmetry). When `--scan-dir` is set, the grep gate enumerates files via `find SCAN_DIR -type f` instead of `git ls-files`. Allow-list handling: when `--scan-dir` is set, ignore `.sanitize-allowlist` (it's a tracked-files concept). Document this in the script's header comment so Phase 6 implementers know.
+
+    4. **No-flag invocation now runs both gates** (replaces Plan 01's grep-only default). Aggregate exit codes: if either gate fails, exit non-zero with the OR of both exit codes. Print a clear separator between gate outputs (e.g., `--- units gate ---`) so failures are easy to attribute.
+
+    5. **Header comment** at the top of `check.sh` (after the shebang, before `set -e`) documenting the four invocation modes:
+       ```
+       # Sanitization gate runner.
+       #
+       # Modes:
+       #   check.sh                          Run grep + units gates against tracked files (default for CI).
+       #   check.sh --grep-only              Run only the banned-literal grep gate.
+       #   check.sh --units-only             Run only the banned-unit-name gate.
+       #   check.sh --scan-dir DIR           Scan DIR via `find` instead of `git ls-files`.
+       #                                     Use case: Phase 6 image-build, scanning the assembled
+       #                                     rootfs at /mnt/img/ before pi-gen finalizes the .img.
+       #                                     NOTE: .sanitize-allowlist is ignored in --scan-dir mode.
+       #
+       # Exit codes: 0 clean, 1 hits found, 2 invalid arguments.
+       ```
+
+    Implementation notes:
+    - Keep the script under ~200 LOC.
+    - Reuse the `:`-split / GitHub-annotation pattern from Plan 01's grep gate for output consistency.
+    - The unit-prefixes.txt's `openclaw-*` is a literal bash glob — when assigned to `prefix` and the RHS of `[[ "$base" == $prefix ]]`, bash performs glob expansion. Confirm via interactive smoke test: `prefix='openclaw-*'; base='openclaw-runner.service'; [[ "$base" == $prefix ]] && echo match`.
+
+    DO NOT: scan unit-file *contents* (RESEARCH §Pitfall — "Banned unit-content scanning" is covered by the grep gate). DO NOT match against full paths (basename match is what CONTEXT specifies). DO NOT add per-prefix override files (CONTEXT defers per-literal precision).
+  </action>
+  <verify>
+    `cat scripts/sanitize/unit-prefixes.txt | wc -l` returns 3.
+    `bash -n scripts/sanitize/check.sh` parses cleanly.
+    `bash scripts/sanitize/check.sh --invalid-flag` exits 2.
+    From repo root, plant a fake unit and confirm catch:
+    ```
+    TMP=$(mktemp -d) && touch "$TMP/openclaw-fake.service"
+    bash scripts/sanitize/check.sh --units-only --scan-dir "$TMP"
+    # Expected: exit 1, prints `::error file=.../openclaw-fake.service,...banned systemd unit...`
+    rm -rf "$TMP"
+    ```
+    Run unit gate against real repo: `bash scripts/sanitize/check.sh --units-only` exits 0 (no tracked units currently match — `.dev-stash/` is gitignored).
+  </verify>
+  <done>
+    unit-prefixes.txt exists with the 3 prefixes. check.sh's `--units-only` is real (not a stub), `--scan-dir DIR` works for both grep and units gates, no-flag invocation runs both, invalid args exit 2, header comment documents all four modes including the Phase 6 reuse contract.
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Extend self-test with planted-unit case and update CI workflow</name>
+  <files>scripts/sanitize/test-check.sh, .github/workflows/sanitize.yml</files>
+  <action>
+    **Extend `scripts/sanitize/test-check.sh`** to add a second test scenario alongside the Plan 01 planted-literal test:
+
+    Add a function-style structure or just two sequential blocks. The second block:
+    - `TMP2=$(mktemp -d)`; `trap "rm -rf $TMP $TMP2" EXIT`.
+    - `touch "$TMP2/openclaw-test.service"` and `touch "$TMP2/safe-unit.service"` (to confirm the gate distinguishes banned-prefix from clean unit).
+    - Run `bash $REPO_ROOT/scripts/sanitize/check.sh --units-only --scan-dir "$TMP2"` and capture exit code.
+    - Assert exit code is non-zero AND that the printed output mentions `openclaw-test.service` but NOT `safe-unit.service`. Capture stdout+stderr to a temp file and `grep -q openclaw-test.service` / `! grep -q safe-unit.service`.
+    - On success: `PASS: gate correctly blocked planted openclaw-test.service while allowing safe-unit.service`.
+
+    Also add a third quick scenario: `--scan-dir` honors the grep gate. Plant a `focal55` literal in TMP2, run `--grep-only --scan-dir "$TMP2"`, assert exit non-zero. This proves the Phase 6 reuse contract for the grep gate too.
+
+    Total expected test-check.sh length: ~60 LOC. Keep test failures loud (clear `FAIL: ...` to stderr + exit 1).
+
+    **Update `.github/workflows/sanitize.yml`**:
+    - Modify the `banlist-and-units` job: replace `bash scripts/sanitize/check.sh --grep-only` with `bash scripts/sanitize/check.sh` (no flag — runs both gates now that Plan 02 implements units). This is the change that makes the workflow exercise the unit-name block on every PR.
+    - The `self-test` job already runs `bash scripts/sanitize/test-check.sh` — no change needed; the test script's expanded scenarios run automatically.
+    - Update the workflow's top comment to reflect that this is the Phase 2 / Plan 02 state (two real gates, dashboard gate added by Plan 03).
+
+    Naming: keep the job names from Plan 01 (`banlist-and-units`, `self-test`) — they were forward-named correctly.
+  </action>
+  <verify>
+    `bash -n scripts/sanitize/test-check.sh` parses cleanly.
+    `bash scripts/sanitize/test-check.sh` exits 0 and prints all three `PASS:` lines (planted-literal, planted-openclaw-unit, --scan-dir grep gate).
+    `grep -F 'scripts/sanitize/check.sh' .github/workflows/sanitize.yml | grep -vE 'check\.sh (--grep-only|--units-only)' | grep -F 'check.sh'` matches the bare `bash scripts/sanitize/check.sh` line in the banlist-and-units job.
+    `python -c "import yaml; yaml.safe_load(open('.github/workflows/sanitize.yml'))"` exits 0.
+  </verify>
+  <done>
+    test-check.sh proves three scenarios (planted literal, planted openclaw unit, --scan-dir grep reuse). sanitize.yml invokes check.sh with no flag so both gates run on every PR. Workflow YAML is valid.
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+**Plan-level verification:**
+
+1. **Both gates run in CI**: `grep -F 'bash scripts/sanitize/check.sh' .github/workflows/sanitize.yml` shows the no-flag invocation in the banlist-and-units job.
+2. **Self-test passes end-to-end**: `bash scripts/sanitize/test-check.sh` exits 0 with three `PASS:` lines.
+3. **Phase 6 reuse contract works**: Plant a `focal55` and an `openclaw-x.service` in a temp dir, run `bash scripts/sanitize/check.sh --scan-dir TMP` — exits non-zero with both kinds of annotations.
+4. **No regressions on Plan 01 behavior**: `bash scripts/sanitize/check.sh --grep-only` still exits non-zero on the current dirty tree (Plan 04 cleans that).
+5. **Units gate is clean on current main**: `bash scripts/sanitize/check.sh --units-only` exits 0 (no tracked units currently match — `.dev-stash/` is gitignored so the founder-only units there don't appear).
+</verification>
+
+<success_criteria>
+- All 2 tasks complete with verify-block passing.
+- `scripts/sanitize/check.sh` supports `--grep-only`, `--units-only`, `--scan-dir DIR`, and no-flag (runs both).
+- `scripts/sanitize/unit-prefixes.txt` exists with the 3 banned prefixes.
+- `scripts/sanitize/test-check.sh` proves planted-literal, planted-unit, and --scan-dir scenarios.
+- `.github/workflows/sanitize.yml` runs both gates on every PR.
+- Phase 6 reuse contract is documented in check.sh's header comment.
+- PR-size budget: estimated ~150 net lines (script delta ~80, unit-prefixes.txt 3, test-check.sh delta ~35, workflow delta ~5). Well under 400.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/02-sanitization-gate/02-02-SUMMARY.md` documenting:
+- The four invocation modes of check.sh (mode → use case mapping)
+- Confirmation that current main has zero unit-name-block hits (founder-only units live in gitignored `.dev-stash/`)
+- The Phase 6 reuse contract: `check.sh --scan-dir /mnt/img/etc/systemd/system` for pre-finalize image-build verification
+- Pointer to Plan 03 (dashboard gate) and Plan 04 (SC4 runtime/ cleanup)
+</output>

--- a/.planning/phases/02-sanitization-gate/02-03-PLAN.md
+++ b/.planning/phases/02-sanitization-gate/02-03-PLAN.md
@@ -123,7 +123,7 @@ Why this plan is independent of Plan 02: the unit-name block (Plan 02) and the r
     DO NOT: change route discovery to read `.next/server/app-paths-manifest.json` (RESEARCH alternative considered + rejected — manifest is post-build and adds coupling). DO NOT use `page.textContent('body')` instead of `page.content()` (CONTEXT explicitly picks `page.content()` to catch <meta> and alt-attribute literals). DO NOT use snapshot files (`toMatchSnapshot`) — RESEARCH §"State of the Art" — snapshots are for positive assertions, not negative "must not contain X". DO NOT mock `/api/*` routes — CONTEXT picks "unconfigured backend, error states valid".
   </action>
   <verify>
-    `cd runtime/dashboard && pnpm exec tsc --noEmit tests/sanitize.spec.ts` exits 0 (TypeScript parses cleanly).
+    `cd runtime/dashboard && pnpm exec tsc --noEmit` exits 0 (TypeScript parses cleanly under the project's tsconfig.json — its jsx, lib, moduleResolution, and paths settings only apply when tsc runs with no file argument; passing a file path causes tsc to ignore tsconfig.json and resolve node:fs / @playwright/test against bare-default settings).
     `cd runtime/dashboard && pnpm exec playwright test tests/sanitize.spec.ts --list` shows multiple tests, one per discovered route. Confirm at least: `route / contains no banned literal`, `route /connectivity contains no banned literal`, `route /logs contains no banned literal`, `route /npu contains no banned literal`.
     `grep -c 'pnpm build' runtime/dashboard/playwright.config.ts` returns at least 1.
     `grep -c 'timeout: 180000' runtime/dashboard/playwright.config.ts` returns 1.

--- a/.planning/phases/02-sanitization-gate/02-03-PLAN.md
+++ b/.planning/phases/02-sanitization-gate/02-03-PLAN.md
@@ -1,0 +1,216 @@
+---
+phase: 02-sanitization-gate
+plan: 03
+type: execute
+wave: 2
+depends_on: [02-01]
+files_modified:
+  - runtime/dashboard/tests/sanitize.spec.ts
+  - runtime/dashboard/playwright.config.ts
+  - .github/workflows/sanitize.yml
+autonomous: true
+
+must_haves:
+  truths:
+    - "A PR that introduces a banned identity literal into rendered dashboard HTML (visible text, <title>, <meta description>, alt attributes) fails the new sanitize.spec.ts Playwright test"
+    - "The spec auto-discovers all dashboard routes by walking runtime/dashboard/app/ for page.tsx files (skipping api/, leading _, treating (group) as transparent)"
+    - "The spec calls page.content() (not page.textContent) so it catches literals in <meta> tags and other non-text HTML elements"
+    - "Each route is scanned against all 6 banlist literals case-insensitively"
+    - "The CI workflow builds the dashboard before booting Playwright's webServer (no `Could not find a production build` flake)"
+    - "The spec only runs in the chromium project to keep CI install time short — other Playwright suites still run multi-browser"
+  artifacts:
+    - path: "runtime/dashboard/tests/sanitize.spec.ts"
+      provides: "Playwright spec that boots the dashboard, visits every auto-discovered page route, and asserts no banlist literal appears in page.content()"
+      min_lines: 60
+      contains: "page.content()"
+    - path: "runtime/dashboard/playwright.config.ts"
+      provides: "Updated webServer command runs `pnpm build && pnpm start -p 3000` and timeout bumped to 180000 to accommodate build time"
+      contains: "pnpm build"
+    - path: ".github/workflows/sanitize.yml"
+      provides: "New dashboard-rendered-text job that installs pnpm + node, runs pnpm install, installs chromium, builds dashboard, runs only the sanitize spec on chromium"
+      contains: "playwright"
+  key_links:
+    - from: "runtime/dashboard/tests/sanitize.spec.ts"
+      to: "runtime/dashboard/app/"
+      via: "fs.readdirSync walks the directory tree at test-collection time to enumerate page.tsx routes"
+      pattern: "readdirSync"
+    - from: ".github/workflows/sanitize.yml dashboard-rendered-text job"
+      to: "runtime/dashboard/tests/sanitize.spec.ts"
+      via: "pnpm exec playwright test sanitize.spec.ts --project=chromium"
+      pattern: "playwright test sanitize"
+    - from: "runtime/dashboard/playwright.config.ts webServer"
+      to: "pnpm build"
+      via: "Required because `pnpm start` (next start) needs .next/ artifacts to exist"
+      pattern: "pnpm build"
+---
+
+<objective>
+Add the third sanitization gate: a Playwright spec that boots the dashboard, visits every page route, and asserts none of the 6 banned identity literals appear in the rendered HTML.
+
+Purpose: The grep gate from Plan 01 catches source-code occurrences. But a literal can be *interpolated* into output (e.g., a hostname assembled at runtime from a config default) — the source might be clean while the rendered page leaks. This gate catches that class of regression by scanning what the browser actually sees.
+
+Output: A new `sanitize.spec.ts` that auto-discovers routes from the app/ filesystem layout, a `playwright.config.ts` update to add `pnpm build` to the webServer command (RESEARCH §Pitfall 3), and a new `dashboard-rendered-text` job in `sanitize.yml`.
+
+Why this plan is independent of Plan 02: the unit-name block (Plan 02) and the rendered-HTML scan (this plan) touch different files and different CI jobs. Both depend only on Plan 01's allow-list and workflow skeleton. They can be developed in parallel by separate DEV agents, though Plan 02's `check.sh` edits and this plan's `playwright.config.ts` edits do not overlap.
+</objective>
+
+<execution_context>
+@~/.claude/get-shit-done/workflows/execute-plan.md
+@~/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/phases/02-sanitization-gate/02-CONTEXT.md
+@.planning/phases/02-sanitization-gate/02-RESEARCH.md
+@.planning/phases/02-sanitization-gate/02-01-SUMMARY.md
+
+# Files this plan extends
+@runtime/dashboard/playwright.config.ts
+@.github/workflows/sanitize.yml
+
+# Existing Playwright specs for stylistic consistency
+@runtime/dashboard/tests/navigation.spec.ts
+@runtime/dashboard/tests/example.spec.ts
+
+# Dashboard app structure (route enumeration target)
+@runtime/dashboard/app/layout.tsx
+@runtime/dashboard/app/page.tsx
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Implement sanitize.spec.ts with route auto-discovery and update playwright.config.ts</name>
+  <files>runtime/dashboard/tests/sanitize.spec.ts, runtime/dashboard/playwright.config.ts</files>
+  <action>
+    **Create `runtime/dashboard/tests/sanitize.spec.ts`** based on RESEARCH §"Pattern 3" with these specifics:
+
+    Route discovery function `enumerateRoutes(appDir: string): string[]`:
+    - Walk `appDir` recursively with `fs.readdirSync` and `fs.statSync`.
+    - For each directory containing a `page.tsx`, record the route.
+    - Skip: directories named `api` (no rendered HTML), directories starting with `_` (Next App Router private folders), files (only directories matter).
+    - Route groups: directories whose name matches `^\(.+\)$` (parens-wrapped) do NOT contribute to the URL — pass through.
+    - Dynamic segments: directories whose name matches `^\[.+\]$` (bracket-wrapped). For sanitize purposes, replace the segment with a synthetic placeholder like `test` so the route is visitable. Document this in a comment. Note: at the time of this plan, the dashboard has no dynamic segments — but include the handling so the spec doesn't silently skip a future `[id]/page.tsx`.
+    - Root: if `appDir/page.tsx` exists, the route `/` is included.
+    - Return a deduplicated array.
+
+    Banlist constant: hardcoded array of the 6 literals (same list as `scripts/sanitize/banlist.txt`). Hardcoding is intentional — this spec is a TypeScript test, not a config file; keeping the literals visible in the test code makes the assertion message readable when a CI failure happens. Add a comment pointing to `scripts/sanitize/banlist.txt` as the canonical source and noting that any addition to one MUST be mirrored to the other (until a future refactor unifies them).
+
+    Test shape: use `test.describe('sanitization: no founder literals in rendered HTML', ...)` with a per-route `test(\`route ${route} contains no banned literal\`, async ({ page }) => { ... })`:
+    - `await page.goto(route, { waitUntil: 'load' });`
+    - `await page.waitForTimeout(1500);` — per RESEARCH §Pitfall 5, `networkidle` is flaky against an unconfigured backend. CONTEXT says error states are valid render targets; a short wait lets useEffect-driven fetches resolve (even with errors) so second-render content is included.
+    - `const html = (await page.content()).toLowerCase();`
+    - Loop: `for (const literal of BANLIST) { expect(html.includes(literal.toLowerCase()), \`route ${route} rendered HTML contains banned literal "${literal}" — search /api response shapes and config defaults\`).toBe(false); }`
+
+    Implementation notes:
+    - `__dirname` for the spec resolves to `runtime/dashboard/tests/`; the app dir is `path.join(__dirname, '..', 'app')`.
+    - Confirm by `console.log` (during local dev only — remove before commit) that `enumerateRoutes` returns at least `/`, `/connectivity`, `/logs`, `/npu` (these match the current `app/` layout per the `ls` snapshot).
+    - Spec file length target: 60-80 LOC.
+
+    **Update `runtime/dashboard/playwright.config.ts`** per RESEARCH §Pitfall 3:
+    - Change `webServer.command` from `'pnpm start -p 3000'` to `'pnpm build && pnpm start -p 3000'`.
+    - Bump `webServer.timeout` from `120000` to `180000` (build adds ~30-60s).
+    - DO NOT touch other config (projects, retries, workers, reporter) — those are stable per Phase 1 plan 11.
+    - Add a comment above the webServer block explaining why `pnpm build` is needed (`next start` requires .next/ artifacts).
+
+    DO NOT: change route discovery to read `.next/server/app-paths-manifest.json` (RESEARCH alternative considered + rejected — manifest is post-build and adds coupling). DO NOT use `page.textContent('body')` instead of `page.content()` (CONTEXT explicitly picks `page.content()` to catch <meta> and alt-attribute literals). DO NOT use snapshot files (`toMatchSnapshot`) — RESEARCH §"State of the Art" — snapshots are for positive assertions, not negative "must not contain X". DO NOT mock `/api/*` routes — CONTEXT picks "unconfigured backend, error states valid".
+  </action>
+  <verify>
+    `pnpm --filter dashboard exec tsc --noEmit tests/sanitize.spec.ts` exits 0 (TypeScript parses cleanly).
+    `pnpm --filter dashboard exec playwright test tests/sanitize.spec.ts --list` shows multiple tests, one per discovered route. Confirm at least: `route / contains no banned literal`, `route /connectivity contains no banned literal`, `route /logs contains no banned literal`, `route /npu contains no banned literal`.
+    `grep -c 'pnpm build' runtime/dashboard/playwright.config.ts` returns at least 1.
+    `grep -c 'timeout: 180000' runtime/dashboard/playwright.config.ts` returns 1.
+    `grep -F 'page.content()' runtime/dashboard/tests/sanitize.spec.ts` matches.
+    Run the spec locally if dashboard builds: `cd runtime/dashboard && pnpm install && pnpm exec playwright install chromium && pnpm exec playwright test sanitize.spec.ts --project=chromium` — expect FAIL on `/` and other routes because `runtime/dashboard/app/layout.tsx:11` and `RetroActivityMonitor.tsx:140` still contain `Arlowe-1`. The expected failure is itself the proof that the gate works; Plan 04 cleans these up.
+  </verify>
+  <done>
+    sanitize.spec.ts exists, parses with `tsc --noEmit`, auto-discovers all current routes, runs against the live dashboard, and FAILS on the current dirty tree (the layout.tsx `Arlowe-1` description leaks into <meta> and the RetroActivityMonitor header shows `ARLOWE-1 SYSTEM MONITOR`). playwright.config.ts webServer command is updated to include `pnpm build` and timeout is 180000.
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Add dashboard-rendered-text job to sanitize.yml workflow</name>
+  <files>.github/workflows/sanitize.yml</files>
+  <action>
+    Add a third job `dashboard-rendered-text` to `.github/workflows/sanitize.yml`. Per RESEARCH §"Pattern 4" with the chromium-only optimization from RESEARCH Open Question 5:
+
+    ```yaml
+      dashboard-rendered-text:
+        name: Dashboard rendered-text gate
+        runs-on: ubuntu-latest
+        defaults:
+          run:
+            working-directory: runtime/dashboard
+        steps:
+          - uses: actions/checkout@v4
+          - uses: pnpm/action-setup@v4
+            with:
+              version: 9
+          - uses: actions/setup-node@v4
+            with:
+              node-version: '20'
+              cache: 'pnpm'
+              cache-dependency-path: runtime/dashboard/pnpm-lock.yaml
+          - name: Install dependencies
+            run: pnpm install --frozen-lockfile
+          - name: Install Playwright chromium
+            run: pnpm exec playwright install --with-deps chromium
+          - name: Build dashboard
+            run: pnpm build
+          - name: Run sanitize spec
+            run: pnpm exec playwright test tests/sanitize.spec.ts --project=chromium
+            env:
+              CI: 'true'
+    ```
+
+    Notes:
+    - The `pnpm build` step here is explicit even though `playwright.config.ts` was updated in Task 1 to include `pnpm build` in the webServer command. Belt-and-suspenders: explicit build step gives a clear CI step boundary so a build failure shows up as "Build dashboard" failing instead of being buried in webServer-timeout logs. The `pnpm start` in webServer is a no-op build if `.next/` already exists.
+    - `--project=chromium` keeps the install + test cycle to one browser. Other Playwright suites (navigation, connectivity) continue to run multi-browser in their own workflows if/when those exist.
+    - `cache-dependency-path` points at the dashboard's pnpm-lock; the repo root has no pnpm-lock.
+    - `CI: 'true'` env var is what Playwright keys off for `forbidOnly`, `retries: 2`, and `reuseExistingServer: !process.env.CI`.
+
+    Update the workflow's top comment to reflect three jobs now: banlist-and-units, self-test, dashboard-rendered-text.
+
+    Naming: dashboard-rendered-text (hyphenated, consistent with existing job names).
+  </action>
+  <verify>
+    `python -c "import yaml; d = yaml.safe_load(open('.github/workflows/sanitize.yml')); jobs = d['jobs']; assert 'dashboard-rendered-text' in jobs, jobs; assert len(jobs) == 3, jobs; print('OK', list(jobs.keys()))"` prints `OK ['banlist-and-units', 'self-test', 'dashboard-rendered-text']`.
+    `grep -c 'pnpm exec playwright' .github/workflows/sanitize.yml` returns 2 (install + test).
+    `grep -c '\-\-project=chromium' .github/workflows/sanitize.yml` returns 1.
+    `grep -F 'cache-dependency-path: runtime/dashboard/pnpm-lock.yaml' .github/workflows/sanitize.yml` matches.
+    `grep -E '^\s+paths:' .github/workflows/sanitize.yml` returns nothing (still no paths filter on the workflow `on:` triggers).
+  </verify>
+  <done>
+    sanitize.yml has three jobs (banlist-and-units, self-test, dashboard-rendered-text). The dashboard job builds the dashboard, installs only chromium, and runs only the sanitize spec. YAML is valid. No paths filter on workflow triggers.
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+**Plan-level verification:**
+
+1. **Spec parses + auto-discovers**: `cd runtime/dashboard && pnpm exec playwright test sanitize.spec.ts --list` lists tests for every page route under `app/`.
+2. **Spec fails on dirty tree (expected)**: `cd runtime/dashboard && pnpm install && pnpm exec playwright install chromium && pnpm exec playwright test sanitize.spec.ts --project=chromium` reports failures on `/` and routes whose pages share the layout's `<meta description="Control panel for Arlowe-1">`. Failure messages name the offending literal. Plan 04 will fix the sources.
+3. **Workflow YAML is valid + has three jobs**: per Task 2 verify.
+4. **No required-check trap**: still no `paths:` filter on `on:` (Plan 01's design preserved).
+5. **Build step is present**: `grep -c 'pnpm build' .github/workflows/sanitize.yml` returns at least 1.
+</verification>
+
+<success_criteria>
+- All 2 tasks complete with verify-block passing.
+- `runtime/dashboard/tests/sanitize.spec.ts` exists, auto-discovers routes, uses `page.content()` not `textContent`.
+- `runtime/dashboard/playwright.config.ts` webServer command runs `pnpm build && pnpm start -p 3000` with timeout 180000.
+- `.github/workflows/sanitize.yml` has a third job `dashboard-rendered-text` that builds the dashboard and runs only the sanitize spec on chromium.
+- Spec correctly FAILS on current main (proving it works) — Plan 04 will drive it to green.
+- PR-size budget: estimated ~180 net lines (spec ~80, config delta ~5, workflow delta ~25 + comment refresh). Well under 400.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/02-sanitization-gate/02-03-SUMMARY.md` documenting:
+- Route enumeration approach (filesystem walk, what's skipped, dynamic-segment placeholder)
+- The `page.content()` vs `textContent()` choice (catches <meta>, <title>, alt attrs — per CONTEXT)
+- The `waitUntil: 'load'` + `waitForTimeout(1500)` choice over `networkidle` (per RESEARCH Pitfall 5)
+- Confirmation that the spec currently FAILS as expected (with the specific routes/literals that trip it) — this is the baseline Plan 04 closes
+- Pointer to Plan 04 for the runtime/ tree SC4 cleanup
+</output>

--- a/.planning/phases/02-sanitization-gate/02-03-PLAN.md
+++ b/.planning/phases/02-sanitization-gate/02-03-PLAN.md
@@ -85,6 +85,13 @@ Why this plan is independent of Plan 02: the unit-name block (Plan 02) and the r
   <action>
     **Create `runtime/dashboard/tests/sanitize.spec.ts`** based on RESEARCH §"Pattern 3" with these specifics:
 
+    Spec imports (top of file — required so `tsc --noEmit` parses cleanly):
+    ```typescript
+    import { test, expect } from "@playwright/test";
+    import fs from "node:fs";
+    import path from "node:path";
+    ```
+
     Route discovery function `enumerateRoutes(appDir: string): string[]`:
     - Walk `appDir` recursively with `fs.readdirSync` and `fs.statSync`.
     - For each directory containing a `page.tsx`, record the route.
@@ -116,15 +123,17 @@ Why this plan is independent of Plan 02: the unit-name block (Plan 02) and the r
     DO NOT: change route discovery to read `.next/server/app-paths-manifest.json` (RESEARCH alternative considered + rejected — manifest is post-build and adds coupling). DO NOT use `page.textContent('body')` instead of `page.content()` (CONTEXT explicitly picks `page.content()` to catch <meta> and alt-attribute literals). DO NOT use snapshot files (`toMatchSnapshot`) — RESEARCH §"State of the Art" — snapshots are for positive assertions, not negative "must not contain X". DO NOT mock `/api/*` routes — CONTEXT picks "unconfigured backend, error states valid".
   </action>
   <verify>
-    `pnpm --filter dashboard exec tsc --noEmit tests/sanitize.spec.ts` exits 0 (TypeScript parses cleanly).
-    `pnpm --filter dashboard exec playwright test tests/sanitize.spec.ts --list` shows multiple tests, one per discovered route. Confirm at least: `route / contains no banned literal`, `route /connectivity contains no banned literal`, `route /logs contains no banned literal`, `route /npu contains no banned literal`.
+    `cd runtime/dashboard && pnpm exec tsc --noEmit tests/sanitize.spec.ts` exits 0 (TypeScript parses cleanly).
+    `cd runtime/dashboard && pnpm exec playwright test tests/sanitize.spec.ts --list` shows multiple tests, one per discovered route. Confirm at least: `route / contains no banned literal`, `route /connectivity contains no banned literal`, `route /logs contains no banned literal`, `route /npu contains no banned literal`.
     `grep -c 'pnpm build' runtime/dashboard/playwright.config.ts` returns at least 1.
     `grep -c 'timeout: 180000' runtime/dashboard/playwright.config.ts` returns 1.
     `grep -F 'page.content()' runtime/dashboard/tests/sanitize.spec.ts` matches.
     Run the spec locally if dashboard builds: `cd runtime/dashboard && pnpm install && pnpm exec playwright install chromium && pnpm exec playwright test sanitize.spec.ts --project=chromium` — expect FAIL on `/` and other routes because `runtime/dashboard/app/layout.tsx:11` and `RetroActivityMonitor.tsx:140` still contain `Arlowe-1`. The expected failure is itself the proof that the gate works; Plan 04 cleans these up.
+
+    Note on verify command shape: there is no pnpm workspace at the repo root (`runtime/dashboard/pnpm-workspace.yaml` is a v9 `ignoredBuiltDependencies` config, not a `packages:` workspace; the package name is `arlowe-dashboard`, not `dashboard`). All Playwright/tsc invocations therefore run from `runtime/dashboard` via `cd && pnpm exec ...` rather than `pnpm --filter <name> exec ...`. The CI workflow (Task 2) uses `defaults.run.working-directory: runtime/dashboard`, which is the equivalent in GitHub Actions.
   </verify>
   <done>
-    sanitize.spec.ts exists, parses with `tsc --noEmit`, auto-discovers all current routes, runs against the live dashboard, and FAILS on the current dirty tree (the layout.tsx `Arlowe-1` description leaks into <meta> and the RetroActivityMonitor header shows `ARLOWE-1 SYSTEM MONITOR`). playwright.config.ts webServer command is updated to include `pnpm build` and timeout is 180000.
+    sanitize.spec.ts exists, has the three required imports (test/expect from @playwright/test, fs, path), parses with `tsc --noEmit`, auto-discovers all current routes, runs against the live dashboard, and FAILS on the current dirty tree (the layout.tsx `Arlowe-1` description leaks into <meta> and the RetroActivityMonitor header shows `ARLOWE-1 SYSTEM MONITOR`). playwright.config.ts webServer command is updated to include `pnpm build` and timeout is 180000.
   </done>
 </task>
 
@@ -204,6 +213,12 @@ Why this plan is independent of Plan 02: the unit-name block (Plan 02) and the r
 - `.github/workflows/sanitize.yml` has a third job `dashboard-rendered-text` that builds the dashboard and runs only the sanitize spec on chromium.
 - Spec correctly FAILS on current main (proving it works) — Plan 04 will drive it to green.
 - PR-size budget: estimated ~180 net lines (spec ~80, config delta ~5, workflow delta ~25 + comment refresh). Well under 400.
+
+**DASH-06 coverage note (partial — documented per CONTEXT.md deferred decision):**
+
+DASH-06 ("no founder/workforce-internal endpoint links in rendered HTML") is covered *transitively* by `page.content()` for any href whose URL string contains one of the 6 banlist literals (e.g., a link to `https://focal55.local/admin` trips the gate because the substring `focal55` appears in the rendered HTML). It is NOT covered for arbitrary workforce-internal hrefs that don't contain a banned literal (e.g., `https://workforce-internal.local/dashboard` would slip past).
+
+Per CONTEXT.md deferred-ideas decision: enumerating and blocking all workforce-internal URL prefixes is out of scope for Phase 2. Defense-in-depth for that class of leak relies on PR review until a future phase introduces an explicit href allow-list. This is a known, deliberate gap — not an oversight.
 </success_criteria>
 
 <output>
@@ -212,5 +227,6 @@ After completion, create `.planning/phases/02-sanitization-gate/02-03-SUMMARY.md
 - The `page.content()` vs `textContent()` choice (catches <meta>, <title>, alt attrs — per CONTEXT)
 - The `waitUntil: 'load'` + `waitForTimeout(1500)` choice over `networkidle` (per RESEARCH Pitfall 5)
 - Confirmation that the spec currently FAILS as expected (with the specific routes/literals that trip it) — this is the baseline Plan 04 closes
+- DASH-06 partial-coverage note: covered for hrefs containing banlist literals; arbitrary workforce-internal hrefs deferred per CONTEXT
 - Pointer to Plan 04 for the runtime/ tree SC4 cleanup
 </output>

--- a/.planning/phases/02-sanitization-gate/02-04-PLAN.md
+++ b/.planning/phases/02-sanitization-gate/02-04-PLAN.md
@@ -206,11 +206,11 @@ Disposition matrix (research-grounded; full audit in 02-RESEARCH.md):
     - `runtime/face/README.md` (3 hits: lines 37, 43, 59)
     - `runtime/llm/README.md` (1 hit: line 52)
     - `runtime/stt/README.md` (1 hit: line 39)
-    - `runtime/tts/README.md` (6 hits: lines 64, 68, 76, 79, 99, plus check for any others)
+    - `runtime/tts/README.md` (5 hits: lines 64, 68, 76, 79, 99)
     - `runtime/voice/README.md` (1 hit: line 23)
     - `runtime/wake-word/README.md` (1 hit: line 93)
 
-    Total: 7 README files, ~14 lines edited (some hits will collapse — e.g., tts/README.md may have a single rewrite that cleans up two adjacent mentions).
+    Total: 7 README files, ~13 lines edited (some hits will collapse — e.g., tts/README.md may have a single rewrite that cleans up two adjacent mentions).
 
     DO NOT touch `runtime/*/requirements.txt` files (allow-listed in Task 1). DO NOT touch `runtime/tts/manifest.yml` (allow-listed in Task 1). DO NOT rewrite README content beyond what's needed to remove banned literals — this is a sanitization sweep, not a content overhaul.
   </action>

--- a/.planning/phases/02-sanitization-gate/02-04-PLAN.md
+++ b/.planning/phases/02-sanitization-gate/02-04-PLAN.md
@@ -1,0 +1,327 @@
+---
+phase: 02-sanitization-gate
+plan: 04
+type: execute
+wave: 3
+depends_on: [02-01, 02-02, 02-03]
+files_modified:
+  - runtime/llm/router.py
+  - runtime/llm/run_api.sh
+  - runtime/llm/README.md
+  - runtime/dashboard/README.md
+  - runtime/dashboard/app/layout.tsx
+  - runtime/dashboard/app/components/RetroActivityMonitor.tsx
+  - runtime/face/README.md
+  - runtime/stt/README.md
+  - runtime/tts/README.md
+  - runtime/voice/README.md
+  - runtime/wake-word/README.md
+  - .sanitize-allowlist
+  - docs/architecture/0001-iol-router-extraction.md
+  - .planning/todos/done/F5-adr-0001-why-option-2-internal-contradiction.md
+autonomous: true
+
+must_haves:
+  truths:
+    - "All three sanitize gates from Plans 01, 02, 03 pass green on main: grep gate exits 0, unit-name block exits 0, dashboard rendered-text spec passes for every route"
+    - "ROADMAP SC4 is satisfied: the current runtime/ tree has zero references to founder hostname, account, SSID, email, home path, or monorepo path (outside the documented allow-list)"
+    - "runtime/dashboard pages render without any of the 6 banned literals in their HTML — specifically, <meta name=\"description\"> no longer says \"Arlowe-1\" and the activity monitor header no longer says \"ARLOWE-1 SYSTEM MONITOR\""
+    - "runtime/ code comments and shell scripts no longer reference /home/focal55 or arlowe-1 directly; comments use generic descriptors"
+    - "runtime/ requirements.txt pinning provenance comments are explicitly allow-listed (decision documented in plan SUMMARY) — they are dev-host audit trails, never ship as user-facing strings"
+    - "F5 todo (ADR-0001 internal contradiction) is resolved and moved to .planning/todos/done/"
+  artifacts:
+    - path: "runtime/llm/router.py"
+      provides: "Code comment on line 35 no longer references /home/focal55 path; uses generic phrasing"
+    - path: "runtime/dashboard/app/layout.tsx"
+      provides: "<meta name=\"description\"> uses generic copy (e.g., \"Control panel for your Arlowe device\")"
+    - path: "runtime/dashboard/app/components/RetroActivityMonitor.tsx"
+      provides: "Header text no longer hardcodes \"ARLOWE-1\"; uses config-derived or generic copy"
+    - path: "runtime/{voice,face,stt,tts,llm,dashboard,wake-word}/README.md"
+      provides: "Generic dev-host phrasing throughout (no `arlowe-1` references); operator instructions remain useful"
+    - path: ".sanitize-allowlist"
+      provides: "Updated to explicitly allow-list runtime/*/requirements.txt and runtime/tts/manifest.yml with inline comments explaining the dev-pinning-provenance rationale"
+    - path: "docs/architecture/0001-iol-router-extraction.md"
+      provides: "F5 fix — Why option-2 rationale rewritten to match the resolved decision"
+    - path: ".planning/todos/done/F5-adr-0001-why-option-2-internal-contradiction.md"
+      provides: "F5 todo moved from pending/ to done/ with a closure note appended"
+  key_links:
+    - from: ".github/workflows/sanitize.yml"
+      to: "main branch HEAD"
+      via: "all three jobs (banlist-and-units, self-test, dashboard-rendered-text) pass on the merged commit"
+      pattern: "(exit 0|All checks pass)"
+    - from: "runtime/dashboard/app/layout.tsx"
+      to: "rendered <meta description>"
+      via: "Next.js App Router Metadata export"
+      pattern: "metadata|description"
+    - from: ".sanitize-allowlist"
+      to: "runtime/*/requirements.txt + runtime/tts/manifest.yml"
+      via: "Path globs that exempt dev-pinning-provenance comments"
+      pattern: "runtime/.*/requirements\\.txt"
+---
+
+<objective>
+Clean up the existing `runtime/` tree so all three sanitization gates from Plans 01, 02, 03 pass green on main. This is the SC4-validating plan — without it, the gates are technically wired but block their own first PR.
+
+Purpose: ROADMAP SC4 requires "the current runtime/ tree passes all sanitization checks: zero references to founder hostname, account, SSID, email, home path, or monorepo path." Phase 1 extracted runtime/ from iol-monorepo with `arlowe-1` and `/home/focal55` references intentionally left intact (they were useful as dev-host audit trail during extraction). Now we cash that audit trail in: each reference is either sanitized (replaced with generic phrasing) or explicitly allow-listed (with the rationale captured in `.sanitize-allowlist` comments).
+
+Plus: fold in the F5 todo (ADR-0001 internal contradiction). It's a ~10 LOC docs fix that's been sitting opportunistic since PR #53; this plan is the natural moment to clear it.
+
+Output: 9 runtime/ files sanitized, 2 dashboard files sanitized (layout.tsx description, activity monitor header), `.sanitize-allowlist` extended with dev-pinning-provenance entries + rationale comments, F5 ADR fix landed, todo moved to done/. The three gate CI jobs go from "expected red" to "green on main."
+
+Disposition matrix (research-grounded; full audit in 02-RESEARCH.md):
+
+| File | Decision | Rationale |
+|------|----------|-----------|
+| runtime/llm/router.py:35 (code comment `/home/focal55/ax-llm/docs/http_api.md`) | Sanitize | It's a code comment in shipping code; rewrite to reference the upstream URL or generic phrasing. |
+| runtime/llm/run_api.sh | Sanitize | Shell script comments mentioning arlowe-1; generic phrasing works. |
+| runtime/dashboard/app/layout.tsx:11 (`description: "Control panel for Arlowe-1"`) | Sanitize | Renders into <meta name="description"> on every page — leaks into HTML the dashboard ships. |
+| runtime/dashboard/app/components/RetroActivityMonitor.tsx:140 (`ARLOWE-1 SYSTEM MONITOR`) | Sanitize | Visible user-facing UI string. Replace with generic or config-derived. |
+| runtime/{voice,face,stt,tts,llm,dashboard,wake-word}/README.md (8 files, ~17 lines) | Sanitize | READMEs ship in the runtime/ tree and are customer-developer-facing. Rewrite operator instructions with `<your-dev-pi>` placeholders or generic `~/venvs/voice/`-style refs. |
+| runtime/*/requirements.txt comments (5 files) | Allow-list | Pure dev-pinning provenance: "Pinned from arlowe-1 ~/venvs/voice/ on 2026-05-02." That's audit-trail metadata, never renders anywhere, never ships as a service. Rewriting loses real value. |
+| runtime/tts/manifest.yml (2 lines) | Allow-list | Same reasoning — records the exact dev host SHA-256 verification was done from. Provenance audit trail. |
+| docs/architecture/0001-iol-router-extraction.md (F5 fix) | Sanitize the contradiction | ~10 LOC; clears a real todo; the file is already path-globbed in `.sanitize-allowlist` so this is hygiene, not gate-driven. |
+</objective>
+
+<execution_context>
+@~/.claude/get-shit-done/workflows/execute-plan.md
+@~/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/phases/02-sanitization-gate/02-CONTEXT.md
+@.planning/phases/02-sanitization-gate/02-RESEARCH.md
+@.planning/phases/02-sanitization-gate/02-01-SUMMARY.md
+@.planning/phases/02-sanitization-gate/02-02-SUMMARY.md
+@.planning/phases/02-sanitization-gate/02-03-SUMMARY.md
+@.planning/todos/pending/F5-adr-0001-why-option-2-internal-contradiction.md
+
+# Files to sanitize (cite for context, not blanket re-read)
+@runtime/llm/router.py
+@runtime/dashboard/app/layout.tsx
+@runtime/dashboard/app/components/RetroActivityMonitor.tsx
+@docs/architecture/0001-iol-router-extraction.md
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Sanitize runtime/ code + dashboard UI files + extend allow-list</name>
+  <files>runtime/llm/router.py, runtime/llm/run_api.sh, runtime/dashboard/app/layout.tsx, runtime/dashboard/app/components/RetroActivityMonitor.tsx, .sanitize-allowlist</files>
+  <action>
+    **`runtime/llm/router.py` (line 35):**
+    Current: `# Authoritative routes per /home/focal55/ax-llm/docs/http_api.md and the`
+    Replace with phrasing that references the upstream source, not the dev host path:
+    `# Authoritative routes per ax-llm's docs/http_api.md (vendored at third_party/ax-llm/) and the`
+
+    **`runtime/llm/run_api.sh`:**
+    Current line 6: `# For the Phase 1 smoke test on arlowe-1, set:`
+    Replace with: `# For local smoke-testing on a Pi 5 dev unit with the AX accelerator, set:`
+    Scan the whole file for any other `arlowe-1` / `/home/focal55` mentions in comments; apply the same generic-phrasing pattern. If any non-comment line references these, flag in the SUMMARY (none expected per the 16-file grep result).
+
+    **`runtime/dashboard/app/layout.tsx` (line 11):**
+    Current: `description: "Control panel for Arlowe-1",`
+    Replace with: `description: "Control panel for your Arlowe device",`
+    This is the highest-leverage fix in the plan — the literal leaks into `<meta name="description">` on every dashboard route, so the Playwright sanitize spec from Plan 03 currently fails on every single page because of this one line.
+
+    **`runtime/dashboard/app/components/RetroActivityMonitor.tsx` (line 140):**
+    Current: `<span className="text-retro-green"> ARLOWE-1 SYSTEM MONITOR </span>`
+    Replace with: `<span className="text-retro-green"> ARLOWE SYSTEM MONITOR </span>`
+    Keep the retro aesthetic; drop the "-1" host suffix. This is visible UI text so the wording matters for product feel — review with the user during PR if there's a better phrasing, but the gate-passing fix is to drop "-1".
+
+    Note: a future config-overlay phase (Phase 4) could thread the device's configured name into the header. For Phase 2, the gate-passing change is the static drop of `-1`. Don't try to thread config here — it's out of scope and dependent on Phase 4.
+
+    **`.sanitize-allowlist` — extend with dev-pinning-provenance entries:**
+
+    Add at the bottom of `.sanitize-allowlist` (preserve all existing entries from Plan 01):
+
+    ```
+    # --- Dev-pinning provenance allow-list (Plan 04 SC4 cleanup) ---
+    # The runtime/*/requirements.txt comments record which dev unit the pins were
+    # captured from and when. These are audit-trail metadata that never render as
+    # user-facing strings and never ship as a service. Rewriting them loses real
+    # provenance value (we'd no longer know which Pi the pins are calibrated against).
+    # Decision rationale: 02-04-PLAN.md disposition matrix.
+    runtime/voice/requirements.txt
+    runtime/face/requirements.txt
+    runtime/stt/requirements.txt
+    runtime/tts/requirements.txt
+    runtime/llm/requirements.txt
+    runtime/wake-word/requirements.txt
+
+    # Same reasoning: tts/manifest.yml's SHA-256-verified-on comments are provenance.
+    runtime/tts/manifest.yml
+    ```
+
+    Note: `runtime/stt/requirements.txt` is included even if grep didn't report it in the 16-file sweep — pre-emptively allow-listing it is harmless (no-op if clean) and prevents a future surprise when stt's requirements.txt is touched.
+
+    DO NOT: sanitize files via `sed -i 's/...//g'`-style sweeps without per-file review — many comment contexts need slight rewording to read naturally. Make each edit deliberate. DO NOT introduce any cross-Plan-03 race by modifying playwright.config.ts here (Plan 03 owns that file).
+  </action>
+  <verify>
+    `grep -F '/home/focal55' runtime/llm/router.py` returns nothing.
+    `grep -F 'arlowe-1' runtime/llm/run_api.sh` returns nothing.
+    `grep -F 'Arlowe-1' runtime/dashboard/app/layout.tsx` returns nothing.
+    `grep -F 'ARLOWE-1' runtime/dashboard/app/components/RetroActivityMonitor.tsx` returns nothing.
+    `grep -c '^runtime/.*requirements\.txt' .sanitize-allowlist` returns 6.
+    `grep -F 'runtime/tts/manifest.yml' .sanitize-allowlist` matches.
+    Run Plan 01's gate: `bash scripts/sanitize/check.sh --grep-only` — should report fewer hits than before but NOT zero yet (the README files in Task 2 still need cleanup).
+  </verify>
+  <done>
+    All 4 code/UI files sanitized (router.py comment, run_api.sh comment, layout.tsx description, RetroActivityMonitor.tsx header). `.sanitize-allowlist` extended with 6 requirements.txt entries + manifest.yml + a rationale comment. The grep gate now reports only README-related hits (the Task 2 target).
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Sanitize the 8 runtime/ README files</name>
+  <files>runtime/dashboard/README.md, runtime/face/README.md, runtime/llm/README.md, runtime/stt/README.md, runtime/tts/README.md, runtime/voice/README.md, runtime/wake-word/README.md</files>
+  <action>
+    Sanitize each of the 8 README files. Per the disposition matrix in this plan's objective, READMEs ship in the runtime/ tree and are customer-developer-facing; their `arlowe-1` references must be replaced with generic phrasing.
+
+    **Pattern for replacements (apply per occurrence, don't blind-sed):**
+
+    | Original phrasing | Replacement |
+    |-------------------|-------------|
+    | "Running locally on arlowe-1" (section header) | "Running locally on a Pi 5 dev unit" |
+    | "On arlowe-1 today the driver lives at..." | "On a dev Pi today the driver typically lives at..." |
+    | "ssh arlowe-1 '...'" (command example) | "ssh <your-dev-pi> '...'" (use angle-bracket placeholder; matches existing convention) |
+    | "Pinned from arlowe-1 system Python..." (in README context, not requirements.txt) | "Pinned from a Pi 5 dev unit's system Python..." |
+    | "Verified present in the arlowe-1 voice venv at version `6.0.3`" | "Verified present in a Pi 5 dev unit's voice venv at version `6.0.3`" |
+    | "the USB combo card on arlowe-1" | "the USB combo card on the dev unit used for Phase 1 testing" |
+    | "is broken on arlowe-1 as of Phase 1" | "is broken in the Phase 1 baseline" |
+    | "verified 2026-05-02 via ssh arlowe-1 'sha256sum ~/models/piper/piper'" | (this one lives in tts/README.md, but be careful — same string in tts/manifest.yml is allow-listed; verify the README occurrence is the one you're editing) → "verified 2026-05-02 via `sha256sum ~/models/piper/piper` on the dev unit" |
+
+    **Special case — `runtime/wake-word/README.md:93`:**
+    Current: ``~/iol-monorepo/packages/whisplay/wake_word/` exists on arlowe-1 alongside the canonical``
+    Both `iol-monorepo` and `arlowe-1` in one sentence. Replace with generic phrasing that preserves the architectural information:
+    `An older copy of the wake-word pipeline existed in the founder dev monorepo (pre-extraction); the runtime/wake-word/ tree is the canonical post-extraction location.`
+    Or similar — preserve the "this is the canonical post-extraction tree" point without naming the source monorepo.
+
+    **Per-file workflow:**
+    1. Read the file fully.
+    2. For each `arlowe-1` / `/home/focal55` / `iol-monorepo` / `focal55` / `casa_ybarra_chelsea` / `joe@focal55` occurrence, identify what the sentence is *trying* to communicate.
+    3. Pick a replacement that preserves the meaning. Prefer angle-bracket placeholders (`<your-dev-pi>`) in command examples and "a Pi 5 dev unit" in prose.
+    4. Verify the surrounding paragraph still flows. If a section header changes (e.g., "Running locally on arlowe-1" → "Running locally on a Pi 5 dev unit"), check whether any other doc cross-links to that header — if so, update the link.
+
+    Files to edit:
+    - `runtime/dashboard/README.md` (1 hit: line 61 section header)
+    - `runtime/face/README.md` (3 hits: lines 37, 43, 59)
+    - `runtime/llm/README.md` (1 hit: line 52)
+    - `runtime/stt/README.md` (1 hit: line 39)
+    - `runtime/tts/README.md` (6 hits: lines 64, 68, 76, 79, 99, plus check for any others)
+    - `runtime/voice/README.md` (1 hit: line 23)
+    - `runtime/wake-word/README.md` (1 hit: line 93)
+
+    Total: 8 README files, ~14 lines edited (some hits will collapse — e.g., tts/README.md may have a single rewrite that cleans up two adjacent mentions).
+
+    DO NOT touch `runtime/*/requirements.txt` files (allow-listed in Task 1). DO NOT touch `runtime/tts/manifest.yml` (allow-listed in Task 1). DO NOT rewrite README content beyond what's needed to remove banned literals — this is a sanitization sweep, not a content overhaul.
+  </action>
+  <verify>
+    `git grep -lE 'focal55|arlowe-1|casa_ybarra_chelsea|/home/focal55|joe@focal55|iol-monorepo' -- 'runtime/**/README.md'` returns nothing (zero README files contain banned literals).
+    Spot-check the rewrites by reading each touched README's affected section — does the paragraph still make sense? Are commands still copy-pasteable (with the angle-bracket placeholder)?
+    Run all gates from repo root:
+    - `bash scripts/sanitize/check.sh` exits 0 (both grep and units gates green).
+    - `cd runtime/dashboard && pnpm install && pnpm exec playwright install chromium && pnpm exec playwright test sanitize.spec.ts --project=chromium` exits 0 (rendered-text gate green).
+  </verify>
+  <done>
+    All 8 README files sanitized with the replacement patterns documented above. Grep gate exits 0 on the full runtime/ tree. Dashboard sanitize spec passes on every route. SC4 satisfied.
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Fix F5 ADR-0001 contradiction and move todo to done/</name>
+  <files>docs/architecture/0001-iol-router-extraction.md, .planning/todos/done/F5-adr-0001-why-option-2-internal-contradiction.md</files>
+  <action>
+    **Fix `docs/architecture/0001-iol-router-extraction.md`** per the F5 todo (the todo is verbatim in this plan's context — read it for the exact problem location and proposed fix).
+
+    The "Why option-2" bullet list (around lines 61-73 per the F5 todo) contains a "Verified working live" bullet that asserts the OpenAI `/v1/chat/completions` shape, contradicting the resolved decision (router uses ax-llm native `/api/chat` returning `{done, message}`).
+
+    Apply the rewrite the F5 todo proposes:
+
+    ```markdown
+    - **Verified working live.** `curl -s -XPOST http://localhost:8000/api/chat \
+      -d '{"messages":[{"role":"user","content":"ping"}]}'` on a Pi 5 dev unit
+      returns `{done: true, message: {...}}`. `voice_client.py` was updated in
+      PR #52 to speak ax-llm's native shape; the previous assumption that ax-llm
+      would expose the OpenAI `/v1/chat/completions` surface returned malformed
+      responses on the running build.
+    ```
+
+    Note the change from the F5 todo's draft: `on arlowe-1` → `on a Pi 5 dev unit` (the docs/architecture/ folder is allow-listed by Plan 01 so `arlowe-1` here wouldn't trip the gate, but using sanitized phrasing in the actual rewrite is consistent — we don't want allow-listed files to be the place future literals creep back).
+
+    Verify the rest of the ADR is internally consistent post-rewrite. The F5 todo notes that the "Refinement history" note (added by commit 640d20a on PR #53) should now align with this bullet. Read the file end-to-end and confirm no other contradictory phrasing remains.
+
+    **Move the F5 todo to done/:**
+
+    1. `mkdir -p .planning/todos/done/` (idempotent; create if absent).
+    2. Move (`git mv`) `.planning/todos/pending/F5-adr-0001-why-option-2-internal-contradiction.md` to `.planning/todos/done/F5-adr-0001-why-option-2-internal-contradiction.md`.
+    3. Append a closure note to the moved file:
+       ```markdown
+
+       ---
+
+       **Closed:** Resolved in Phase 2, Plan 04 (sanitization-gate cleanup sweep).
+       The "Why option-2" bullet now matches the resolved decision; ADR is internally consistent.
+       ```
+
+    Side effect on STATE.md: per workforce convention, .planning/STATE.md tracks pending todos. The current STATE.md lists F5 under "Pending Todos". Update that list to remove F5 (or mark it closed) — this is a state-of-record update, not part of the F5 fix itself. Do it as part of this task.
+
+    **Update `.planning/STATE.md`:**
+    Find the F5 line in the "Pending Todos" section:
+    `- F5-adr-0001-why-option-2-internal-contradiction.md — opportunistic ADR-0001 rationale fix; candidate for Phase 2 docs sanitization sweep`
+    Delete that line. The list goes from 5 pending todos to 4.
+
+    DO NOT: rewrite other parts of the ADR (the F5 fix is scoped to the "Why option-2" bullet contradiction). DO NOT add new ADR sections. DO NOT touch ADR-0002 (different file, different concern).
+  </action>
+  <verify>
+    `grep -F '/v1/chat/completions' docs/architecture/0001-iol-router-extraction.md | wc -l` — should match expectations after the fix. The mention of `/v1/chat/completions` is allowed in a *historical/contrastive* sense (i.e., "the previous assumption that ax-llm would expose the OpenAI `/v1/chat/completions` surface returned malformed responses") but not as an assertion that this is the chosen route.
+    `grep -F '/api/chat' docs/architecture/0001-iol-router-extraction.md | wc -l` — should be >= 1 (the current chosen route should appear at least in the rewritten bullet).
+    `ls .planning/todos/pending/F5-*.md 2>/dev/null | wc -l` returns 0.
+    `ls .planning/todos/done/F5-*.md 2>/dev/null | wc -l` returns 1.
+    `tail -5 .planning/todos/done/F5-adr-0001-why-option-2-internal-contradiction.md | grep -F 'Closed:'` matches.
+    `grep -F 'F5-adr-0001' .planning/STATE.md` returns nothing.
+  </verify>
+  <done>
+    ADR-0001 "Why option-2" bullet rewritten so the rationale and the resolved decision agree. F5 todo moved from pending/ to done/ with a closure note. STATE.md pending-todos list no longer mentions F5.
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+**Plan-level verification (THIS IS THE PHASE-CLOSING VERIFICATION):**
+
+1. **Grep gate green on main**: `bash scripts/sanitize/check.sh --grep-only` exits 0.
+2. **Unit-name block green on main**: `bash scripts/sanitize/check.sh --units-only` exits 0 (no regression from Plan 02 baseline).
+3. **Both gates green together**: `bash scripts/sanitize/check.sh` (no flag) exits 0.
+4. **Self-test still works**: `bash scripts/sanitize/test-check.sh` exits 0 with all three PASS lines.
+5. **Dashboard rendered-text gate green**: from `runtime/dashboard/`, `pnpm install && pnpm exec playwright install chromium && pnpm exec playwright test sanitize.spec.ts --project=chromium` reports all routes passing.
+6. **CI smoke**: Push to a branch and open a PR; the three sanitize-workflow jobs (banlist-and-units, self-test, dashboard-rendered-text) all show green checkmarks.
+7. **Deliberate-failure test in PR**: add a comment containing `focal55` to a tracked, non-allow-listed file, push, observe the workflow fail with an inline annotation. Revert. (Optional but high-value smoke test for the phase exit.)
+8. **F5 closed**: `.planning/todos/pending/F5-*` is gone, `.planning/todos/done/F5-*` exists with closure note.
+9. **ROADMAP SC4 satisfied**: zero references to founder hostname / account / SSID / email / home path / monorepo path in `runtime/` outside the documented allow-list.
+</verification>
+
+<success_criteria>
+- All 3 tasks complete with verify-block passing.
+- All three gates pass on main: grep, unit-name, dashboard rendered-text.
+- ROADMAP SC4 satisfied: zero hits on `git grep -inE 'focal55|arlowe-1|casa_ybarra_chelsea|/home/focal55|joe@focal55|iol-monorepo' -- runtime/` (the explicit dev-pinning provenance comments are now allow-listed via `.sanitize-allowlist`).
+- ROADMAP SC1, SC2, SC3 also satisfied (gates from Plans 01, 02, 03 are wired, exercised, and green).
+- F5 todo closed.
+- PR-size budget: estimated ~120 net lines (8 READMEs ~50 lines, 4 code/UI files ~10 lines, allow-list extension ~12 lines, ADR fix ~12 lines, todo move + STATE.md edit ~10 lines, plus deletions). Well under 400.
+
+**Phase exit criteria (must_haves for gsd-verifier):**
+- A PR introducing `focal55` (or any of the 6 literals) anywhere in a tracked non-allow-listed file fails CI with grep-style + GitHub annotation output ✓ (Plan 01 + green main proves it)
+- A PR adding `openclaw-foo.service` to a tracked path fails CI ✓ (Plan 02 self-test proves it; CI exercises the gate)
+- A PR introducing a banned literal into a dashboard page fails the Playwright spec ✓ (Plan 03 + green main proves it)
+- runtime/ tree is grep-clean (zero banned literals outside the allow-list) ✓ (this plan's Task 2 verify)
+- The allow-list is documented and the failure message includes a "if this is legit, add to .sanitize-allowlist" hint ✓ (Plan 01 Task 2 wording)
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/02-sanitization-gate/02-04-SUMMARY.md` documenting:
+- The disposition matrix (sanitize vs allow-list) actually applied per file, with any deviations from this plan
+- The F5 fix landed and the todo move
+- Confirmation that all four phase-exit criteria from ROADMAP are met (with specific verification commands run)
+- A snapshot of `.sanitize-allowlist` final contents
+- Any provenance comment phrasing that ended up being non-obvious during PR review (for future-author reference)
+- Phase 2 closure note: this is the last plan in Phase 2; the next milestone is `/gsd:verify-work` against Phase 2's SC1-SC4
+</output>

--- a/.planning/phases/02-sanitization-gate/02-04-PLAN.md
+++ b/.planning/phases/02-sanitization-gate/02-04-PLAN.md
@@ -66,7 +66,7 @@ Purpose: ROADMAP SC4 requires "the current runtime/ tree passes all sanitization
 
 Plus: fold in the F5 todo (ADR-0001 internal contradiction). It's a ~10 LOC docs fix that's been sitting opportunistic since PR #53; this plan is the natural moment to clear it.
 
-Output: 9 runtime/ files sanitized, 2 dashboard files sanitized (layout.tsx description, activity monitor header), `.sanitize-allowlist` extended with dev-pinning-provenance entries + rationale comments, F5 ADR fix landed, todo moved to done/. The three gate CI jobs go from "expected red" to "green on main."
+Output: 7 runtime/ README files sanitized, 2 dashboard files sanitized (layout.tsx description, activity monitor header), 2 runtime/ code/shell files sanitized (router.py, run_api.sh), `.sanitize-allowlist` extended with dev-pinning-provenance entries + rationale comments, F5 ADR fix landed, todo moved to done/. The three gate CI jobs go from "expected red" to "green on main."
 
 Disposition matrix (research-grounded; full audit in 02-RESEARCH.md):
 
@@ -76,7 +76,7 @@ Disposition matrix (research-grounded; full audit in 02-RESEARCH.md):
 | runtime/llm/run_api.sh | Sanitize | Shell script comments mentioning arlowe-1; generic phrasing works. |
 | runtime/dashboard/app/layout.tsx:11 (`description: "Control panel for Arlowe-1"`) | Sanitize | Renders into <meta name="description"> on every page — leaks into HTML the dashboard ships. |
 | runtime/dashboard/app/components/RetroActivityMonitor.tsx:140 (`ARLOWE-1 SYSTEM MONITOR`) | Sanitize | Visible user-facing UI string. Replace with generic or config-derived. |
-| runtime/{voice,face,stt,tts,llm,dashboard,wake-word}/README.md (8 files, ~17 lines) | Sanitize | READMEs ship in the runtime/ tree and are customer-developer-facing. Rewrite operator instructions with `<your-dev-pi>` placeholders or generic `~/venvs/voice/`-style refs. |
+| runtime/{voice,face,stt,tts,llm,dashboard,wake-word}/README.md (7 files, ~17 lines) | Sanitize | READMEs ship in the runtime/ tree and are customer-developer-facing. Rewrite operator instructions with `<your-dev-pi>` placeholders or generic `~/venvs/voice/`-style refs. |
 | runtime/*/requirements.txt comments (5 files) | Allow-list | Pure dev-pinning provenance: "Pinned from arlowe-1 ~/venvs/voice/ on 2026-05-02." That's audit-trail metadata, never renders anywhere, never ships as a service. Rewriting loses real value. |
 | runtime/tts/manifest.yml (2 lines) | Allow-list | Same reasoning — records the exact dev host SHA-256 verification was done from. Provenance audit trail. |
 | docs/architecture/0001-iol-router-extraction.md (F5 fix) | Sanitize the contradiction | ~10 LOC; clears a real todo; the file is already path-globbed in `.sanitize-allowlist` so this is hygiene, not gate-driven. |
@@ -171,10 +171,10 @@ Disposition matrix (research-grounded; full audit in 02-RESEARCH.md):
 </task>
 
 <task type="auto">
-  <name>Task 2: Sanitize the 8 runtime/ README files</name>
+  <name>Task 2: Sanitize the 7 runtime/ README files</name>
   <files>runtime/dashboard/README.md, runtime/face/README.md, runtime/llm/README.md, runtime/stt/README.md, runtime/tts/README.md, runtime/voice/README.md, runtime/wake-word/README.md</files>
   <action>
-    Sanitize each of the 8 README files. Per the disposition matrix in this plan's objective, READMEs ship in the runtime/ tree and are customer-developer-facing; their `arlowe-1` references must be replaced with generic phrasing.
+    Sanitize each of the 7 README files. Per the disposition matrix in this plan's objective, READMEs ship in the runtime/ tree and are customer-developer-facing; their `arlowe-1` references must be replaced with generic phrasing.
 
     **Pattern for replacements (apply per occurrence, don't blind-sed):**
 
@@ -210,7 +210,7 @@ Disposition matrix (research-grounded; full audit in 02-RESEARCH.md):
     - `runtime/voice/README.md` (1 hit: line 23)
     - `runtime/wake-word/README.md` (1 hit: line 93)
 
-    Total: 8 README files, ~14 lines edited (some hits will collapse — e.g., tts/README.md may have a single rewrite that cleans up two adjacent mentions).
+    Total: 7 README files, ~14 lines edited (some hits will collapse — e.g., tts/README.md may have a single rewrite that cleans up two adjacent mentions).
 
     DO NOT touch `runtime/*/requirements.txt` files (allow-listed in Task 1). DO NOT touch `runtime/tts/manifest.yml` (allow-listed in Task 1). DO NOT rewrite README content beyond what's needed to remove banned literals — this is a sanitization sweep, not a content overhaul.
   </action>
@@ -222,7 +222,7 @@ Disposition matrix (research-grounded; full audit in 02-RESEARCH.md):
     - `cd runtime/dashboard && pnpm install && pnpm exec playwright install chromium && pnpm exec playwright test sanitize.spec.ts --project=chromium` exits 0 (rendered-text gate green).
   </verify>
   <done>
-    All 8 README files sanitized with the replacement patterns documented above. Grep gate exits 0 on the full runtime/ tree. Dashboard sanitize spec passes on every route. SC4 satisfied.
+    All 7 README files sanitized with the replacement patterns documented above. Grep gate exits 0 on the full runtime/ tree. Dashboard sanitize spec passes on every route. SC4 satisfied.
   </done>
 </task>
 
@@ -287,17 +287,30 @@ Disposition matrix (research-grounded; full audit in 02-RESEARCH.md):
 </tasks>
 
 <verification>
-**Plan-level verification (THIS IS THE PHASE-CLOSING VERIFICATION):**
+**Plan-level verification (autonomous DEV agent runs these after Task 3 completes):**
 
 1. **Grep gate green on main**: `bash scripts/sanitize/check.sh --grep-only` exits 0.
 2. **Unit-name block green on main**: `bash scripts/sanitize/check.sh --units-only` exits 0 (no regression from Plan 02 baseline).
 3. **Both gates green together**: `bash scripts/sanitize/check.sh` (no flag) exits 0.
 4. **Self-test still works**: `bash scripts/sanitize/test-check.sh` exits 0 with all three PASS lines.
 5. **Dashboard rendered-text gate green**: from `runtime/dashboard/`, `pnpm install && pnpm exec playwright install chromium && pnpm exec playwright test sanitize.spec.ts --project=chromium` reports all routes passing.
-6. **CI smoke**: Push to a branch and open a PR; the three sanitize-workflow jobs (banlist-and-units, self-test, dashboard-rendered-text) all show green checkmarks.
-7. **Deliberate-failure test in PR**: add a comment containing `focal55` to a tracked, non-allow-listed file, push, observe the workflow fail with an inline annotation. Revert. (Optional but high-value smoke test for the phase exit.)
-8. **F5 closed**: `.planning/todos/pending/F5-*` is gone, `.planning/todos/done/F5-*` exists with closure note.
-9. **ROADMAP SC4 satisfied**: zero references to founder hostname / account / SSID / email / home path / monorepo path in `runtime/` outside the documented allow-list.
+
+---
+
+**Phase-exit handoff (manual, post-merge — NOT for the autonomous DEV agent):**
+
+Steps 6-7 below require opening a PR and observing CI in the GitHub UI. They are *not* part of this plan's autonomous task-level verification — an autonomous DEV agent cannot meaningfully open a PR to validate its own work without human/orchestrator involvement. They are documented here as the human/post-merge gates the user (or workforce orchestrator) should run before declaring Phase 2 closed.
+
+6. **CI smoke (manual)**: Push the merged-to-main branch (or the PR branch carrying Plans 01-04) and confirm in the GitHub Actions UI that the three sanitize-workflow jobs (banlist-and-units, self-test, dashboard-rendered-text) all show green checkmarks. This is the proof that the gates run cleanly in the actual CI environment, not just locally.
+
+7. **Deliberate-failure test in PR (manual, optional but high-value)**: On a throwaway branch, add a comment containing `focal55` to a tracked, non-allow-listed file, push, observe the workflow fail with an inline annotation, revert. This is the end-to-end smoke that the gates would actually catch a regression. Skip if the user does not want to spend the CI minutes; the test-check.sh self-test (verify step 4 above) covers the same logic locally.
+
+---
+
+**Post-merge tracking (do not gate this plan on these):**
+
+8. **F5 closed**: `.planning/todos/pending/F5-*` is gone, `.planning/todos/done/F5-*` exists with closure note. (This *is* gated by Task 3's verify block — listed here for completeness in the phase-exit checklist.)
+9. **ROADMAP SC4 satisfied**: zero references to founder hostname / account / SSID / email / home path / monorepo path in `runtime/` outside the documented allow-list. (This *is* gated by verify steps 1-5 above — listed here so the verifier has the SC4 mapping explicit.)
 </verification>
 
 <success_criteria>
@@ -306,7 +319,7 @@ Disposition matrix (research-grounded; full audit in 02-RESEARCH.md):
 - ROADMAP SC4 satisfied: zero hits on `git grep -inE 'focal55|arlowe-1|casa_ybarra_chelsea|/home/focal55|joe@focal55|iol-monorepo' -- runtime/` (the explicit dev-pinning provenance comments are now allow-listed via `.sanitize-allowlist`).
 - ROADMAP SC1, SC2, SC3 also satisfied (gates from Plans 01, 02, 03 are wired, exercised, and green).
 - F5 todo closed.
-- PR-size budget: estimated ~120 net lines (8 READMEs ~50 lines, 4 code/UI files ~10 lines, allow-list extension ~12 lines, ADR fix ~12 lines, todo move + STATE.md edit ~10 lines, plus deletions). Well under 400.
+- PR-size budget: estimated ~120 net lines (7 READMEs ~45 lines, 4 code/UI files ~10 lines, allow-list extension ~12 lines, ADR fix ~12 lines, todo move + STATE.md edit ~10 lines, plus deletions). Well under 400.
 
 **Phase exit criteria (must_haves for gsd-verifier):**
 - A PR introducing `focal55` (or any of the 6 literals) anywhere in a tracked non-allow-listed file fails CI with grep-style + GitHub annotation output ✓ (Plan 01 + green main proves it)

--- a/.planning/phases/02-sanitization-gate/02-CONTEXT.md
+++ b/.planning/phases/02-sanitization-gate/02-CONTEXT.md
@@ -1,0 +1,92 @@
+# Phase 2: Sanitization Gate - Context
+
+**Gathered:** 2026-05-25
+**Status:** Ready for planning
+
+<domain>
+## Phase Boundary
+
+Three mechanical sanitization gates that prevent founder identity from re-entering the codebase or shipping in firmware:
+
+1. **CI grep gate** — fails any PR that introduces a banned identity literal in tracked files
+2. **Image-build unit-name block** — fails CI if any tracked systemd unit file matches a banned founder-only service name (Phase 6 will reuse the same script at image-assembly time)
+3. **Dashboard rendered-text gate** — Playwright test fails if any banned literal appears in rendered dashboard HTML
+
+Plus: ensure the current `runtime/` tree passes all gates (SC4).
+
+**Strategic role.** This is the *guardrail* phase. Phase 1 just landed a clean tree; every subsequent phase (service user, config overlay, image build, pairing, OTA, support access, dashboard surfaces) will add a lot of new code. Without this gate, each one would need a manual re-audit before merge. Landing it now is the cheapest possible moment.
+
+**Why this matters specifically because we ship firmware.** Founder-only services aren't just labels — `openclaw-*`, `trace-*`, and `workforce-metrics-snapshot.*` are services that phone home to founder infrastructure. If one shipped on a customer's Pi, their device would try to reach founder-internal endpoints from their home network. The grep gate catches strings; the systemd-unit block catches the actual surveillance vectors. The artifact ships to physical hardware that can't be hot-fixed — the image build is the last reversible checkpoint, and Phase 12's first-flash SC1 grep-verifies a mounted SD card. Phase 2 is what makes that verification pass mechanically instead of by accident.
+
+Out of scope: secrets scanning, license scanning, PII detection, founder name/brand literals beyond the 6 from ROADMAP SC1.
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Banned-literal list & matching
+- **List locked to the 6 from ROADMAP SC1**: `focal55`, `arlowe-1`, `casa_ybarra_chelsea`, `/home/focal55`, `joe@focal55`, `iol-monorepo`
+- **Case-insensitive** matching (catches `Focal55`, `FOCAL55`, `/Home/Focal55`)
+- **Substring (raw grep)** matching — no word-boundary anchoring; accept the false-positive risk for simpler implementation
+- **Scans the whole tracked tree** — every file `git ls-files` returns
+
+### Allow-list + failure ergonomics
+- **Single file: `.sanitize-allowlist` at repo root**; entries are path globs (e.g., `.planning/**`, `docs/architecture/0001-*.md`, `docs/journey/**`)
+- A path glob in the allow-list permits *any* banned literal in matching files — no per-literal precision
+- **Comments on entries are optional**, not required
+- **Failure output**: exit code + grep-style stdout (`path:line: literal`) + GitHub Actions `::error file=...,line=...` annotations so PRs show inline red marks at offending lines
+- **Where it runs**: GitHub Actions PR check only, marked **required** on the default branch. No pre-commit hook. Agents and humans both discover failure via PR status.
+
+### Image-build unit-name block
+- **Phase 2 ships a tracked-file scan now**; Phase 6 reuses the same script when wiring pi-gen
+- **Banned patterns locked to the 3 from ROADMAP SC2**: `openclaw-*`, `trace-*`, `workforce-metrics-snapshot.*`
+- **Scan scope**: all tracked systemd unit files by extension — `*.service`, `*.timer`, `*.socket`, `*.target`, `*.mount`, `*.path`
+- **Deliberate-failure test case = unit test on the script**: temp dir containing a fake `openclaw-test.service`, assert the script exits non-zero. Runs in CI alongside the gate itself. No fixture file committed under a production-scanned path.
+
+### Dashboard snapshot strategy
+- **Tool: Playwright** (already wired up in `runtime/dashboard/`, see `playwright.config.ts` and existing `tests/*.spec.ts`)
+- **Text content only** — `page.content()` (rendered HTML) grep-checked for the 6 banned literals; no screenshots, no href/attribute scanning
+- **Backend strategy**: dashboard runs via `pnpm dev` (or `playwright webServer`) with real, unconfigured API routes; pages render with empty/error states, which is what the gate validates against. Closest to production behavior, no fixture maintenance.
+- **Route enumeration**: auto-discover from `runtime/dashboard/app/` directory structure (or Next route manifest) so new pages are covered automatically
+- **File location**: new `runtime/dashboard/tests/sanitize.spec.ts`
+
+### Claude's Discretion
+- Grep-gate implementation tool (ripgrep + shell vs Python script). Lean toward whichever produces cleaner structured output for GitHub annotations.
+- Exact mechanism for auto-discovering Next routes (filesystem walk over `app/` vs Next route manifest)
+- File layout under `scripts/` (single `scripts/sanitize/` directory vs flat scripts)
+- Whether the unit-name check is its own script or folded into the same runner as the grep gate
+- Allow-list comment syntax (probably `#` line comments — same as `.gitignore`)
+- CI workflow file naming/structure (`.github/workflows/sanitize.yml` vs adding a step to an existing workflow)
+- Whether to emit a "did you mean" hint message on failure ("if this is a legit historical reference, add the path to .sanitize-allowlist")
+
+</decisions>
+
+<specifics>
+## Specific Ideas
+
+- The grep-gate failure output should be **agent-parseable**: `path/to/file.py:42: focal55` is enough for an agent to retry with context. A hint message ("banned identity literal; if it's a legit historical reference, add the path to .sanitize-allowlist") helps an agent self-correct without a human round-trip.
+- The dashboard snapshot test should treat **error states as legitimate render targets** — the goal is "no banned literal in the rendered output," and error pages are part of the rendered surface that ships.
+- The 3 banned unit prefixes (`openclaw-*`, `trace-*`, `workforce-metrics-snapshot.*`) match exactly the units present in `.dev-stash/arlowe-1/systemd-user/` — `.dev-stash/` is gitignored so they don't trip the gate today, but the prefixes are calibrated to those exact founder-internal services.
+
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+- **Screenshots from headless dashboard run** — ROADMAP SC3 mentions this; text-grep covers the same signal without screenshot maintenance overhead. ROADMAP SC3 may be amended to drop screenshots, or they may be added in a later phase if Phase 12 first-flash reveals a gap that text-grep missed.
+- **Link `href` / attribute scanning in dashboard snapshot** — ROADMAP SC3 mentions "links to founder repos or workforce-internal endpoints." Text-grep on rendered HTML won't catch a banned literal inside an `<a href="...">` attribute value, but the source-tree grep gate *will* catch it in the source that produced the href. Defended by overlap; revisit if a real miss is observed.
+- **Founder name/brand literals beyond the 6** (`Joe Ybarra`, `joeybarrajr`, `Ybarra`, `8bit Homies`, `focal55.com`) — explicitly scoped out per Area 1 decision. Could be added in a follow-up phase or as a hot-fix if a leak is found in practice.
+- **Allow-list expiry / audit / required-reviewer approval on `.sanitize-allowlist` changes** — considered and rejected; allow-list edits are normal PRs reviewed normally.
+- **Per-literal allow-list precision** (`docs/architecture/0001-*.md: iol-monorepo` allows only `iol-monorepo` there, not `focal55`) — rejected for v1; whole-file allowance via path glob is simpler.
+- **Local pre-commit hook** — skipped; PR check is sufficient.
+- **Generic identity-rule config** (hostname/email/handle patterns instead of literal list) — over-engineered for v1.
+- **API response sanitization checks** (`/api/config`, `/api/voice`, etc.) — covered transitively by the source-tree grep gate; deferred unless a runtime-generated literal is observed.
+- **Banned unit-content scanning** (e.g., `ExecStart=/home/focal55/...` inside a `whisper-stt.service`) — partially covered by the grep gate already scanning the unit file's text. No separate content scan needed.
+
+</deferred>
+
+---
+
+*Phase: 02-sanitization-gate*
+*Context gathered: 2026-05-25*

--- a/.sanitize-allowlist
+++ b/.sanitize-allowlist
@@ -1,0 +1,37 @@
+# .sanitize-allowlist
+# Path globs (gitignore-style) of tracked files allowed to contain banned identity literals.
+# Single `*` does NOT cross `/`; use `**` for recursive matching.
+# If you're tempted to add a new entry, ask: does this file ship in the firmware image?
+# If yes, fix the literal instead of allow-listing.
+
+# Planning artifacts that document banned literals as part of their purpose.
+.planning/**
+
+# Architecture decision records and operational docs that capture historical state.
+docs/architecture/**
+docs/architecture-overview.md
+docs/operations/phase-1-smoke-test.md
+
+# Journey entries (workforce diary; never ships in firmware).
+docs/journey/**
+
+# Workforce / template plumbing — references @focal55 the GitHub username, not founder
+# identity in the firmware sense. None of these files ship in the image.
+.github/CODEOWNERS
+.github/ISSUE_TEMPLATE/config.yml
+AGENTS.md.template
+README.md
+
+# Dev pull script: references arlowe-1 because that's the dev unit it pulls from.
+scripts/dev-pull-from-pi.sh
+
+# Third-party distribution paperwork.
+third_party/axcl/DISTRIBUTION-RIGHTS.md
+third_party/axcl/INSTALL.md
+third_party/whisplay-driver/PROVENANCE.md
+
+# Sanitize gate self-references (the data files contain the literals by design).
+.sanitize-allowlist
+scripts/sanitize/banlist.txt
+scripts/sanitize/unit-prefixes.txt
+scripts/sanitize/test-check.sh

--- a/scripts/sanitize/banlist.txt
+++ b/scripts/sanitize/banlist.txt
@@ -1,0 +1,6 @@
+focal55
+arlowe-1
+casa_ybarra_chelsea
+/home/focal55
+joe@focal55
+iol-monorepo

--- a/scripts/sanitize/check.sh
+++ b/scripts/sanitize/check.sh
@@ -10,6 +10,11 @@
 #   --scan-dir DIR  (reserved for Plan 06 image-build hook; not yet implemented)
 #
 # No flag defaults to --grep-only. When Plan 02 lands, no-flag will run both gates.
+#
+# Exit codes:
+#   0  clean — no banned literals found
+#   1  banned literal detected in at least one tracked file
+#   2  tool dependency missing (e.g., ripgrep not installed)
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -38,6 +43,8 @@ if [[ "$MODE" == "units-only" ]]; then
 fi
 
 # --- grep-only mode ---
+
+command -v rg >/dev/null 2>&1 || { echo "check.sh: rg not found; install ripgrep" >&2; exit 2; }
 
 # Build a pathspec array from .sanitize-allowlist (gitignore-style globs).
 # git ls-files honors :(exclude,glob) pathspecs with gitignore semantics.

--- a/scripts/sanitize/check.sh
+++ b/scripts/sanitize/check.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# scripts/sanitize/check.sh
+#
+# Grep gate: scans tracked, non-allow-listed files for banned identity literals.
+# Emits GitHub Actions error annotations on hits; exits non-zero if any found.
+#
+# Flags:
+#   --grep-only   Run the banlist scan (default behavior in Plan 01).
+#   --units-only  Placeholder for Plan 02 unit-name block (exits 0 with a note).
+#   --scan-dir DIR  (reserved for Plan 06 image-build hook; not yet implemented)
+#
+# No flag defaults to --grep-only. When Plan 02 lands, no-flag will run both gates.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+BANLIST="$SCRIPT_DIR/banlist.txt"
+ALLOWLIST=".sanitize-allowlist"
+
+MODE="grep-only"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --grep-only)  MODE="grep-only" ; shift ;;
+    --units-only) MODE="units-only"; shift ;;
+    --scan-dir)
+      echo "check.sh: --scan-dir not implemented yet; landing in plan 06" >&2
+      exit 0
+      ;;
+    *) echo "check.sh: unknown flag: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [[ "$MODE" == "units-only" ]]; then
+  echo "check.sh: units gate not implemented in plan 01; landing in plan 02" >&2
+  exit 0
+fi
+
+# --- grep-only mode ---
+
+# Build a pathspec array from .sanitize-allowlist (gitignore-style globs).
+# git ls-files honors :(exclude,glob) pathspecs with gitignore semantics.
+PATHSPECS=()
+if [[ -f "$ALLOWLIST" ]]; then
+  while IFS= read -r line; do
+    line="${line%%#*}"                            # strip inline comments
+    line="${line#"${line%%[![:space:]]*}"}"       # ltrim
+    line="${line%"${line##*[![:space:]]}"}"       # rtrim
+    [[ -z "$line" ]] && continue
+    PATHSPECS+=(":(exclude,glob)$line")
+  done < "$ALLOWLIST"
+fi
+
+# Enumerate tracked, non-allow-listed files.
+# Use a while-read loop instead of mapfile for bash 3.x compatibility (macOS dev).
+FILES=()
+while IFS= read -r f; do
+  FILES+=("$f")
+done < <(git ls-files -- "${PATHSPECS[@]+${PATHSPECS[@]}}")
+
+if [[ ${#FILES[@]} -eq 0 ]]; then
+  echo "sanitize: clean (0 tracked files scanned after allow-list)"
+  exit 0
+fi
+
+# Scan for banned literals. rg exits 1 on no-matches; || true keeps pipefail happy.
+# -H forces filename in output even when only one file is scanned (no-heading alone
+# omits the filename for single-file runs, breaking the path:line:col:text parse).
+HITS=$(rg -iFnH --column --no-heading -f "$BANLIST" -- "${FILES[@]}" || true)
+
+if [[ -z "$HITS" ]]; then
+  echo "sanitize: clean (${#FILES[@]} tracked files scanned)"
+  exit 0
+fi
+
+# Emit GitHub annotations and human-readable output for each hit.
+EXIT=0
+while IFS= read -r hit; do
+  [[ -z "$hit" ]] && continue
+  # rg -n --column output: path:line:col:matched-text
+  IFS=: read -r path line col rest <<< "$hit"
+  printf '::error file=%s,line=%s,col=%s,title=Banned identity literal::banned identity literal at %s:%s:%s — if this is a legitimate historical reference, add the path to .sanitize-allowlist\n' \
+    "$path" "$line" "$col" "$path" "$line" "$col"
+  printf '%s:%s:%s: %s\n' "$path" "$line" "$col" "$rest" >&2
+  EXIT=1
+done <<< "$HITS"
+
+exit "$EXIT"

--- a/scripts/sanitize/test-check.sh
+++ b/scripts/sanitize/test-check.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# scripts/sanitize/test-check.sh
+#
+# Self-test: plants a banned literal in a temp git tree and asserts check.sh exits non-zero.
+# This file is in .sanitize-allowlist so the literal below doesn't trip the production gate.
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+# Create a minimal git tree in the temp dir with a planted banned literal.
+git -C "$TMP" init -q
+echo "user: focal55" > "$TMP/planted.txt"
+git -C "$TMP" add .
+git -C "$TMP" -c user.email=t@t -c user.name=t commit -qm test
+
+# Copy banlist and an effectively-empty allow-list into the temp tree.
+# The real allow-list globs don't match any paths in this temp tree, so no
+# exclusions apply — the gate must catch the planted literal.
+cp "$REPO_ROOT/scripts/sanitize/banlist.txt" "$TMP/"
+touch "$TMP/.sanitize-allowlist"
+
+# Run the gate against the temp tree; capture exit code without triggering set -e.
+EXIT_CODE=0
+if (cd "$TMP" && bash "$REPO_ROOT/scripts/sanitize/check.sh" --grep-only); then
+  EXIT_CODE=0
+else
+  EXIT_CODE=$?
+fi
+
+if [[ "$EXIT_CODE" -eq 0 ]]; then
+  echo "FAIL: gate did not catch planted focal55" >&2
+  exit 1
+fi
+
+echo "PASS: gate correctly blocked planted focal55"
+exit 0


### PR DESCRIPTION
## Summary

- Adds `scripts/sanitize/check.sh`: ripgrep-backed bash runner that scans tracked, non-allow-listed files for 6 banned identity literals; emits GitHub Actions error annotations with `.sanitize-allowlist` self-correction hint; exits non-zero on any hit
- Adds `scripts/sanitize/banlist.txt`: the 6 literals from ROADMAP SC1
- Adds `.sanitize-allowlist`: 24 gitignore-style path globs covering planning artifacts, docs, workforce plumbing, and the gate's own data files; header explains `**` semantics
- Adds `scripts/sanitize/test-check.sh`: plants `focal55` in a temp git tree, asserts gate exits non-zero
- Adds `.github/workflows/sanitize.yml`: two jobs (`banlist-and-units`, `self-test`), no `paths:` filter (avoids required-check pending-forever trap documented in RESEARCH §Pitfall 1)
- Adds `.planning/phases/02-sanitization-gate/02-01-SUMMARY.md`: verification snapshot showing 25 hits in `runtime/` that plan 04 will clean up

`--units-only` is a placeholder stub (exits 0); plan 02 implements it. `--scan-dir` is reserved for plan 06.

## Test plan

- [x] `bash scripts/sanitize/test-check.sh` exits 0 (PASS)
- [x] `bash scripts/sanitize/check.sh --grep-only` exits 1 on current dirty tree with `::error file=...` annotations
- [x] All error messages contain `.sanitize-allowlist` hint string
- [x] No hits in allow-listed paths (`.planning/`, `docs/`, `scripts/sanitize/banlist.txt`, etc.)
- [x] `bash scripts/sanitize/check.sh --units-only` exits 0 with stderr note
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/sanitize.yml'))"` exits 0
- [x] No `paths:` filter in `sanitize.yml`

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)