### PR TITLE
feat(sanitize): SC4 runtime/ cleanup + F5 ADR-0001 fix

### DIFF
--- a/.planning/phases/02-sanitization-gate/02-04-SUMMARY.md
+++ b/.planning/phases/02-sanitization-gate/02-04-SUMMARY.md
@@ -1,0 +1,145 @@
+---
+phase: 02-sanitization-gate
+plan: 04
+type: summary
+status: complete
+---
+
+# Plan 02-04 Summary — runtime/ SC4 cleanup + F5 ADR-0001 fix
+
+## Disposition matrix applied
+
+| File | Decision | Notes |
+|------|----------|-------|
+| `runtime/llm/router.py:35` | Sanitized | `/home/focal55/ax-llm/docs/http_api.md` → `ax-llm's docs/http_api.md (vendored at third_party/ax-llm/)` |
+| `runtime/llm/run_api.sh:6` | Sanitized | `smoke test on arlowe-1` → `smoke-testing on a Pi 5 dev unit with the AX accelerator` |
+| `runtime/dashboard/app/layout.tsx:11` | Sanitized | `"Control panel for Arlowe-1"` → `"Control panel for your Arlowe device"` |
+| `runtime/dashboard/app/components/RetroActivityMonitor.tsx:140` | Sanitized | `ARLOWE-1 SYSTEM MONITOR` → `ARLOWE SYSTEM MONITOR` |
+| `runtime/dashboard/README.md:61` | Sanitized | Section header `Running locally on arlowe-1` → `Running locally on a Pi 5 dev unit` |
+| `runtime/face/README.md:37,43,59` | Sanitized | 3 occurrences: driver path prose, broken-endpoint note, section header |
+| `runtime/llm/README.md:52` | Sanitized | Smoke-test env-override note |
+| `runtime/stt/README.md:39` | Sanitized | Section header |
+| `runtime/tts/README.md:64,68,76,79,99` | Sanitized | 5 occurrences: PyYAML venv note, ssh command, smoke-test note, section header, PLAY_DEVICE known limitation |
+| `runtime/voice/README.md:23` | Sanitized | Section header |
+| `runtime/wake-word/README.md:91-97` | Sanitized | Both `iol-monorepo` and `arlowe-1` in one paragraph; rewritten to generic post-extraction architectural note |
+| `runtime/*/requirements.txt` (6 files) | Allow-listed | Dev-pinning provenance comments; audit-trail metadata, never renders or ships as a service |
+| `runtime/tts/manifest.yml` | Allow-listed | Same reasoning — SHA-256 verification provenance |
+| `runtime/dashboard/tests/sanitize.spec.ts` | Allow-listed | Gate test file; contains banned literals as test data by design |
+| `docs/architecture/0001-iol-router-extraction.md` | Sanitized (F5 fix) | "Why option-2" bullet rewritten to match resolved decision |
+
+No deviations from the plan's disposition matrix.
+
+## F5 fix landed
+
+- `docs/architecture/0001-iol-router-extraction.md` "Verified working live" bullet rewritten: removed false assertion that ax-llm speaks OpenAI `/v1/chat/completions`; replaced with accurate curl against `/api/chat` returning `{done, message}` and explanation of the PR #52 drift.
+- F5 todo moved from `.planning/todos/pending/` to `.planning/todos/done/` with closure note appended.
+- `STATE.md` did not list F5 (it was captured as an untracked file, never committed to STATE); no STATE.md edit needed.
+
+## Phase-exit criteria verification
+
+All four ROADMAP SC criteria met:
+
+**SC1 — Grep gate wired and exercised:**
+```
+bash scripts/sanitize/check.sh --grep-only
+# sanitize grep: clean (119 files scanned) — exit 0
+```
+
+**SC2 — Unit-name block wired and exercised:**
+```
+bash scripts/sanitize/check.sh --units-only
+# sanitize units: clean (3 unit files checked) — exit 0
+```
+
+**SC3 — Dashboard rendered-text gate wired and exercised:**
+```
+cd runtime/dashboard && pnpm exec playwright test sanitize.spec.ts --project=chromium
+# 4 passed (25.3s) — exit 0
+```
+All four routes pass: `/`, `/connectivity`, `/logs`, `/npu`.
+
+**SC4 — runtime/ tree zero banned literals outside allow-list:**
+```
+bash scripts/sanitize/check.sh
+# --- grep gate ---
+# sanitize grep: clean (119 files scanned)
+# --- units gate ---
+# sanitize units: clean (3 unit files checked)
+```
+
+Self-test still passes all 3 PASS lines:
+```
+bash scripts/sanitize/test-check.sh
+# PASS: grep gate correctly blocked planted focal55
+# PASS: gate correctly blocked planted openclaw-test.service while allowing safe-unit.service
+# PASS: grep gate with --scan-dir correctly blocked planted focal55 literal
+```
+
+## Final .sanitize-allowlist contents
+
+```
+# .sanitize-allowlist
+# Path globs (gitignore-style) of tracked files allowed to contain banned identity literals.
+# Single `*` does NOT cross `/`; use `**` for recursive matching.
+# If you're tempted to add a new entry, ask: does this file ship in the firmware image?
+# If yes, fix the literal instead of allow-listing.
+
+# Planning artifacts that document banned literals as part of their purpose.
+.planning/**
+
+# Architecture decision records and operational docs that capture historical state.
+docs/architecture/**
+docs/architecture-overview.md
+docs/operations/phase-1-smoke-test.md
+
+# Journey entries (workforce diary; never ships in firmware).
+docs/journey/**
+
+# Workforce / template plumbing — references @focal55 the GitHub username, not founder
+# identity in the firmware sense. None of these files ship in the image.
+.github/CODEOWNERS
+.github/ISSUE_TEMPLATE/config.yml
+AGENTS.md.template
+README.md
+
+# Dev pull script: references arlowe-1 because that's the dev unit it pulls from.
+scripts/dev-pull-from-pi.sh
+
+# Third-party distribution paperwork.
+third_party/axcl/DISTRIBUTION-RIGHTS.md
+third_party/axcl/INSTALL.md
+third_party/whisplay-driver/PROVENANCE.md
+
+# Sanitize gate self-references (the data files contain the literals by design).
+.sanitize-allowlist
+scripts/sanitize/banlist.txt
+scripts/sanitize/unit-prefixes.txt
+scripts/sanitize/test-check.sh
+runtime/dashboard/tests/sanitize.spec.ts
+
+# --- Dev-pinning provenance allow-list (Plan 04 SC4 cleanup) ---
+# The runtime/*/requirements.txt comments record which dev unit the pins were
+# captured from and when. These are audit-trail metadata that never render as
+# user-facing strings and never ship as a service. Rewriting them loses real
+# provenance value (we'd no longer know which Pi the pins are calibrated against).
+# Decision rationale: 02-04-PLAN.md disposition matrix.
+runtime/voice/requirements.txt
+runtime/face/requirements.txt
+runtime/stt/requirements.txt
+runtime/tts/requirements.txt
+runtime/llm/requirements.txt
+runtime/wake-word/requirements.txt
+
+# Same reasoning: tts/manifest.yml's SHA-256-verified-on comments are provenance.
+runtime/tts/manifest.yml
+```
+
+## Provenance phrasing notes for future authors
+
+- `runtime/tts/README.md:68` — the `ssh <your-dev-pi>` angle-bracket placeholder is intentional; it matches the convention used for operator docs where the command is device-specific.
+- `runtime/wake-word/README.md:91-97` — the original paragraph named both the source monorepo and the dev hostname in a single sentence. The replacement drops both proper nouns and preserves only the architectural point (pre-extraction copy vs. canonical post-extraction tree). No cross-links existed to the old section header.
+- `runtime/dashboard/tests/sanitize.spec.ts` — the test file contains banned literals as its test-data array. Allow-listing it is the correct call; the gate script validates rendered output, not the test file itself.
+
+## Phase 2 closure note
+
+This is the last plan in Phase 2 (sanitization gate). Plans 01-04 are complete. The next step is `/gsd:verify-work` against Phase 2's SC1-SC4 success criteria. All three sanitize CI jobs (banlist-and-units, self-test, dashboard-rendered-text) are expected to go GREEN on this PR, completing Phase 2.

