### PR TITLE
feat(sanitize): plan 02-03 — Playwright dashboard rendered-text gate

### DIFF
--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -5,9 +5,14 @@ name: Sanitize
 # would stay in "Expected — Waiting for status" forever, blocking merge.
 # The full scan takes ~2s on the current tree; path-gating is not worth the risk.
 #
-# To promote this to a required check: Settings → Branches → branch protection rule
-# → "Require status checks to pass" → add "Banlist + unit-name block" and
-# "Gate self-test". Do this AFTER the workflow has run green on a few PRs.
+# Three gates:
+#   banlist-and-units      — grep gate + systemd unit-name block (Plans 01–02)
+#   self-test              — deliberate-failure cases for the bash gates
+#   dashboard-rendered-text — Playwright rendered-HTML scan (Plan 03)
+#
+# To promote to required checks: Settings → Branches → branch protection rule
+# → "Require status checks to pass" → add job names. Do this AFTER the workflow
+# has run green on a few PRs.
 
 on:
   pull_request:
@@ -41,3 +46,30 @@ jobs:
         run: sudo apt-get install -y ripgrep
       - name: Run deliberate-failure self-test
         run: bash scripts/sanitize/test-check.sh
+
+  dashboard-rendered-text:
+    name: Dashboard rendered-text gate
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: runtime/dashboard
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+          cache-dependency-path: runtime/dashboard/pnpm-lock.yaml
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Install Playwright chromium
+        run: pnpm exec playwright install --with-deps chromium
+      - name: Build dashboard
+        run: pnpm build
+      - name: Run sanitize spec
+        run: pnpm exec playwright test tests/sanitize.spec.ts --project=chromium
+        env:
+          CI: 'true'

--- a/.planning/phases/02-sanitization-gate/02-03-SUMMARY.md
+++ b/.planning/phases/02-sanitization-gate/02-03-SUMMARY.md
@@ -1,0 +1,54 @@
+---
+phase: 02-sanitization-gate
+plan: 03
+type: summary
+status: complete
+branch: feat/sanitize-02-03-dashboard-gate
+---
+
+# Plan 02-03 Summary: Playwright Dashboard Rendered-Text Gate
+
+## What was shipped
+
+Three files changed:
+
+- `runtime/dashboard/tests/sanitize.spec.ts` (new, ~80 LOC)
+- `runtime/dashboard/playwright.config.ts` (small edit)
+- `.github/workflows/sanitize.yml` (new job, ~30 lines)
+
+## Route enumeration approach
+
+`enumerateRoutes(appDir)` walks `runtime/dashboard/app/` recursively using `fs.readdirSync` and `fs.statSync`. Rules:
+
+- Skips `api/` (API routes — no rendered HTML) and directories starting with `_` (Next App Router private folders).
+- Route groups `(name)` are transparent — they do not add a URL segment.
+- Dynamic segments `[param]` get a synthetic `test` placeholder so the route is visitable. No dynamic segments exist today but handling is included to prevent silent skipping if one is added later.
+- Root `app/page.tsx` maps to `/`.
+- Returns a deduplicated array.
+
+Discovered routes on current tree: `/`, `/connectivity`, `/logs`, `/npu`.
+
+## `page.content()` vs `textContent()` choice
+
+`page.content()` returns the full rendered HTML including `<head>`. This catches literals in `<meta name="description">`, `<title>`, and `alt` attributes — surfaces that `page.textContent('body')` would miss. Per CONTEXT.md: "text content only — `page.content()` (rendered HTML)."
+
+## `waitUntil: 'load'` + `waitForTimeout(1500)` over `networkidle`
+
+`networkidle` is flaky against an unconfigured backend: dashboard pages make `useEffect`-driven fetches to `/api/*` routes that return errors, and the network never fully settles. Per RESEARCH Pitfall 5. A 1500ms fixed wait lets second-render content (including error states) be included in the scan. Error states are valid render targets per CONTEXT.md.
+
+## Expected failure baseline (Plan 04 closes this)
+
+The spec currently FAILS on the main tree. Two sources of leakage:
+
+1. `runtime/dashboard/app/layout.tsx:11` — `description: "Control panel for Arlowe-1"` renders into `<meta name="description" content="Control panel for Arlowe-1">` on every route. Trips the `arlowe-1` banlist entry.
+2. `runtime/dashboard/app/components/RetroActivityMonitor.tsx` — renders `ARLOWE-1 SYSTEM MONITOR` in visible text. Trips on every route that includes the sidebar/header.
+
+All 4 routes (`/`, `/connectivity`, `/logs`, `/npu`) fail on the `arlowe-1` literal. Plan 04 cleans these runtime/ references.
+
+## DASH-06 partial coverage
+
+`page.content()` catches any href whose URL string contains a banlist literal (e.g., a link to `https://focal55.local/admin` trips the gate because `focal55` appears in the rendered HTML attribute value). Arbitrary workforce-internal hrefs that do not contain a banlist literal are not covered. Per CONTEXT.md deferred-ideas: enumerating all workforce-internal URL prefixes is out of scope for Phase 2. Defense-in-depth for that class relies on PR review until a future phase introduces an explicit href allow-list. Known, deliberate gap.
+
+## Pointer to Plan 04
+
+Plan 04 (`#57`) cleans the `runtime/` tree references that cause the current expected failures. Once merged, all 4 routes should pass the rendered-text gate.

