### PR TITLE
feat(sanitize): plan 02-02 — systemd unit-name block + --scan-dir reuse hook

### DIFF
--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -1,5 +1,10 @@
 name: Sanitize
 
+# Phase 2 / Plan 02 state: two real gates in effect.
+#   Gate 1 — grep gate: banned identity literals in tracked files (Plan 01)
+#   Gate 2 — unit-name block: banned systemd unit basenames in tracked unit files (Plan 02)
+# Gate 3 (dashboard rendered-text) added by Plan 03.
+#
 # NO `paths:` filter — required checks + path filtering = "pending forever" trap.
 # A PR that only touches docs/ wouldn't trigger the workflow; the required check
 # would stay in "Expected — Waiting for status" forever, blocking merge.
@@ -29,8 +34,8 @@ jobs:
         run: sudo apt-get install -y ripgrep
       - name: Verify ripgrep is available
         run: rg --version
-      - name: Run grep gate
-        run: bash scripts/sanitize/check.sh --grep-only
+      - name: Run grep + units gates
+        run: bash scripts/sanitize/check.sh
 
   self-test:
     name: Gate self-test

--- a/.planning/phases/02-sanitization-gate/02-02-SUMMARY.md
+++ b/.planning/phases/02-sanitization-gate/02-02-SUMMARY.md
@@ -1,0 +1,65 @@
+---
+phase: 02-sanitization-gate
+plan: 02
+type: summary
+completed: 2026-05-26
+pr: pending
+---
+
+# Plan 02-02 Summary: systemd unit-name block + --scan-dir reuse hook
+
+## What was shipped
+
+Two tasks, both complete:
+
+1. `scripts/sanitize/unit-prefixes.txt` — 3 banned unit-name patterns (one per line, no comments inside data):
+   - `openclaw-*`
+   - `trace-*`
+   - `workforce-metrics-snapshot.*`
+
+2. `scripts/sanitize/check.sh` — full implementation replacing Plan 01 stubs:
+   - `--units-only` is real (basename glob-match against all tracked `*.service|timer|socket|target|mount|path` files)
+   - `--scan-dir DIR` supported for both grep and units gates; switches enumeration from `git ls-files` to `find DIR -type f`
+   - `--grep-only --units-only` combination exits 2 (invalid); unknown flags exit 2
+   - No-flag invocation runs both gates back-to-back, OR'ing exit codes
+   - Header comment documents all four invocation modes including the Phase 6 reuse contract
+
+3. `scripts/sanitize/test-check.sh` — extended with two new scenarios:
+   - Planted `openclaw-test.service` + `safe-unit.service`; assert units gate catches banned prefix, passes clean unit
+   - Planted `focal55` literal in scan dir; assert `--grep-only --scan-dir` is non-zero (grep gate reuse contract)
+
+4. `.github/workflows/sanitize.yml` — `banlist-and-units` job now invokes `check.sh` with no flag (both gates); top comment updated to reflect Phase 2 / Plan 02 state.
+
+## Four invocation modes
+
+| Mode | Use case |
+|------|----------|
+| `check.sh` | Default CI: both grep + units gates against tracked files |
+| `check.sh --grep-only` | Banned identity literals only (faster, used in pre-02-02 CI) |
+| `check.sh --units-only` | Banned systemd unit basenames only |
+| `check.sh --scan-dir DIR` | Scan DIR via `find` instead of `git ls-files`; allow-list ignored |
+
+Flags `--grep-only` and `--units-only` may also be combined with `--scan-dir`.
+
+## Phase 6 reuse contract
+
+```bash
+bash scripts/sanitize/check.sh --scan-dir /mnt/img/etc/systemd/system
+```
+
+Runs both grep and units gates against the assembled rootfs before pi-gen finalizes the `.img`. The `.sanitize-allowlist` is intentionally ignored in `--scan-dir` mode — the allow-list is a tracked-files concept, not an image-content concept.
+
+## Current main: zero unit-name-block hits
+
+`bash scripts/sanitize/check.sh --units-only` exits 0. The three tracked unit files are:
+
+- `.planning/phases/01-runtime-extraction/test-units/arlowe-dashboard-test.service`
+- `.planning/phases/01-runtime-extraction/test-units/arlowe-face-test.service`
+- `.planning/phases/01-runtime-extraction/test-units/arlowe-voice-test.service`
+
+All use the `arlowe-*` prefix — none match any banned pattern. Founder-only units (`openclaw-*`, `trace-*`, `workforce-metrics-snapshot.*`) live in gitignored `.dev-stash/` and do not appear in `git ls-files`.
+
+## What's next
+
+- **Plan 03** (issue #56): dashboard rendered-text gate — Playwright spec at `runtime/dashboard/tests/sanitize.spec.ts`
+- **Plan 04** (issue #57): SC4 runtime/ cleanup — make `bash scripts/sanitize/check.sh` exit 0 end-to-end (grep gate currently exits 1 on `runtime/` literals; Plan 04 owns fixing that)

--- a/scripts/sanitize/check.sh
+++ b/scripts/sanitize/check.sh
@@ -1,20 +1,19 @@
 #!/usr/bin/env bash
 # scripts/sanitize/check.sh
 #
-# Grep gate: scans tracked, non-allow-listed files for banned identity literals.
-# Emits GitHub Actions error annotations on hits; exits non-zero if any found.
+# Sanitization gate runner.
 #
-# Flags:
-#   --grep-only   Run the banlist scan (default behavior in Plan 01).
-#   --units-only  Placeholder for Plan 02 unit-name block (exits 0 with a note).
-#   --scan-dir DIR  (reserved for Plan 06 image-build hook; not yet implemented)
+# Modes:
+#   check.sh                Run grep + units gates against tracked files (default for CI).
+#   check.sh --grep-only    Run only the banned-literal grep gate.
+#   check.sh --units-only   Run only the banned-unit-name gate.
+#   check.sh --scan-dir DIR Scan DIR via `find` instead of `git ls-files`.
+#                           Use case: Phase 6 image-build, scanning the assembled
+#                           rootfs at /mnt/img/ before pi-gen finalizes the .img.
+#                           NOTE: .sanitize-allowlist is ignored in --scan-dir mode.
+#                           Can be combined with --grep-only or --units-only.
 #
-# No flag defaults to --grep-only. When Plan 02 lands, no-flag will run both gates.
-#
-# Exit codes:
-#   0  clean — no banned literals found
-#   1  banned literal detected in at least one tracked file
-#   2  tool dependency missing (e.g., ripgrep not installed)
+# Exit codes: 0 clean, 1 hits found, 2 invalid arguments.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -24,73 +23,174 @@ cd "$REPO_ROOT"
 BANLIST="$SCRIPT_DIR/banlist.txt"
 ALLOWLIST=".sanitize-allowlist"
 
-MODE="grep-only"
+MODE="both"
+SCAN_DIR=""
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --grep-only)  MODE="grep-only" ; shift ;;
-    --units-only) MODE="units-only"; shift ;;
-    --scan-dir)
-      echo "check.sh: --scan-dir not implemented yet; landing in plan 06" >&2
-      exit 0
+    --grep-only)
+      if [[ "$MODE" == "units-only" ]]; then
+        echo "check.sh: --grep-only and --units-only are mutually exclusive" >&2
+        exit 2
+      fi
+      MODE="grep-only"
+      shift
       ;;