--- a/.planning/todos/done/F5-adr-0001-why-option-2-internal-contradiction.md
+++ b/.planning/todos/done/F5-adr-0001-why-option-2-internal-contradiction.md
@@ -1,0 +1,49 @@
+# F5 — ADR-0001 "Why option-2" bullet list contradicts the decision
+
+**Origin:** PR-Reviewer pass on PR #53 (2026-05-24) flagged this as a blocker; PR was merged anyway as it ships docs-only and the contradiction is self-contained to the rationale section. Capturing here so it doesn't get forgotten.
+
+**Target phase:** Opportunistic — fix the next time `docs/architecture/0001-iol-router-extraction.md` is touched, OR roll into Phase 2 docs sanitization if a sanitization-gate plan happens to revise ADRs. Not worth its own PR.
+
+## Problem
+
+`docs/architecture/0001-iol-router-extraction.md` is internally inconsistent post-PR-#52:
+
+- **Decision statement, route table, and observable-behaviour section** all correctly state that the router uses ax-llm's native `POST /api/chat` returning `{done, message}`.
+- **"Why option-2" bullet list (lines 63–65)** still says, verbatim: *"The native surface speaks the OpenAI `/v1/chat/completions` shape that `voice_client.py` already expects."*
+
+That second statement is the opposite of the actual decision. A future reader hits the ADR asserting both endpoints and both response shapes simultaneously.
+
+The 640d20a commit on PR #53 attempted to reconcile the drift but only touched the decision/route/observable sections; it missed the "Why option-2" rationale.
+
+## Fix shape
+
+Rewrite the "Verified working live" bullet (and adjacent rationale) to reflect post-PR-#52 reality:
+
+```markdown
+- **Verified working live.** `curl -s -XPOST http://localhost:8000/api/chat \
+  -d '{"messages":[{"role":"user","content":"ping"}]}'` on arlowe-1 returns
+  `{done: true, message: {...}}`. `voice_client.py` was updated in PR #52 to
+  speak ax-llm's native shape; the previous assumption that ax-llm would
+  expose the OpenAI `/v1/chat/completions` surface returned malformed
+  responses on the running build.
+```
+
+Acceptance:
+- ADR no longer asserts contradictory things about which endpoint/shape is in use.
+- "Refinement history" note (already added by 640d20a) is consistent with the bullet rationale.
+- No code changes.
+
+## Effort estimate
+
+~10 LOC docs change, single file. ~10min.
+
+## Cross-references
+
+- PR #53 review comment (posted by pr-reviewer agent, 2026-05-24)
+- PR #52 — the actual fix that introduced the drift (`fix(llm): use ax-llm /api/chat native API instead of OpenAI-compat`)
+- File: `docs/architecture/0001-iol-router-extraction.md:61-73`
+
+---
+
+**Closed:** Resolved in Phase 2, Plan 04 (sanitization-gate cleanup sweep).
+The "Why option-2" bullet now matches the resolved decision; ADR is internally consistent.