--- a/runtime/dashboard/playwright.config.ts
+++ b/runtime/dashboard/playwright.config.ts
@@ -83,11 +83,14 @@ export default defineConfig({
     // },
   ],
 
-  /* Run the Next.js production server before starting the tests */
+  /* Run the Next.js production server before starting the tests.
+   * `pnpm build` is required because `next start` needs .next/ artifacts to exist.
+   * Without it, starting the server on a fresh checkout fails with
+   * "Could not find a production build in the .next directory." */
   webServer: {
-    command: 'pnpm start -p 3000',
+    command: 'pnpm build && pnpm start -p 3000',
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
-    timeout: 120000,
+    timeout: 180000,
   },
 });

--- a/runtime/dashboard/tests/sanitize.spec.ts
+++ b/runtime/dashboard/tests/sanitize.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from "@playwright/test";
+import fs from "node:fs";
+import path from "node:path";
+
+// Walk app/ for directories containing page.tsx, convert each to a URL path.
+// Skips:
+//   - api/ directories (API routes, no rendered HTML)
+//   - directories starting with _ (Next App Router private folders)
+// Route groups: (name) folders are transparent — they do not add a URL segment.
+// Dynamic segments: [param] folders get a synthetic "test" value so the route
+// is visitable. No dynamic segments exist in the dashboard today, but this
+// prevents silent route-skipping if one is added later.
+function enumerateRoutes(appDir: string): string[] {
+  const routes: string[] = [];
+
+  function walk(dir: string, urlSegments: string[]) {
+    for (const entry of fs.readdirSync(dir)) {
+      const full = path.join(dir, entry);
+      if (!fs.statSync(full).isDirectory()) continue;
+      if (entry === "api" || entry.startsWith("_")) continue;
+
+      let nextSegments: string[];
+      if (entry.startsWith("(") && entry.endsWith(")")) {
+        // Route group — transparent to URL
+        nextSegments = urlSegments;
+      } else if (entry.startsWith("[") && entry.endsWith("]")) {
+        // Dynamic segment — substitute synthetic placeholder
+        nextSegments = [...urlSegments, "test"];
+      } else {
+        nextSegments = [...urlSegments, entry];
+      }
+
+      try {
+        fs.statSync(path.join(full, "page.tsx"));
+        routes.push("/" + nextSegments.join("/"));
+      } catch {
+        // no page.tsx in this directory — keep walking
+      }
+
+      walk(full, nextSegments);
+    }
+  }
+
+  // Root page.tsx → '/'
+  try {
+    fs.statSync(path.join(appDir, "page.tsx"));
+    routes.push("/");
+  } catch {
+    // no root page.tsx
+  }
+
+  walk(appDir, []);
+  return [...new Set(routes)];
+}
+
+const APP_DIR = path.join(__dirname, "..", "app");
+const ROUTES = enumerateRoutes(APP_DIR);
+
+// Mirrors scripts/sanitize/banlist.txt — canonical source is that file.
+// Any addition to banlist.txt MUST be mirrored here until a future refactor
+// unifies them into a single source of truth.
+const BANLIST = [
+  "focal55",
+  "arlowe-1",
+  "casa_ybarra_chelsea",
+  "/home/focal55",
+  "joe@focal55",
+  "iol-monorepo",
+];
+
+test.describe("sanitization: no founder literals in rendered HTML", () => {
+  for (const route of ROUTES) {
+    test(`route ${route} contains no banned literal`, async ({ page }) => {
+      await page.goto(route, { waitUntil: "load" });
+      // waitForTimeout instead of networkidle: networkidle is flaky against an
+      // unconfigured backend (API routes return errors, never fully settle).
+      // A short fixed wait lets useEffect-driven fetches resolve so second-render
+      // content is included. Error states are valid render targets per CONTEXT.md.
+      await page.waitForTimeout(1500);
+      const html = (await page.content()).toLowerCase();
+      for (const literal of BANLIST) {
+        expect(
+          html.includes(literal.toLowerCase()),
+          `route ${route} rendered HTML contains banned literal "${literal}" — search /api response shapes and config defaults`,
+        ).toBe(false);
+      }
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Adds the third sanitization gate: a Playwright spec that boots the dashboard, visits every auto-discovered page route, and asserts none of the 6 banned identity literals appear in `page.content()` (rendered HTML, including `<meta>`, `<title>`, alt attrs).

Closes #56

## What changed

**`runtime/dashboard/tests/sanitize.spec.ts`** (new, ~80 LOC)
- `enumerateRoutes(appDir)` walks `app/` recursively via `fs.readdirSync`, skips `api/` and `_*` dirs, treats `(group)` as URL-transparent, substitutes `test` for `[dynamic]` segments
- Hardcoded `BANLIST` mirrors `scripts/sanitize/banlist.txt` with comment pointing to canonical source
- One `test()` per route, uses `page.goto(route, { waitUntil: 'load' })` + `waitForTimeout(1500)` (not `networkidle` — flaky against unconfigured backend per RESEARCH Pitfall 5)
- Asserts `page.content().toLowerCase()` does not include each literal

**`runtime/dashboard/playwright.config.ts`**
- `webServer.command`: `'pnpm start -p 3000'` → `'pnpm build && pnpm start -p 3000'`
- `webServer.timeout`: 120000 → 180000

**`.github/workflows/sanitize.yml`**
- New `dashboard-rendered-text` job: pnpm v9 + node 20, frozen lockfile install, chromium only (`playwright install --with-deps chromium`), explicit `pnpm build` step, runs `tests/sanitize.spec.ts --project=chromium`
- Top comment updated to reflect 3 gates
- No `paths:` filter (Plan 01 design preserved)

## CI expectations

- `dashboard-rendered-text` job **FAILS** — this is expected and is the proof the gate works. `layout.tsx:11` leaks `arlowe-1` into `<meta name="description">` on every route. Plan 04 (#57) cleans the runtime/ references.
- `banlist-and-units` may also fail (Plan 04 scope).
- `self-test` should remain green.

## Verification run locally

```
cd runtime/dashboard && pnpm exec tsc --noEmit          # exits 0
pnpm exec playwright test tests/sanitize.spec.ts --list  # lists 4 routes
python3 -c "import yaml; d=yaml.safe_load(open('.github/workflows/sanitize.yml')); print(list(d['jobs'].keys()))"
# ['banlist-and-units', 'self-test', 'dashboard-rendered-text']
```

## Out of scope

- Cleaning dashboard runtime/ literals (Plan 04 / #57)
- Mocking `/api/*` routes (CONTEXT: error states valid)
- Arbitrary workforce-internal href blocking (DASH-06 partial coverage; deferred per CONTEXT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)