-    *) echo "check.sh: unknown flag: $1" >&2; exit 1 ;;
+    --units-only)
+      if [[ "$MODE" == "grep-only" ]]; then
+        echo "check.sh: --grep-only and --units-only are mutually exclusive" >&2
+        exit 2
+      fi
+      MODE="units-only"
+      shift
+      ;;
+    --scan-dir)
+      if [[ $# -lt 2 ]]; then
+        echo "check.sh: --scan-dir requires a directory argument" >&2
+        exit 2
+      fi
+      SCAN_DIR="$2"
+      shift 2
+      ;;
+    *)
+      echo "check.sh: unknown flag: $1" >&2
+      exit 2
+      ;;
   esac
 done
 
-if [[ "$MODE" == "units-only" ]]; then
-  echo "check.sh: units gate not implemented in plan 01; landing in plan 02" >&2
-  exit 0
+# ---------------------------------------------------------------------------
+# Grep gate
+# ---------------------------------------------------------------------------
+
+run_grep_gate() {
+  command -v rg >/dev/null 2>&1 || { echo "check.sh: rg not found; install ripgrep" >&2; exit 2; }
+
+  local files=()
+  if [[ -n "$SCAN_DIR" ]]; then
+    # --scan-dir mode: enumerate all files under DIR; allow-list does not apply.
+    while IFS= read -r f; do
+      files+=("$f")
+    done < <(find "$SCAN_DIR" -type f)
+  else
+    # tracked-files mode: apply allow-list exclusions.
+    local pathspecs=()
+    if [[ -f "$ALLOWLIST" ]]; then
+      while IFS= read -r line; do
+        line="${line%%#*}"                          # strip inline comments
+        line="${line#"${line%%[![:space:]]*}"}"     # ltrim
+        line="${line%"${line##*[![:space:]]}"}"     # rtrim
+        [[ -z "$line" ]] && continue
+        pathspecs+=(":(exclude,glob)$line")
+      done < "$ALLOWLIST"
+    fi
+    while IFS= read -r f; do
+      files+=("$f")
+    done < <(git ls-files -- "${pathspecs[@]+${pathspecs[@]}}")
+  fi
+
+  if [[ ${#files[@]} -eq 0 ]]; then
+    echo "sanitize grep: clean (0 files scanned)"
+    return 0
+  fi
+
+  # rg exits 1 on no-matches; || true keeps pipefail happy.
+  # -H forces filename even for single-file scans (no-heading alone omits it).
+  local hits
+  hits=$(rg -iFnH --column --no-heading -f "$BANLIST" -- "${files[@]}" || true)
+
+  if [[ -z "$hits" ]]; then
+    echo "sanitize grep: clean (${#files[@]} files scanned)"
+    return 0
+  fi
+
+  local exit_code=0
+  while IFS= read -r hit; do
+    [[ -z "$hit" ]] && continue
+    # rg -n --column output: path:line:col:matched-text
+    IFS=: read -r path line col rest <<< "$hit"
+    printf '::error file=%s,line=%s,col=%s,title=Banned identity literal::banned identity literal at %s:%s:%s — if this is a legitimate historical reference, add the path to .sanitize-allowlist\n' \
+      "$path" "$line" "$col" "$path" "$line" "$col"
+    printf '%s:%s:%s: %s\n' "$path" "$line" "$col" "$rest" >&2
+    exit_code=1
+  done <<< "$hits"
+
+  return "$exit_code"
+}
+
+# ---------------------------------------------------------------------------
+# Units gate
+# ---------------------------------------------------------------------------
+
+run_units_gate() {
+  local units=()
+  if [[ -n "$SCAN_DIR" ]]; then
+    while IFS= read -r u; do
+      units+=("$u")
+    done < <(find "$SCAN_DIR" -type f \
+      \( -name '*.service' -o -name '*.timer' -o -name '*.socket' \
+         -o -name '*.target' -o -name '*.mount' -o -name '*.path' \))
+  else
+    while IFS= read -r u; do
+      units+=("$u")
+    done < <(git ls-files \
+      -- '*.service' '*.timer' '*.socket' '*.target' '*.mount' '*.path')
+  fi
+
+  if [[ ${#units[@]} -eq 0 ]]; then
+    echo "sanitize units: clean (0 unit files found)"
+    return 0
+  fi
+
+  local exit_code=0
+  while IFS= read -r prefix; do
+    prefix="${prefix%%#*}"                        # strip inline comments
+    prefix="${prefix#"${prefix%%[![:space:]]*}"}" # ltrim
+    prefix="${prefix%"${prefix##*[![:space:]]}"}" # rtrim
+    [[ -z "$prefix" ]] && continue
+    for unit in "${units[@]+${units[@]}}"; do
+      local base
+      base="$(basename "$unit")"
+      # Unquoted RHS triggers bash glob matching — the 3 prefixes are bash globs.
+      if [[ "$base" == $prefix ]]; then
+        printf '::error file=%s,line=1,title=Banned systemd unit::banned systemd unit name %s (matches pattern %s); founder-only service must not ship in firmware\n' \
+          "$unit" "$base" "$prefix"
+        printf '%s: banned unit basename (matches %s)\n' "$unit" "$prefix" >&2
+        exit_code=1
+      fi
+    done
+  done < "$SCRIPT_DIR/unit-prefixes.txt"
+
+  if [[ "$exit_code" -eq 0 ]]; then
+    echo "sanitize units: clean (${#units[@]} unit files checked)"
+  fi
+
+  return "$exit_code"
+}
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+GREP_EXIT=0
+UNITS_EXIT=0
+
+case "$MODE" in
+  grep-only)
+    run_grep_gate || GREP_EXIT=$?
+    ;;
+  units-only)
+    run_units_gate || UNITS_EXIT=$?
+    ;;
+  both)
+    echo "--- grep gate ---"
+    run_grep_gate  || GREP_EXIT=$?
+    echo "--- units gate ---"
+    run_units_gate || UNITS_EXIT=$?
+    ;;
+esac
+
+if [[ $((GREP_EXIT | UNITS_EXIT)) -ne 0 ]]; then
+  exit 1
 fi
-
-# --- grep-only mode ---
-
-command -v rg >/dev/null 2>&1 || { echo "check.sh: rg not found; install ripgrep" >&2; exit 2; }
-
-# Build a pathspec array from .sanitize-allowlist (gitignore-style globs).
-# git ls-files honors :(exclude,glob) pathspecs with gitignore semantics.
-PATHSPECS=()
-if [[ -f "$ALLOWLIST" ]]; then
-  while IFS= read -r line; do
-    line="${line%%#*}"                            # strip inline comments
-    line="${line#"${line%%[![:space:]]*}"}"       # ltrim
-    line="${line%"${line##*[![:space:]]}"}"       # rtrim
-    [[ -z "$line" ]] && continue
-    PATHSPECS+=(":(exclude,glob)$line")
-  done < "$ALLOWLIST"
-fi
-
-# Enumerate tracked, non-allow-listed files.
-# Use a while-read loop instead of mapfile for bash 3.x compatibility (macOS dev).
-FILES=()
-while IFS= read -r f; do
-  FILES+=("$f")
-done < <(git ls-files -- "${PATHSPECS[@]+${PATHSPECS[@]}}")
-
-if [[ ${#FILES[@]} -eq 0 ]]; then
-  echo "sanitize: clean (0 tracked files scanned after allow-list)"
-  exit 0
-fi
-
-# Scan for banned literals. rg exits 1 on no-matches; || true keeps pipefail happy.
-# -H forces filename in output even when only one file is scanned (no-heading alone
-# omits the filename for single-file runs, breaking the path:line:col:text parse).
-HITS=$(rg -iFnH --column --no-heading -f "$BANLIST" -- "${FILES[@]}" || true)
-
-if [[ -z "$HITS" ]]; then
-  echo "sanitize: clean (${#FILES[@]} tracked files scanned)"
-  exit 0
-fi
-
-# Emit GitHub annotations and human-readable output for each hit.
-EXIT=0
-while IFS= read -r hit; do
-  [[ -z "$hit" ]] && continue
-  # rg -n --column output: path:line:col:matched-text
-  IFS=: read -r path line col rest <<< "$hit"
-  printf '::error file=%s,line=%s,col=%s,title=Banned identity literal::banned identity literal at %s:%s:%s — if this is a legitimate historical reference, add the path to .sanitize-allowlist\n' \
-    "$path" "$line" "$col" "$path" "$line" "$col"
-  printf '%s:%s:%s: %s\n' "$path" "$line" "$col" "$rest" >&2
-  EXIT=1
-done <<< "$HITS"
-
-exit "$EXIT"
+exit 0

--- a/scripts/sanitize/test-check.sh
+++ b/scripts/sanitize/test-check.sh
@@ -1,28 +1,28 @@
 #!/usr/bin/env bash
 # scripts/sanitize/test-check.sh
 #
-# Self-test: plants a banned literal in a temp git tree and asserts check.sh exits non-zero.
-# This file is in .sanitize-allowlist so the literal below doesn't trip the production gate.
+# Self-test: plants banned artifacts in temp trees and asserts check.sh catches them.
+# This file is in .sanitize-allowlist so the literals below don't trip the production gate.
 set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
-TMP=$(mktemp -d)
-trap 'rm -rf "$TMP"' EXIT
+# ---------------------------------------------------------------------------
+# Scenario 1: planted banned literal — grep gate catches it
+# ---------------------------------------------------------------------------
 
-# Create a minimal git tree in the temp dir with a planted banned literal.
+TMP=$(mktemp -d)
+TMP2=$(mktemp -d)
+trap 'rm -rf "$TMP" "$TMP2"' EXIT
+
 git -C "$TMP" init -q
 echo "user: focal55" > "$TMP/planted.txt"
 git -C "$TMP" add .
 git -C "$TMP" -c user.email=t@t -c user.name=t commit -qm test
 
-# Copy banlist and an effectively-empty allow-list into the temp tree.
-# The real allow-list globs don't match any paths in this temp tree, so no
-# exclusions apply — the gate must catch the planted literal.
 cp "$REPO_ROOT/scripts/sanitize/banlist.txt" "$TMP/"
 touch "$TMP/.sanitize-allowlist"
 
-# Run the gate against the temp tree; capture exit code without triggering set -e.
 EXIT_CODE=0
 if (cd "$TMP" && bash "$REPO_ROOT/scripts/sanitize/check.sh" --grep-only); then
   EXIT_CODE=0
@@ -31,9 +31,55 @@ else
 fi
 
 if [[ "$EXIT_CODE" -eq 0 ]]; then
-  echo "FAIL: gate did not catch planted focal55" >&2
+  echo "FAIL: grep gate did not catch planted focal55" >&2
   exit 1
 fi
 
-echo "PASS: gate correctly blocked planted focal55"
+echo "PASS: grep gate correctly blocked planted focal55"
+
+# ---------------------------------------------------------------------------
+# Scenario 2: planted openclaw unit — units gate catches it, clean unit passes
+# ---------------------------------------------------------------------------
+
+touch "$TMP2/openclaw-test.service"
+touch "$TMP2/safe-unit.service"
+
+UNIT_OUT=$(bash "$REPO_ROOT/scripts/sanitize/check.sh" --units-only --scan-dir "$TMP2" 2>&1 || true)
+UNIT_EXIT=0
+bash "$REPO_ROOT/scripts/sanitize/check.sh" --units-only --scan-dir "$TMP2" >/dev/null 2>&1 || UNIT_EXIT=$?
+
+if [[ "$UNIT_EXIT" -eq 0 ]]; then
+  echo "FAIL: units gate did not catch planted openclaw-test.service" >&2
+  exit 1
+fi
+
+if ! echo "$UNIT_OUT" | grep -q "openclaw-test.service"; then
+  echo "FAIL: units gate output did not mention openclaw-test.service" >&2
+  echo "  output was: $UNIT_OUT" >&2
+  exit 1
+fi
+
+if echo "$UNIT_OUT" | grep -q "safe-unit.service"; then
+  echo "FAIL: units gate output incorrectly flagged safe-unit.service" >&2
+  echo "  output was: $UNIT_OUT" >&2
+  exit 1
+fi
+
+echo "PASS: gate correctly blocked planted openclaw-test.service while allowing safe-unit.service"
+
+# ---------------------------------------------------------------------------
+# Scenario 3: --scan-dir honors the grep gate (Phase 6 reuse contract)
+# ---------------------------------------------------------------------------
+
+echo "user: focal55" > "$TMP2/leaked-config.txt"
+
+GREP_EXIT=0
+bash "$REPO_ROOT/scripts/sanitize/check.sh" --grep-only --scan-dir "$TMP2" >/dev/null 2>&1 || GREP_EXIT=$?
+
+if [[ "$GREP_EXIT" -eq 0 ]]; then
+  echo "FAIL: grep gate with --scan-dir did not catch planted focal55 literal" >&2
+  exit 1
+fi
+
+echo "PASS: grep gate with --scan-dir correctly blocked planted focal55 literal"
 exit 0

--- a/scripts/sanitize/unit-prefixes.txt
+++ b/scripts/sanitize/unit-prefixes.txt
@@ -1,0 +1,3 @@
+openclaw-*
+trace-*
+workforce-metrics-snapshot.*


### PR DESCRIPTION
## Summary

Extends the sanitization gate runner from Plan 01 with the systemd unit-name block and the Phase 6 image-build reuse hook.

### What changed

**scripts/sanitize/unit-prefixes.txt** (new) — 3 banned unit-name patterns:
- `openclaw-*`
- `trace-*`
- `workforce-metrics-snapshot.*`

**scripts/sanitize/check.sh** — replaces Plan 01 stubs with real implementation:
- `--units-only`: basename glob-match against all tracked `*.service|timer|socket|target|mount|path` files via `git ls-files`, or `find DIR` when `--scan-dir` is set
- `--scan-dir DIR`: switches enumeration from `git ls-files` to `find DIR -type f` for both gates; allow-list ignored in this mode (Phase 6 reuse contract)
- No-flag invocation runs both gates back-to-back, OR-ing exit codes; gate outputs separated by `--- grep gate ---` / `--- units gate ---` headers
- Invalid flag combos (`--grep-only --units-only`) exit 2; unknown flags exit 2
- Header comment documents all four invocation modes including the Phase 6 reuse contract

**scripts/sanitize/test-check.sh** — adds 2 new scenarios (3 PASS lines total):
1. Planted `openclaw-test.service` + `safe-unit.service` via `--units-only --scan-dir`; asserts gate catches banned prefix, passes clean unit
2. Planted `focal55` literal via `--grep-only --scan-dir`; proves grep gate reuse contract

**.github/workflows/sanitize.yml** — `banlist-and-units` job now invokes `check.sh` with no flag (runs both gates); top comment updated to Phase 2 / Plan 02 state.

**.planning/phases/02-sanitization-gate/02-02-SUMMARY.md** (new) — per-plan output artifact.

### Verification

All plan-level verification steps pass locally:
- `bash scripts/sanitize/test-check.sh` exits 0 with three `PASS:` lines
- `bash scripts/sanitize/check.sh --units-only` exits 0 (3 tracked `arlowe-*` units, none matching banned patterns)
- `bash scripts/sanitize/check.sh --grep-only` still exits non-zero on dirty tree (Plan 04 / issue #57 owns runtime/ cleanup)
- Phase 6 reuse contract: `check.sh --scan-dir TMP` catches both grep and unit violations in a planted temp dir

Closes #55

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)