--- a/.sanitize-allowlist
+++ b/.sanitize-allowlist
@@ -35,3 +35,20 @@ third_party/whisplay-driver/PROVENANCE.md
 scripts/sanitize/banlist.txt
 scripts/sanitize/unit-prefixes.txt
 scripts/sanitize/test-check.sh
+runtime/dashboard/tests/sanitize.spec.ts
+
+# --- Dev-pinning provenance allow-list (Plan 04 SC4 cleanup) ---
+# The runtime/*/requirements.txt comments record which dev unit the pins were
+# captured from and when. These are audit-trail metadata that never render as
+# user-facing strings and never ship as a service. Rewriting them loses real
+# provenance value (we'd no longer know which Pi the pins are calibrated against).
+# Decision rationale: 02-04-PLAN.md disposition matrix.
+runtime/voice/requirements.txt
+runtime/face/requirements.txt
+runtime/stt/requirements.txt
+runtime/tts/requirements.txt
+runtime/llm/requirements.txt
+runtime/wake-word/requirements.txt
+
+# Same reasoning: tts/manifest.yml's SHA-256-verified-on comments are provenance.
+runtime/tts/manifest.yml

--- a/docs/architecture/0001-iol-router-extraction.md
+++ b/docs/architecture/0001-iol-router-extraction.md
@@ -60,9 +60,12 @@ axcl-context branch). The authoritative routes are documented in
 
 ### Why option-2
 
-- **Verified working live.** `curl http://localhost:8000/v1/models` on arlowe-1
-  returns ok against the running ax-llm process. The native surface speaks the
-  OpenAI `/v1/chat/completions` shape that `voice_client.py` already expects.
+- **Verified working live.** `curl -s -XPOST http://localhost:8000/api/chat \
+  -d '{"messages":[{"role":"user","content":"ping"}]}'` on a Pi 5 dev unit
+  returns `{done: true, message: {...}}`. `voice_client.py` was updated in
+  PR #52 to speak ax-llm's native shape; the previous assumption that ax-llm
+  would expose the OpenAI `/v1/chat/completions` surface returned malformed
+  responses on the running build.
 - **Lowest LOC delta.** One URL constant changed; no new file.
 - **Removes a moving part.** One fewer service to keep alive. The previous
   3-service path (`qwen-tokenizer` → `qwen-openai` shim → `qwen-api`) collapses

--- a/runtime/dashboard/README.md
+++ b/runtime/dashboard/README.md
@@ -58,7 +58,7 @@ See `.env.example` for the full documented list. Key knobs:
 | `ARLOWE_LOGS_DIR` | `/var/lib/arlowe/logs` | Voice log directory read by `/api/logs` |
 | `DASHBOARD_API_SECRET` | (unset) | Bearer token for protected routes; Phase 7 wires owner-pairing |
 
-## Running locally on arlowe-1
+## Running locally on a Pi 5 dev unit
 
 ```bash
 cd runtime/dashboard

--- a/runtime/dashboard/app/components/RetroActivityMonitor.tsx
+++ b/runtime/dashboard/app/components/RetroActivityMonitor.tsx
@@ -137,7 +137,7 @@ export default function RetroActivityMonitor() {
           <div className="retro-header">
             <span className="text-retro-amber">╔══════════════════════════════════════╗</span>
             <span className="text-retro-amber">║</span>
-            <span className="text-retro-green"> ARLOWE-1 SYSTEM MONITOR </span>
+            <span className="text-retro-green"> ARLOWE SYSTEM MONITOR </span>
             <span className="text-retro-amber">║</span>
             <span className="text-retro-amber">║</span>
             <span className="text-retro-green"> {currentTime} </span>

--- a/runtime/dashboard/app/layout.tsx
+++ b/runtime/dashboard/app/layout.tsx
@@ -8,7 +8,7 @@ const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
   title: "Arlowe Dashboard",
-  description: "Control panel for Arlowe-1",
+  description: "Control panel for your Arlowe device",
   appleWebApp: {
     capable: true,
     statusBarStyle: "black-translucent",

--- a/runtime/face/README.md
+++ b/runtime/face/README.md
@@ -34,13 +34,13 @@ See `third_party/whisplay-driver/PROVENANCE.md` for driver source, license, and
 installation instructions. The driver is a vendor-supplied Python module that ships
 with the WhisPlay display hardware -- it is not available via pip.
 
-On arlowe-1 today the driver lives at `~/Library/Whisplay/Driver/WhisPlay.py`
+On a dev Pi today the driver typically lives at `~/Library/Whisplay/Driver/WhisPlay.py`
 (system-wide install). Image-build (Phase 11) will bake it into `/opt/arlowe/`.
 
 ## Sentiment classifier behaviour
 
 1. On incoming text, `sentiment_classifier.py` first tries `localhost:8001/v1/chat/completions`
-   (the Qwen OpenAI-compat shim). As of Phase 1, this endpoint is broken on arlowe-1
+   (the Qwen OpenAI-compat shim). As of Phase 1, this endpoint is broken in the Phase 1 baseline
    (see research notes / plan 13 for the qwen-openai resolution). The NPU path times
    out and falls through to the heuristic.
 
@@ -56,7 +56,7 @@ On arlowe-1 today the driver lives at `~/Library/Whisplay/Driver/WhisPlay.py`
 Phase 1 smoke test passes via the heuristic path. The NPU path is not required for
 the Phase 1 success criterion.
 
-## Running locally on arlowe-1
+## Running locally on a Pi 5 dev unit
 
 ```bash
 cd /path/to/runtime

--- a/runtime/llm/README.md
+++ b/runtime/llm/README.md
@@ -49,7 +49,7 @@ Both paths log token counts and latency to `/var/lib/arlowe/state/usage-stats.js
 | `AX_LLM_BIN` | `/opt/arlowe/runtime/llm/bin/main_api_axcl_aarch64` | Path to ax-llm binary (used by `run_api.sh`) |
 | `QWEN_MODEL_DIR` | `/opt/arlowe/models/qwen2.5-7b-int4-ax650` | Path to Qwen model directory (used by `run_api.sh`) |
 
-For the Phase 1 smoke test on arlowe-1, override `AX_LLM_BIN` and `QWEN_MODEL_DIR`
+For the Phase 1 smoke test on a Pi 5 dev unit, override `AX_LLM_BIN` and `QWEN_MODEL_DIR`
 to point at the existing locations under `~/ax-llm/` and `~/models/`. See plan 13.
 
 ## openai_wrapper.py status

--- a/runtime/llm/router.py
+++ b/runtime/llm/router.py
@@ -32,7 +32,7 @@ USAGE_LOCK_PATH = USAGE_STATS_PATH.with_suffix(".lock")
 # Local Qwen API — ax-llm native (option-2 revised, plan 13 smoke-test).
 # The originally-assumed OpenAI-compat surface (/v1/chat/completions) does
 # not exist on the running ax-llm build (Feb 2026 axcl-context branch).
-# Authoritative routes per /home/focal55/ax-llm/docs/http_api.md and the
+# Authoritative routes per ax-llm's docs/http_api.md (vendored at third_party/ax-llm/) and the
 # binary's own registered routes:
 #   POST /api/chat   — synchronous {messages: [...]}  →  {done, message}
 #   POST /api/reset  — KV cache + system_prompt reset

--- a/runtime/llm/run_api.sh
+++ b/runtime/llm/run_api.sh
@@ -3,7 +3,7 @@
 #
 # Paths are resolved at runtime via env vars so the image build can provision
 # them under /opt/arlowe/ without editing this file.
-# For the Phase 1 smoke test on arlowe-1, set:
+# For local smoke-testing on a Pi 5 dev unit with the AX accelerator, set:
 #   AX_LLM_BIN=~/ax-llm/build/main_api_axcl_aarch64
 #   QWEN_MODEL_DIR=~/models/Qwen2.5-7B-Instruct/qwen2.5-7b-ctx-int4-ax650
 # See plan-13 smoke-test notes for the exact export commands.

--- a/runtime/stt/README.md
+++ b/runtime/stt/README.md
@@ -36,7 +36,7 @@ before responding. VAD filtering is on (`min_silence_duration_ms=500`).
 `~/.cache/huggingface/`. In the image build, pre-populate `/var/lib/arlowe/models/whisper/`
 to skip the runtime download.
 
-## Running on arlowe-1
+## Running on a Pi 5 dev unit
 
 ```bash
 # Activate the voice venv and start the server

--- a/runtime/tts/README.md
+++ b/runtime/tts/README.md
@@ -61,11 +61,11 @@ These are system-level binaries installed via pi-gen at image build time — not
 ### PyYAML
 
 PyYAML is required for the `/etc/arlowe/config.yml` overlay loader.
-Verified present in the arlowe-1 voice venv at version `6.0.3`.
+Verified present in a Pi 5 dev unit's voice venv at version `6.0.3`.
 
 If PyYAML is absent on a fresh venv:
 ```bash
-ssh arlowe-1 '~/venvs/voice/bin/pip install PyYAML==6.0.3'
+ssh <your-dev-pi> '~/venvs/voice/bin/pip install PyYAML==6.0.3'
 ```
 
 This install requirement is also noted in plan 13 (smoke-test prerequisites).
@@ -73,10 +73,10 @@ This install requirement is also noted in plan 13 (smoke-test prerequisites).
 ### Piper assets
 
 Assets are not included in the repo. The image build fetches and verifies them using
-`manifest.yml`. For the Phase 1 smoke test on arlowe-1, the assets are already present
+`manifest.yml`. For the Phase 1 smoke test on a Pi 5 dev unit, the assets are already present
 at `~/models/piper/piper` and `~/models/piper-voices/en_US-lessac-medium.onnx`.
 
-## Running / testing on arlowe-1
+## Running / testing on a Pi 5 dev unit
 
 ```python
 from pathlib import Path
@@ -96,7 +96,7 @@ Or run the built-in test:
 
 ## Known limitations
 
-- `PLAY_DEVICE` defaults to `plughw:2,0` (USB combo card on arlowe-1). Phase 5 will make
+- `PLAY_DEVICE` defaults to `plughw:2,0` (USB combo card on the dev unit used for Phase 1 testing). Phase 5 will make
   this config-driven via audio auto-detect.
 - Cloud TTS path (ElevenLabs) requires an owner-provisioned key. Phase 4 and 7 wire this
   fully through first-boot pairing + customer-bound API key. On a sanitized customer unit

--- a/runtime/voice/README.md
+++ b/runtime/voice/README.md
@@ -20,7 +20,7 @@ Runs as a single Python process under the `arlowe` system user (currently the de
 | LLM router | via `llm.router` (delegates internally to `localhost:8000` or `claude` CLI) | generate response text |
 | dashboard | `http://localhost:3000` (`ARLOWE_DASHBOARD_URL`) | rules engine fetches orchestration config; stub does not call this today |
 
-## How to run locally on arlowe-1
+## How to run locally on a Pi 5 dev unit
 
 Requires the face service, STT server, and LLM router to be running first.
 

--- a/runtime/wake-word/README.md
+++ b/runtime/wake-word/README.md
@@ -90,11 +90,12 @@ EXTRACT-07.
 
 ## Duplicate at whisplay package level (deliberately not extracted)
 
-`~/iol-monorepo/packages/whisplay/wake_word/` exists on arlowe-1 alongside the canonical
-`~/wake_word/`. Research Q5 confirmed that `voice_client.py` looks for the verifier under
-`~/wake_word/` -- that is the canonical path. The whisplay-level copy (which has its own
-`record_negative.py`, `record_positive.py`, `test_wake.py`) was an earlier split and is stale.
-Only the canonical `~/wake_word/` scripts were extracted here.
+An older copy of the wake-word pipeline existed in the founder dev monorepo (pre-extraction);
+the `runtime/wake-word/` tree is the canonical post-extraction location. Research Q5 confirmed
+that `voice_client.py` looks for the verifier under `~/wake_word/` -- that is the canonical path.
+The whisplay-level copy (which has its own `record_negative.py`, `record_positive.py`,
+`test_wake.py`) was an earlier split and is stale. Only the canonical `~/wake_word/` scripts
+were extracted here.
 
 ## Env knobs
 


### PR DESCRIPTION
## Summary

Phase 2 finale. Cleans the runtime/ tree so all three sanitization gates from Plans 01-03 go green on main. Also resolves the F5 todo (ADR-0001 internal contradiction).

Closes #57

## What changed

**Task 1 — 4 code/UI files sanitized:**
- `runtime/llm/router.py:35` — replaced `/home/focal55/ax-llm/docs/http_api.md` comment with reference to vendored upstream source
- `runtime/llm/run_api.sh:6` — replaced `arlowe-1` in smoke-test comment with generic Pi 5 dev unit phrasing
- `runtime/dashboard/app/layout.tsx:11` — changed `description: "Control panel for Arlowe-1"` to `"Control panel for your Arlowe device"` (eliminates the leak into `<meta name="description">` on every dashboard route)
- `runtime/dashboard/app/components/RetroActivityMonitor.tsx:140` — dropped `-1` from `ARLOWE-1 SYSTEM MONITOR` header

**Task 1 — .sanitize-allowlist extended:**
- 6 `runtime/*/requirements.txt` files (dev-pinning provenance — audit trail, never ships)
- `runtime/tts/manifest.yml` (same reasoning)
- `runtime/dashboard/tests/sanitize.spec.ts` (gate test data — contains banned literals by design)

**Task 2 — 7 runtime/ README files sanitized:**
All `arlowe-1` and `iol-monorepo` references replaced with generic phrasing (`a Pi 5 dev unit`, `<your-dev-pi>`). `wake-word/README.md:91-97` special-cased to rewrite both banned literals in one paragraph while preserving the architectural context.

**Task 3 — F5 ADR-0001 fix:**
Rewrote the "Verified working live" bullet in the "Why option-2" section of `docs/architecture/0001-iol-router-extraction.md`. Previous text falsely asserted ax-llm speaks the OpenAI `/v1/chat/completions` shape; corrected to show the actual `/api/chat` endpoint returning `{done, message}`. Moved F5 todo from `pending/` to `done/` with closure note.

## Verification

All three sanitize gates pass locally:
- `bash scripts/sanitize/check.sh --grep-only` → `sanitize grep: clean (119 files scanned)` exit 0
- `bash scripts/sanitize/check.sh --units-only` → `sanitize units: clean (3 unit files checked)` exit 0
- `bash scripts/sanitize/check.sh` → both gates clean, exit 0
- `bash scripts/sanitize/test-check.sh` → all 3 PASS lines, exit 0
- `pnpm exec playwright test sanitize.spec.ts --project=chromium` → 4 passed (all routes clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)