### PR TITLE
docs(phase-2,phase-3): close Phase 2, seed Phase 3 planning artifacts

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -94,7 +94,14 @@ Plans:
   3. Every shipping systemd unit is system-level (no `--user` units), runs as the `arlowe` user, and applies `PrivateTmp`, `ProtectSystem`, and unit-appropriate `ReadWritePaths`.
   4. A test on the dev image verifies that the runtime cannot write outside `/var/lib/arlowe/` (and explicit allow-listed paths) when running under the configured sandbox.
 
-**Plans**: TBD
+**Plans**: 5 plans
+
+Plans:
+- [ ] 03-01-PLAN.md — Provisioning scripts (install-arlowe-user + install-arlowe-fs) + Docker testbed + SC1/SC2 assertions + layout-reference doc (Wave 1, foundational; OTA-01 amendment noted)
+- [ ] 03-02-PLAN.md — Six systemd unit files + install-units.sh + SC3 assertions (systemd-analyze verify + security) (Wave 2, depends on 03-01)
+- [ ] 03-03-PLAN.md — Udev rules (Axera + GPIO/SPI defense-in-depth) + polkit rule (arlowe→systemctl arlowe-*) + axcl-deb diagnostic (Wave 2, depends on 03-01; parallel with 03-02)
+- [ ] 03-04-PLAN.md — CLI symlinks installer + boot-check ARLOWE_SYSTEMCTL_FLAGS default flip to system-level (Wave 2, depends on 03-01; parallel with 03-02, 03-03)
+- [ ] 03-05-PLAN.md — arlowe-1 staging-user harness: install/uninstall, SC4 sandbox write-deny on real hardware, speculative-group + gpiochip resolution (Wave 3; non-autonomous, depends on 03-01..04)
 
 ### Phase 4: Config overlay
 
@@ -255,8 +262,8 @@ Phases execute in numeric order: 1 -> 2 -> 3 -> 4 -> 5 -> 6 -> 7 -> 8 -> 9 -> 10
 | Phase | Plans Complete | Status | Completed |
 |-------|----------------|--------|-----------|
 | 1. Runtime extraction | 15/15 | Complete (qualified — SC4 hardware loop deferred to Phase 12; see plan 13 SUMMARY F1-F4) | 2026-05-17 |
-| 2. Sanitization gate | 0/4 | Planned | - |
-| 3. Service user and filesystem layout | 0/TBD | Not started | - |
+| 2. Sanitization gate | 4/4 | Complete | 2026-05-27 |
+| 3. Service user and filesystem layout | 0/5 | Planned | - |
 | 4. Config overlay | 0/TBD | Not started | - |
 | 5. Audio device auto-detection | 0/TBD | Not started | - |
 | 6. Image build with A/B partitions | 0/TBD | Not started | - |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -5,38 +5,36 @@
 See: .planning/PROJECT.md (updated 2026-04-30)
 
 **Core value:** A factory-fresh Pi 5 + AX accelerator + Whisplay can flash this image, boot, pair to an owner, and run wake -> STT -> LLM -> TTS -> face entirely on-device, with no founder identity present anywhere in the image.
-**Current focus:** Phase 1 complete (qualified). Ready for Phase 2 (sanitization gate).
+**Current focus:** Phase 2 complete. Phase 3 (service user and filesystem layout) planned, ready to execute.
 
 ## Current Position
 
-Phase: 1 of 12 (Runtime extraction) — COMPLETE (qualified)
-Plan: 15 of 15 in current phase
-Status: Phase 1 closed 2026-05-17 as passed-with-notes; SC4 hardware-loop deferred to Phase 12 + plan F4
-Last activity: 2026-05-17 -- branch `plan-13/smoke-test` (5 commits) ready to PR; phase metadata committed
+Phase: 2 of 12 (Sanitization gate) — COMPLETE
+Plan: 4 of 4 in Phase 2
+Status: Phase 2 closed 2026-05-27. All four SC criteria met (grep gate, units gate, dashboard Playwright gate, runtime/ zero banned literals). Phase 3 plans (5) and research committed in this PR.
+Last activity: 2026-05-27 -- Phase 2 PRs #58-#61 all merged; Phase 3 plans ready to seed as issues via /issue-from-plan 3
 
-Progress: [██████████] 100% (15/15 plans done, qualified)
+Progress: Phase 1 [██████████] 100% qualified; Phase 2 [██████████] 100% complete; Phase 3 [░░░░░░░░░░] 0/5 planned
 
 ## Performance Metrics
 
 **Velocity:**
-- Total plans completed: 15 (01, 02, 03, 03b, 04, 05, 06, 07, 08, 08b, 09, 10, 11, 12, 13)
-- Plan 13 closed as passed-with-notes after 3 Task 4 retry iterations surfaced 4 staging-scaffolding bugs (3 fixed in-iteration, 1 deferred to F1)
-- Total execution time: ~3 days of agentic workforce dispatch + 1 finalizer day
+- Phase 1: 15 plans, ~3 days agent + 1 finalizer day
+- Phase 2: 4 plans, 1 day (parallel fan-out of 02-01..02-03, then 02-04 SC4 cleanup)
 
 **By Phase:**
 
-| Phase | Plans | Done | Avg/Plan |
-|-------|-------|------|----------|
-| 1 | 15 | 15 | ~3hr agent + queue time |
+| Phase | Plans | Done | Status |
+|-------|-------|------|--------|
+| 1 | 15 | 15 | Complete (qualified) |
+| 2 | 4 | 4 | Complete |
+| 3 | 5 | 0 | Planned |
 
-**Recent Trend:**
-- Wave 1 (Plan 01): scaffold — 1 PR
-- Wave 2 (Plans 02, 03, 03b, 05, 06, 09, 10, 11, 12): parallel fan-out — 9 PRs in one batch
-- Wave 3 (Plans 04, 07): STT/TTS + dashboard delete pass — 4 PRs (07 split into 3 stacked)
-- Wave 4 (Plan 08): dashboard /api/config + /api/logs rewrite — 1 PR
-- Wave 5 (Plan 08b): dashboard /api/voice + .env.example + README — 1 PR
-- Wave 6 (Plan 13): smoke test — 3 retry iterations on hardware, closed passed-with-notes; branch `plan-13/smoke-test` (5 commits) ready to PR
-- Plus 3 infra PRs (CI fixes #18, #29, #39 — Node-job gating, cap raise, lockfile exclusion)
+**Recent Trend (Phase 2):**
+- 02-01: grep gate runner, allow-list, CI workflow (#58)
+- 02-02: systemd unit-name block + --scan-dir reuse (#59)
+- 02-03: Playwright dashboard rendered-text gate (#60)
+- 02-04: SC4 runtime/ cleanup + F5 ADR-0001 fix (#61) — closes Phase 2
 
 ## Accumulated Context
 
@@ -47,11 +45,10 @@ Recent decisions affecting current work:
 
 - **ADR-0001** (resolved): option-2 chosen for `openai_wrapper.py`. Router points at ax-llm `/api/chat` native (`localhost:8000`), not `/v1/chat/completions`. `qwen-openai.service` deprecated.
 - **ADR-0002** (resolved): `arlowe-scheduled-summary.service` stripped from firmware.
-- **WhisPlay driver**: PiSugar (Apache 2.0). Strategy A — vendor at image build (Phase 6). Runtime face.py already honors `ARLOWE_WHISPLAY_DRIVER_PATH` (default `/opt/arlowe/third_party/whisplay-driver`).
+- **Phase 2 sanitization gate** (resolved): three CI jobs (banlist-and-units, self-test, dashboard-rendered-text) gate every PR. `.sanitize-allowlist` codifies exception paths. Provenance comments in `runtime/*/requirements.txt` and `tts/manifest.yml` allow-listed by Plan 02-04 disposition matrix.
+- **WhisPlay driver**: PiSugar (Apache 2.0). Strategy A — vendor at image build (Phase 6).
 - **ax-llm submodule**: pinned at `df75c34c…` on `axcl-context` branch.
-- **axcl deb**: SHA-256 pinned in `third_party/axcl/manifest.yml`, never committed (Strategy C — user supplies). `scripts/verify-third-party.sh` gates.
-- **Dashboard audit**: 12 of 27 API routes retained; 4 of 13 pages retained. OpenClaw/iol-monorepo couplings stripped.
-- **Plan 13 closure**: passed-with-notes; hardware wake-phrase loop not exercised this session. Acceptance: Phase 1 SC4 qualified-pass per plan front-matter; fully-sanitized first-flash test owned by Phase 12; hybrid live/test re-run unblocked once F2 lands.
+- **axcl deb**: SHA-256 pinned in `third_party/axcl/manifest.yml`, never committed (Strategy C). `scripts/verify-third-party.sh` gates.
 
 ### Pending Todos
 
@@ -61,18 +58,20 @@ In `.planning/todos/pending/`:
 - F3-arlowe1-persistent-journald.md — workforce infra (dev-env)
 - F4-plan-13-rerun-post-phase-6.md — post-Phase-6 hybrid smoke-test re-run
 
+In `.planning/todos/done/`:
+- F5-adr-0001-why-option-2-internal-contradiction.md — closed by Plan 02-04 (ADR doc rewritten)
+
 Workforce-infra debt tracked in Claude's memory store:
 - Board-sync workflow needs PAT with `Projects: read/write` scope (`PROJECTS_TOKEN` secret) — owner must mint.
 - OpenClaw bearer token leaked in `iol-monorepo` source — separate repo, should rotate.
 
 ### Blockers/Concerns
 
-- **`plan-13/smoke-test` branch not yet PR'd**: 5 commits ahead of main, ready for owner-initiated `gh pr create`.
 - ADR pending (Phase 7): specific managed-PKI service selection.
 - ADR pending (Phase 8): pairing channel mechanism (Wi-Fi captive portal vs. BLE).
 
 ## Session Continuity
 
-Last session: 2026-05-17
-Stopped at: Phase 1 closed as passed-with-notes. Plan 13 SUMMARY written; smoke-test doc Observed-run section finalized; F1-F4 deferred items captured as todos. Next step: open PR for `plan-13/smoke-test`, then `/gsd:discuss-phase 2` for sanitization-gate planning.
-Resume file: branch `plan-13/smoke-test`, `.planning/phases/01-runtime-extraction/01-13-SUMMARY.md`
+Last session: 2026-05-27
+Stopped at: Phase 2 closed. Phase 3 research + 5 plans drafted and committed. Branch `chore/phase-3-seed` opened to land planning artifacts. Next step: merge this PR, then run `/issue-from-plan 3` to populate board for workforce-tick dispatch.
+Resume file: branch `chore/phase-3-seed`, `.planning/phases/03-service-user-and-filesystem-layout/`

--- a/.planning/phases/02-sanitization-gate/02-RESEARCH.md
+++ b/.planning/phases/02-sanitization-gate/02-RESEARCH.md
@@ -1,0 +1,500 @@
+# Phase 2: Sanitization Gate - Research
+
+**Researched:** 2026-05-25
+**Domain:** CI guardrails (ripgrep + GitHub Actions + Playwright + Next.js App Router)
+**Confidence:** HIGH
+
+## Summary
+
+Three mechanical gates implementing what `02-CONTEXT.md` already locked down. Tooling choices are essentially forced by what's already in the repo:
+
+- **Grep gate**: ripgrep 14.1.1 (already installed in standard GitHub Actions `ubuntu-latest` runners as of 2024). `git ls-files` to scope to tracked files, `-iFn --column --no-heading` for case-insensitive fixed-string output in a parseable form. A bash loop converts each hit to a `::error file=PATH,line=N,col=C::message` line for inline PR annotations. Allow-list filtering happens in pure bash against the captured hits — no need to pull in a node glob library when the gate is run from bash. Use `git check-ignore` semantics via a small awk/shell script or vendor a tiny glob matcher; the simplest path is `git ls-files -- ':!:GLOB1' ':!:GLOB2' ...` populated from `.sanitize-allowlist`, which gives gitignore-compatible globs for free.
+- **Unit-name block**: same runner script, different inputs. `git ls-files '*.service' '*.timer' '*.socket' '*.target' '*.mount' '*.path'` enumerates tracked unit files, basename-match against the three banned prefixes (`openclaw-*`, `trace-*`, `workforce-metrics-snapshot.*`). Deliberate-failure test is a bash test against a `mktemp -d` containing a fake `openclaw-test.service`, asserting non-zero exit.
+- **Dashboard rendered-text gate**: new Playwright spec at `runtime/dashboard/tests/sanitize.spec.ts`. Enumerate routes by `fs.readdirSync` walking `app/` for `page.tsx` (NOT `route.ts` — those are API endpoints, no rendered HTML to scan). For each route, `await page.goto(...)`, `await page.waitForLoadState('networkidle')`, then `expect(await page.content()).not.toMatch(/.../i)`. The existing `playwright.config.ts` already runs `pnpm start -p 3000` via `webServer` and has `reuseExistingServer: !process.env.CI` set correctly. **Pitfall**: the existing config uses `pnpm start` (production server), which requires `pnpm build` first; CI must run build before the test or the webServer command must become `pnpm build && pnpm start -p 3000`.
+
+**Primary recommendation:** Single bash script `scripts/sanitize/check.sh` runs both grep gate + unit-name block, called from a new `.github/workflows/sanitize.yml`. Dashboard gate stays in the existing Playwright suite. Required-check trap (path-filtered workflows blocking PRs forever as "pending"): solve by **not using `paths:` in `on:`** — the sanitize workflow always runs on every PR, no exceptions. The scan itself is fast enough (~1s on 182 tracked files) that path-filtering is premature optimization that breaks branch protection.
+
+## Standard Stack
+
+### Core
+| Tool | Version | Purpose | Why Standard |
+|------|---------|---------|--------------|
+| ripgrep (`rg`) | 14.1.1 (system) | Banlist scan | Already installed on `ubuntu-latest` runners; `--vimgrep` and `--json` outputs are explicitly machine-parseable. Faster than `grep -r` and respects `.gitignore` by default. |
+| `git ls-files` | bundled | Tracked-file enumeration | Authoritative scope: matches exactly the SC1 "tracked files" definition. Avoids the `.dev-stash/` problem mechanically — gitignored = not listed. |
+| bash 5 | runner-provided | Glue, output formatting | Single language for the whole runner script keeps it auditable in <100 LOC. |
+| Playwright | 1.58.2 (already in `runtime/dashboard/devDependencies`) | Dashboard rendered-HTML scan | Already wired up; `playwright.config.ts` already provisions webServer + Chromium + Firefox. |
+| Node `fs.readdirSync` | bundled with Node 20 | Route enumeration in spec | Walking `app/` for `page.tsx` is ~15 LOC; no library needed. |
+
+### Supporting
+| Tool | Purpose | When to Use |
+|------|---------|-------------|
+| `git diff --name-only` | (Optional, deferred) Limit scan to changed files in PR | NOT for v1. Full-tree scan is correct because a literal can be reintroduced by a rebase/merge that touches a file the PR author didn't write. Mentioned only because someone will suggest it. |
+| `actions/setup-node@v4`, `pnpm/action-setup@v4` | Already in `ci.yml` | Reuse, don't reinstall, in the new workflow. |
+
+### Alternatives Considered
+| Instead of | Could Use | Tradeoff |
+|------------|-----------|----------|
+| ripgrep | `grep -rIni` (POSIX) | grep is universal but ~5x slower and lacks `.gitignore` awareness. ripgrep is on every modern runner image; portability is not a real concern in CI. |
+| ripgrep | Python script with `re.compile` | Python gives precise control over allow-list glob matching and JSON output. ~50 extra LOC vs bash; only worth it if we ever need per-literal precision (which 02-CONTEXT.md explicitly defers). |
+| ripgrep | `git grep -inE` | `git grep` is what `dashboard-extraction-audit.md` already uses elsewhere. Equivalent functionality. Slightly less flexible on `--column` / `--vimgrep` outputs. Either works; pick one and stay consistent. |
+| `fs.readdirSync` for route enumeration | Read `.next/server/app-paths-manifest.json` | The manifest is post-build, exists only after `pnpm build`. Since Playwright already requires a built dashboard (webServer is `pnpm start`), reading the manifest is technically possible. But filesystem walk of `app/` is simpler and works even if a future spec author runs `pnpm test:e2e` against `pnpm dev`. Stick with `fs.readdirSync`. |
+| Playwright snapshot `toMatchSnapshot` | Direct `expect(content).not.toMatch(BANLIST_REGEX)` | Snapshot diffing for a "must not contain X" check is the wrong tool — snapshots assert on *positive* content shape. Use direct regex assertion. |
+
+**Installation:**
+ripgrep is pre-installed on `ubuntu-latest`. Verify with `rg --version` in a workflow step before relying on it. No `npm install` or `apt install` step required.
+
+## Architecture Patterns
+
+### Recommended Project Structure
+```
+scripts/
+└── sanitize/
+    ├── check.sh                # Main runner (grep gate + unit-name block)
+    ├── banlist.txt             # 6 literals, one per line, no comments
+    ├── unit-prefixes.txt       # 3 banned unit prefixes
+    └── test-check.sh           # Self-test: creates temp tree with planted hit, asserts non-zero exit
+.sanitize-allowlist             # Path globs allowed to contain banned literals (gitignore-style)
+.github/workflows/
+└── sanitize.yml                # Calls scripts/sanitize/check.sh + invokes Playwright sanitize spec
+runtime/dashboard/tests/
+└── sanitize.spec.ts            # Rendered-HTML banlist scan
+```
+
+Rationale for splitting `banlist.txt` / `unit-prefixes.txt` out of the script: a future "add a 7th literal" PR touches a single data file, not the runner. Also makes the deliberate-failure test trivial — feed the test runner a different banlist.
+
+### Pattern 1: Grep gate runner
+**What:** Scan tracked files for any banlist literal; convert hits to GitHub annotations; exit non-zero on any hit.
+
+**When to use:** Top of `.github/workflows/sanitize.yml`, every PR.
+
+**Skeleton:**
+```bash
+#!/usr/bin/env bash
+# scripts/sanitize/check.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+BANLIST="$SCRIPT_DIR/banlist.txt"
+ALLOWLIST=".sanitize-allowlist"
+
+# Build a pathspec from .sanitize-allowlist (gitignore-style globs).
+# git ls-files honors :(exclude) pathspecs with gitignore semantics.
+PATHSPECS=()
+if [[ -f "$ALLOWLIST" ]]; then
+  while IFS= read -r line; do
+    # Strip comments (#...) and blank lines.
+    line="${line%%#*}"
+    line="${line#"${line%%[![:space:]]*}"}"   # ltrim
+    line="${line%"${line##*[![:space:]]}"}"   # rtrim
+    [[ -z "$line" ]] && continue
+    PATHSPECS+=(":(exclude,glob)$line")
+  done < "$ALLOWLIST"
+fi
+
+# Enumerate tracked, non-allow-listed files.
+mapfile -t FILES < <(git ls-files -- "${PATHSPECS[@]+${PATHSPECS[@]}}")
+
+# Build a single alternation pattern from the banlist (one literal per line).
+# -iF makes it case-insensitive fixed-string; we still want one-pattern-per-rg-call
+# only if we need per-literal column data. Easier: -f BANLIST.
+HITS=$(rg -iFn --column --no-heading -f "$BANLIST" -- "${FILES[@]}" || true)
+
+if [[ -z "$HITS" ]]; then
+  echo "sanitize: clean (${#FILES[@]} tracked files scanned)"
+  exit 0
+fi
+
+# Emit GitHub annotations + human-readable summary.
+EXIT=0
+while IFS= read -r hit; do
+  # hit format from rg -n --column: path:line:col:matched-text
+  IFS=: read -r path line col rest <<< "$hit"
+  msg="banned identity literal; if this is a legit historical reference, add the path to .sanitize-allowlist"
+  printf '::error file=%s,line=%s,col=%s::%s\n' "$path" "$line" "$col" "$msg"
+  printf '%s:%s:%s: %s\n' "$path" "$line" "$col" "$rest" >&2
+  EXIT=1
+done <<< "$HITS"
+exit "$EXIT"
+```
+
+**Sources:**
+- ripgrep flags (`-i`, `-F`, `-n`, `--column`, `--no-heading`, `-f`): verified via `rg --help` on system, ripgrep 14.1.1.
+- `git ls-files -- ':(exclude,glob)foo/**'` pathspec syntax: git ≥2.13.
+- GitHub annotation format: confirmed against GitHub Actions workflow-commands docs (see Sources).
+
+### Pattern 2: Unit-name block
+**What:** Enumerate tracked systemd unit files; basename-match against banned prefixes.
+
+**Skeleton (call from same `check.sh` or a sibling script):**
+```bash
+# Tracked unit files.
+mapfile -t UNITS < <(git ls-files \
+  -- '*.service' '*.timer' '*.socket' '*.target' '*.mount' '*.path')
+
+EXIT=0
+while IFS= read -r prefix; do
+  prefix="${prefix%%#*}"; prefix="${prefix// /}"
+  [[ -z "$prefix" ]] && continue
+  for unit in "${UNITS[@]}"; do
+    base="$(basename "$unit")"
+    # shell glob match — relies on extglob NOT being needed for *. prefix patterns
+    if [[ "$base" == $prefix ]]; then
+      printf '::error file=%s,line=1::banned systemd unit name (matches %s)\n' "$unit" "$prefix"
+      EXIT=1
+    fi
+  done
+done < "$SCRIPT_DIR/unit-prefixes.txt"
+exit "$EXIT"
+```
+
+The three prefixes (`openclaw-*`, `trace-*`, `workforce-metrics-snapshot.*`) are literally bash glob patterns; `[[ basename == $prefix ]]` does the right thing when `$prefix` is unquoted on the RHS.
+
+**Deliberate-failure self-test** (runs alongside the gate in CI):
+```bash
+# scripts/sanitize/test-check.sh
+set -euo pipefail
+TMP=$(mktemp -d)
+trap "rm -rf $TMP" EXIT
+git -C "$TMP" init -q
+touch "$TMP/openclaw-test.service"
+git -C "$TMP" add . && git -C "$TMP" -c user.email=t@t -c user.name=t commit -qm test
+
+# Run the unit-block portion against TMP — should exit non-zero.
+if (cd "$TMP" && bash "$REPO_ROOT/scripts/sanitize/check.sh" --units-only); then
+  echo "FAIL: gate did not catch planted openclaw-test.service" >&2
+  exit 1
+fi
+echo "PASS: gate correctly blocked planted unit"
+```
+
+Add a matching planted-literal test for the grep gate. Both tests run in CI as a separate workflow job (`name: sanitize-self-test`) so a regression in the gate itself is caught.
+
+### Pattern 3: Dashboard rendered-text gate
+**What:** Boot the dashboard, visit every page, assert rendered HTML contains none of the 6 literals.
+
+**Skeleton (`runtime/dashboard/tests/sanitize.spec.ts`):**
+```typescript
+import { test, expect } from '@playwright/test';
+import { readdirSync, statSync } from 'fs';
+import path from 'path';
+
+// Walk app/ for page.tsx files, convert each to a URL path.
+// Skip route groups (parens), private folders (_underscore), and api/ (no rendered HTML).
+function enumerateRoutes(appDir: string): string[] {
+  const routes: string[] = [];
+  function walk(dir: string, urlSegments: string[]) {
+    for (const entry of readdirSync(dir)) {
+      const full = path.join(dir, entry);
+      if (!statSync(full).isDirectory()) continue;
+      if (entry === 'api' || entry.startsWith('_')) continue;
+      // Route groups: (name) folders do not contribute to URL.
+      const nextSegments = entry.startsWith('(') && entry.endsWith(')')
+        ? urlSegments
+        : [...urlSegments, entry];
+      // If this directory has page.tsx, record the route.
+      try {
+        statSync(path.join(full, 'page.tsx'));
+        routes.push('/' + nextSegments.join('/'));
+      } catch { /* no page.tsx, just keep walking */ }
+      walk(full, nextSegments);
+    }
+  }
+  // Root page.tsx → '/'
+  try { statSync(path.join(appDir, 'page.tsx')); routes.push('/'); } catch {}
+  walk(appDir, []);
+  return [...new Set(routes)];
+}
+
+const APP_DIR = path.join(__dirname, '..', 'app');
+const ROUTES = enumerateRoutes(APP_DIR);
+const BANLIST = [
+  'focal55', 'arlowe-1', 'casa_ybarra_chelsea',
+  '/home/focal55', 'joe@focal55', 'iol-monorepo',
+];
+
+test.describe('sanitization: no founder literals in rendered HTML', () => {
+  for (const route of ROUTES) {
+    test(`route ${route} contains no banned literal`, async ({ page }) => {
+      await page.goto(route, { waitUntil: 'networkidle' });
+      const html = await page.content();
+      for (const literal of BANLIST) {
+        expect(
+          html.toLowerCase().includes(literal.toLowerCase()),
+          `route ${route} rendered HTML contains "${literal}"`,
+        ).toBe(false);
+      }
+    });
+  }
+});
+```
+
+**Why `page.content()` not `page.textContent('body')`:** the CONTEXT decision is "text content only — `page.content()` (rendered HTML)." This catches literals in `<title>`, `<meta>`, alt attributes, and visible text. Does NOT catch `href` attributes mid-attribute (confirmed in CONTEXT deferred list), but covers the layout.tsx `description: "Control panel for Arlowe-1"` which renders into `<meta name="description">`.
+
+**Why `networkidle`:** the dashboard pages do `useEffect`-driven `fetch('/api/health')` etc. on mount and render placeholder content first. `networkidle` waits for the API requests to settle so the second-render text is included in the scan. The trade-off is ~500ms per route. For 4 routes that's 2s; acceptable.
+
+**Sources:**
+- Next.js App Router file conventions (page.tsx, route.ts, route groups `(name)`, dynamic segments `[name]`, private folders `_name`): confirmed against Next.js docs.
+- `page.content()` returns full HTML including doctype: Playwright docs.
+
+### Pattern 4: GitHub Actions workflow
+**File:** `.github/workflows/sanitize.yml`
+
+**Skeleton:**
+```yaml
+name: Sanitize
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+# NO `paths:` filter — required checks + path filtering = "pending forever" trap.
+# The whole scan takes ~2s; path-gating is premature optimization.
+
+concurrency:
+  group: sanitize-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  banlist-and-units:
+    name: Banlist + unit-name block
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: rg --version  # sanity-check that rg is on the runner
+      - run: bash scripts/sanitize/check.sh
+
+  self-test:
+    name: Gate self-test (deliberate-failure cases)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: bash scripts/sanitize/test-check.sh
+
+  dashboard-rendered-text:
+    name: Dashboard rendered-text gate
+    runs-on: ubuntu-latest
+    defaults: { run: { working-directory: runtime/dashboard } }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with: { version: 9 }
+      - uses: actions/setup-node@v4
+        with: { node-version: '20', cache: 'pnpm' }
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm exec playwright install --with-deps chromium
+      - run: pnpm build      # required because playwright.config webServer uses `pnpm start`
+      - run: pnpm exec playwright test sanitize.spec.ts
+```
+
+### Anti-Patterns to Avoid
+
+- **Path-filtered required check.** Do NOT add `on: pull_request: paths: ['runtime/**', 'scripts/**']`. A PR that only edits `docs/journey/2026-05-25.md` will not trigger the workflow; the required check stays pending forever; the PR cannot merge. This is a well-documented GitHub bug (see Sources). The fix is to not use `paths:` at all on a required check. If skipping is genuinely desired in the future, use a "bucket" job pattern with `dorny/paths-filter` and an aggregator job that's `if: always()` and inspects sub-job results.
+- **Skipping `pnpm build` before Playwright.** The existing `playwright.config.ts` has `webServer: { command: 'pnpm start -p 3000' }` — `next start` requires a `.next/` build artifact. Add `pnpm build` to the workflow OR change the webServer command to `pnpm build && pnpm start -p 3000` (CONTEXT mentions `pnpm dev` as an option; that works too but renders different output and includes dev-only HMR scripts. Production build is closer to ship behavior).
+- **Allow-listing whole `.planning/**` for the grep gate without thinking.** `.planning/phases/02-sanitization-gate/02-RESEARCH.md` (this file) MUST be allow-listed because it contains every banned literal as documentation. So must `02-CONTEXT.md`, `.planning/REQUIREMENTS.md`, and most of `.planning/phases/01-runtime-extraction/`. But `.planning/STATE.md` and future phase plans should NOT be blanket-allow-listed — they could legitimately need scanning. Recommended starting `.sanitize-allowlist`:
+  ```
+  # Planning artifacts that document banned literals as part of their purpose.
+  .planning/REQUIREMENTS.md
+  .planning/ROADMAP.md
+  .planning/PROJECT.md
+  .planning/phases/01-runtime-extraction/**
+  .planning/phases/02-sanitization-gate/**
+  # Architecture decision records that capture historical state.
+  docs/architecture/0001-iol-router-extraction.md
+  docs/architecture/0002-arlowe-scheduled-summary-stripped.md
+  docs/architecture/dashboard-extraction-audit.md
+  docs/architecture-overview.md
+  # Operations doc that records phase-1 smoke-test history.
+  docs/operations/phase-1-smoke-test.md
+  # Workforce wiring — references @focal55 the GitHub user, not the founder identity in firmware sense.
+  .github/CODEOWNERS
+  .github/ISSUE_TEMPLATE/config.yml
+  AGENTS.md.template
+  README.md
+  # Dev pull script — references arlowe-1 because that's the dev unit it pulls from.
+  scripts/dev-pull-from-pi.sh
+  # Third-party distribution paperwork.
+  third_party/axcl/DISTRIBUTION-RIGHTS.md
+  third_party/axcl/INSTALL.md
+  third_party/whisplay-driver/PROVENANCE.md
+  # Allowlist of itself — required so the script doesn't grep its own banlist via the script file.
+  .sanitize-allowlist
+  scripts/sanitize/banlist.txt
+  scripts/sanitize/unit-prefixes.txt
+  ```
+  See "Open Questions" for which of these the planner should challenge.
+- **Trying to use `rg --json` for annotations.** The JSON output is one message per *event* (begin/match/end), not one per match line, and includes `submatches` arrays. Bash parsing of it is painful. `-n --column --no-heading` plain output is `path:line:col:text` which is trivial to split on `:`. Stick with that.
+
+## Don't Hand-Roll
+
+| Problem | Don't Build | Use Instead | Why |
+|---------|-------------|-------------|-----|
+| Tracked-file enumeration | `find . -type f` with manual `.gitignore` parsing | `git ls-files` | Honors `.gitignore`, `.git/info/exclude`, submodule boundaries, and pathspec excludes for free. Matches the SC1 "tracked files" definition exactly. |
+| Glob-pattern path matching for allow-list | minimatch/micromatch/picomatch JS library | `git ls-files -- ':(exclude,glob)PATTERN'` pathspec | gitignore-style globs come for free via git's own pathspec engine. No node_modules, no extra dependency for a bash script. |
+| Route discovery in dashboard test | next/router internal APIs, parsing `app-paths-manifest.json` | 15-line `fs.readdirSync` walk | App Router routes ARE the filesystem. No abstraction layer needed; the manifest only exists post-build and adds coupling. |
+| Banlist regex compilation | Hand-crafted character-class regex | ripgrep `-f banlist.txt -F` | `-F` says "treat each pattern as a literal", `-f` reads patterns from a file. Adding a 7th literal is a one-line file edit. |
+| GitHub Actions annotation formatting | Custom JSON output parsed by a third-party action | `printf '::error file=...::message\n'` directly | The annotation format is a documented workflow-command stdin syntax; the runner picks it up automatically. No action plugin needed. |
+| Deliberate-failure test harness | Pytest, bats, or another test framework | Plain bash with `mktemp -d`, `git init -q`, `set -e` | The test is "run the script against a planted tree and assert non-zero exit." Three lines of bash. A framework adds friction. |
+
+**Key insight:** This phase is bash + ripgrep + git's own pathspec engine + a 50-line Playwright spec. The temptation to introduce a Python script or a node CLI tool is real and should be resisted — every new dependency is a new surface to sanitize.
+
+## Common Pitfalls
+
+### Pitfall 1: Required check + path filter = unmergeable PRs
+**What goes wrong:** A workflow with `on: pull_request: paths: ['runtime/**']` doesn't trigger on a PR that only touches `docs/`. The required status check then shows as "Expected — Waiting for status to be reported" forever, blocking merge.
+**Why it happens:** GitHub's required-check logic treats "workflow did not trigger" as "check never reported" — not as "check passed because it didn't need to run."
+**How to avoid:** Don't use `paths:` filters on workflows that are marked required. Sanitize runs in ~2s on the current tree; gating it on path changes is not worth the complexity.
+**Warning signs:** PRs sitting in "Some checks haven't completed" purgatory; check the workflow runs page — if the workflow shows zero runs for the head SHA, this is the trap.
+**Source:** [GitHub community discussion #44490 — Allow required checks to pass/skip when using path filtering](https://github.com/orgs/community/discussions/44490)
+
+### Pitfall 2: Allow-list glob semantics don't match user intuition
+**What goes wrong:** Author adds `docs/architecture/*.md` to `.sanitize-allowlist`, expecting it to also cover `docs/architecture/subfolder/foo.md`. It doesn't — single `*` doesn't cross `/`.
+**Why it happens:** This is `.gitignore` semantics, which is what `git ls-files :(exclude,glob)` uses. Most JS devs expect minimatch defaults where `*` may or may not cross `/` depending on options.
+**How to avoid:** Use `**` for recursive matching in the allow-list. Document this in the allow-list file header comment. Test by running `git ls-files -- ':(exclude,glob)docs/architecture/**'` locally and confirming the expected paths drop out.
+**Warning signs:** A file the author thought was allow-listed shows up as a gate hit; verify the actual glob expansion with `git ls-files`.
+
+### Pitfall 3: Playwright `webServer` starts before build artifacts exist
+**What goes wrong:** `pnpm start -p 3000` (current config) crashes immediately with "Could not find a production build" if `.next/` doesn't exist. Playwright's webServer waits for URL availability and times out at 120s.
+**Why it happens:** `next start` requires `next build` artifacts; the existing config assumes someone (a human running locally) has built first. CI doesn't have that context.
+**How to avoid:** Add an explicit `pnpm build` step in the workflow before `pnpm exec playwright test`. Alternative: change `webServer.command` to `pnpm build && pnpm start -p 3000` and bump `timeout` to 180000.
+**Warning signs:** Playwright failures with "Error: timed out waiting 120000ms" or HTTP 500s from the dashboard.
+
+### Pitfall 4: ripgrep matches its own arguments file
+**What goes wrong:** `scripts/sanitize/banlist.txt` contains the 6 literals as data; when the script enumerates tracked files via `git ls-files`, this file is in the list; ripgrep scans it; finds all 6 literals; exits non-zero. The gate fails because of its own configuration.
+**Why it happens:** The banlist file is, by design, a list of the banned literals.
+**How to avoid:** Allow-list `scripts/sanitize/banlist.txt` and `scripts/sanitize/unit-prefixes.txt` in `.sanitize-allowlist`. The `.sanitize-allowlist` file itself does not contain banned literals so does not need self-allow-listing — but if a future version comments out a literal as "allowed only here", it would, so allow-list it too pre-emptively.
+**Warning signs:** First CI run of the gate fails with hits inside `scripts/sanitize/`.
+
+### Pitfall 5: Network-idle wait masks empty-state false negatives
+**What goes wrong:** A page's `useEffect` fetches `/api/voice`, gets a 500 (because no backend), renders an error message "Failed to load voice status for arlowe-1". Page hits `networkidle` only after the error renders. Gate catches it. Good. BUT — if the API hangs (because the backend partially works and never responds), `networkidle` never fires, Playwright times out, test fails for the wrong reason and looks like a flake.
+**Why it happens:** `networkidle` is fragile when backends are unhealthy.
+**How to avoid:** Either (a) mock all `/api/*` routes in the spec with `page.route('**/api/**', r => r.fulfill({...}))` returning a deterministic error shape, OR (b) use `waitUntil: 'load'` (DOM ready, scripts run) which is less strict and lets the test scan whatever rendered, even if API requests are pending. CONTEXT picks "unconfigured backend, error states are valid render targets" — option (b) aligns with that. Recommend `waitUntil: 'load'` plus a short explicit `page.waitForTimeout(1500)` to let async useEffects settle. Yes, that's a sleep; for a 4-route test it's fine.
+**Warning signs:** Sanitize test passes locally, fails intermittently in CI with timeout errors.
+
+### Pitfall 6: Case-insensitive matches inside JSON / YAML keys
+**What goes wrong:** A future PR adds `casa_ybarra_chelsea` to a JSON object as a key name. The gate catches it (good). But a future PR adds an OAuth scope literal like `iol-monorepo-readonly` which is a coincidental substring match. False positive.
+**Why it happens:** Substring matching is what CONTEXT picked (no word-boundary anchoring) and the false-positive risk was explicitly accepted.
+**How to avoid:** Allow-list the offending file with a comment. This is the documented v1 behavior, not a bug.
+**Warning signs:** Author surprised by a hit on a file they didn't realize contained the substring. Failure-output message hints at the allow-list remedy.
+
+## Code Examples
+
+### Reading the banlist file once, scanning all tracked files
+```bash
+# Source: ripgrep --help (rg 14.1.1)
+rg -iFn --column --no-heading -f scripts/sanitize/banlist.txt -- $(git ls-files)
+```
+- `-i` case-insensitive
+- `-F` fixed strings (no regex interpretation)
+- `-n` line numbers
+- `--column` column of first match (1-based)
+- `--no-heading` flat `path:line:col:text` per match (default-on when output isn't a terminal, but explicit is safer)
+- `-f FILE` read patterns from FILE, one per line
+
+### Emitting GitHub annotations from a shell loop
+```bash
+# Source: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions
+printf '::error file=%s,line=%s,col=%s,title=%s::%s\n' \
+  "$path" "$line" "$col" "Banned literal" "$message"
+```
+The runner picks up `::error` lines on stdout (the `::` prefix and `::` separator are both required). Multi-line messages need `%0A` in place of `\n` inside the message body; for single-line messages this isn't a concern.
+
+### Excluding via git pathspec (gitignore-style)
+```bash
+# Source: git pathspec docs, magic signature :(exclude,glob)
+git ls-files -- \
+  ':(exclude,glob).planning/phases/01-runtime-extraction/**' \
+  ':(exclude,glob)docs/architecture/0001-iol-router-extraction.md'
+```
+Note the `glob` magic — without it, `**` would only literally match `**`. With it, `.gitignore` semantics apply.
+
+### Walking app/ for routes
+```typescript
+// Source: Node fs docs + Next.js App Router file conventions
+import { readdirSync, statSync } from 'fs';
+import { join } from 'path';
+
+function hasPage(dir: string): boolean {
+  try { return statSync(join(dir, 'page.tsx')).isFile(); } catch { return false; }
+}
+// then walk subdirectories, skipping 'api/', leading '_', and treating
+// '(group)/' as a transparent passthrough that does not add a URL segment.
+```
+
+## State of the Art
+
+| Old Approach | Current Approach | Notes |
+|--------------|------------------|-------|
+| GNU grep -rIn | ripgrep `rg` | Faster, gitignore-aware, JSON+vimgrep outputs. Standard on modern CI runners. |
+| Snapshot files for "must not contain X" tests | Direct assertion `expect(text).not.toMatch(/.../i)` | Snapshots are for "must look like Y" tests; banlist is "must not contain X" — negative assertion, no file artifact needed. |
+| Custom Github Actions for inline annotations | Plain `::error file=...::msg` printf to stdout | Workflow commands are runner-built-in; no marketplace action required. |
+| Pages Router `pages/foo.tsx` route convention | App Router `app/foo/page.tsx` | Already adopted in `runtime/dashboard/`. `page.tsx` is the public-page marker; `route.ts` is the API marker; route groups `(name)/` don't contribute URL segments. |
+
+**Deprecated/outdated:**
+- `--column` is shown in older ripgrep examples as if it implies `-n`; it does, but always pair with explicit `-n` for clarity. (rg 14 docs.)
+- The `paths:` filter on a required workflow is sometimes mentioned in older blog posts as a monorepo optimization — actively harmful for required-check workflows on small/fast scans. Use only with the "bucket job" aggregator pattern.
+
+## Open Questions
+
+1. **Should `.github/CODEOWNERS` be allow-listed, or sanitized?**
+   - What we know: it contains `* @focal55` because `@focal55` is the GitHub username of the founder, and CODEOWNERS routes workforce review automation. Removing it breaks the workforce protocol; sanitizing the username breaks GitHub's CODEOWNERS validation.
+   - What's unclear: whether SC1 considers GitHub-username `@focal55` "founder identity in the firmware sense" or just "version control plumbing."
+   - Recommendation: allow-list it. The risk SANIT exists to prevent is founder-identity strings *shipping in firmware/image*; CODEOWNERS never ships in any image. CONTEXT's deferred-ideas section already excludes "founder name/brand literals" so the author has already drawn this line.
+
+2. **Should `AGENTS.md.template` and `README.md` be allow-listed?**
+   - These reference `@focal55` and `github.com/focal55/agentic-workforce-template.git` for legitimate workforce-template purposes.
+   - Recommendation: allow-list. Same reasoning as CODEOWNERS — workforce plumbing doesn't ship.
+
+3. **Does the F5 ADR-0001 contradiction get fixed in Phase 2 or stay opportunistic?**
+   - F5 todo (`/Users/joeybarrajr/projects/arlowe-firmware/.planning/todos/pending/F5-adr-0001-why-option-2-internal-contradiction.md`) explicitly says "Opportunistic — fix the next time docs/architecture/0001-... is touched, OR roll into Phase 2 docs sanitization."
+   - The current Phase 2 SC4 ("the current runtime/ tree passes all sanitization checks") does NOT cover `docs/`. Allow-listing the ADR file means SC4 is met without touching the file.
+   - Recommendation: do the ADR fix as a side-quest task in Phase 2's plan (10 LOC, ~10 min) only if (a) the file ends up *not* allow-listed, or (b) the plan author wants to clear the F5 todo. Otherwise defer it. Not blocking.
+
+4. **Is the Phase 6 image-build hook future-proofed?**
+   - The unit-name block scans `git ls-files` for `*.service` etc. Phase 6 will need it to scan the assembled image rootfs *before* pi-gen finalizes the `.img`. That's a different filesystem (mounted rootfs at e.g. `/mnt/img/etc/systemd/system/`), not git.
+   - What's unclear: whether the same script can take a `--root DIR` argument and `find DIR -name '*.service'` instead of `git ls-files`, OR whether Phase 6 ships its own variant.
+   - Recommendation: design `check.sh` with a `--scan-dir DIR` flag from day one. Default scans `git ls-files`; with `--scan-dir`, it `find`s tracked-extension files under DIR. Phase 6 then reuses the binary, not just the logic. Document this contract in the script's header.
+
+5. **Does `pnpm exec playwright install --with-deps chromium` need every browser, or just chromium?**
+   - The existing config defines both chromium and firefox projects. The sanitize spec only needs one browser — HTML output is browser-independent for a rendered-text scan.
+   - Recommendation: in the sanitize CI job, pass `--project=chromium` to keep install time short. Other Playwright tests (connectivity, navigation) can still run multi-browser in a separate workflow.
+
+## Sources
+
+### Primary (HIGH confidence)
+- ripgrep 14.1.1 `--help` (verified directly via `rg --help` on dev machine) — flag semantics for `-i`, `-F`, `-n`, `--column`, `--no-heading`, `-f`, `--vimgrep`, `--json`.
+- Next.js App Router file conventions — [`/docs/app/getting-started/layouts-and-pages`](https://nextjs.org/docs/app/getting-started/layouts-and-pages) — verifies `page.tsx`/`route.ts`/dynamic segments/route groups.
+- Playwright `page.content()` returns full HTML — [Playwright Page API](https://playwright.dev/docs/api/class-page#page-content).
+- Playwright webServer `reuseExistingServer` semantics — [Playwright test-webserver docs](https://playwright.dev/docs/test-webserver).
+- GitHub Actions annotation syntax — [Workflow commands docs](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions).
+- Existing repo state directly inspected:
+  - `.github/workflows/ci.yml`, `pr-checks.yml`, `auto-label.yml`, `project-board-sync.yml`
+  - `runtime/dashboard/playwright.config.ts`, `package.json`, `tests/*.spec.ts`
+  - `runtime/dashboard/app/` route layout, `Navigation.tsx`, `layout.tsx`, `RetroActivityMonitor.tsx`
+  - `.gitignore` (confirms `.dev-stash/` is gitignored)
+  - `git grep -inE` direct output showing 16 runtime files with banned literals (the SC4 cleanup target)
+
+### Secondary (MEDIUM confidence)
+- GitHub required-check + path-filter trap — multiple community sources agree this is a real bug:
+  - [community discussion #44490](https://github.com/orgs/community/discussions/44490)
+  - [community discussion #26251](https://github.com/orgs/community/discussions/26251)
+  - [community discussion #54877](https://github.com/orgs/community/discussions/54877)
+- micromatch / minimatch / gitignore-glob comparison — [npm-compare micromatch vs minimatch](https://npm-compare.com/micromatch,minimatch). MEDIUM because the recommendation here is to avoid both in favor of git's native pathspec.
+
+### Tertiary (LOW confidence)
+- "Filesystem walk vs Next route manifest for test fixture" — pattern is common in community blog posts but not officially documented. Recommendation backed by reading the actual Next 16 docs that confirm file-system routing semantics. LOW because no single canonical source.
+
+## Metadata
+
+**Confidence breakdown:**
+- Standard stack: HIGH — every tool is already in the repo or pre-installed on `ubuntu-latest`; flags verified directly against `rg --help`.
+- Architecture: HIGH — script skeletons compiled mentally against actual repo file layout; no novel patterns.
+- Pitfalls: MEDIUM-HIGH — required-check trap is HIGH confidence (multiple GitHub community threads), Playwright `webServer` build-artifact trap is HIGH (read the config directly), networkidle flakiness is MEDIUM (general Playwright lore, not specific to this repo).
+- Open questions: explicit; planner should resolve allow-list scope (Q1, Q2) before tasking the gate runner.
+
+**Research date:** 2026-05-25
+**Valid until:** 2026-06-25 (30 days; ripgrep/playwright/GitHub Actions are stable, allow-list contents depend on what other PRs land first).

--- a/.planning/phases/03-service-user-and-filesystem-layout/03-01-PLAN.md
+++ b/.planning/phases/03-service-user-and-filesystem-layout/03-01-PLAN.md
@@ -1,0 +1,373 @@
+---
+phase: 03-service-user-and-filesystem-layout
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - scripts/provision/install-arlowe-user.sh
+  - scripts/provision/install-arlowe-fs.sh
+  - tests/phase-3/docker/Dockerfile
+  - tests/phase-3/docker/run-tests.sh
+  - tests/phase-3/assertions/01-user-shape.sh
+  - tests/phase-3/assertions/02-fs-layout.sh
+  - tests/phase-3/README.md
+  - docs/operations/phase-3-layout.md
+autonomous: true
+estimated_loc: 380
+requirements_covered:
+  - USER-01
+  - USER-02
+  - USER-03
+
+# Cross-phase notes baked in here so later phases honor them:
+# - OTA-01 amendment (assumed-accepted; Phase 9 must honor): OTA agent runs as a
+#   system-level systemd service with strictly sandboxed root, with
+#   ReadWritePaths=/opt/arlowe and a tight SystemCallFilter. The /opt/arlowe/
+#   tree is root-owned and read-only at runtime; only the OTA agent (running as
+#   sandboxed root) ever writes to it. If Phase 9 disagrees, raise it then —
+#   Phase 3 reserves /opt/arlowe ownership as root:arlowe 0750 to enable this.
+# - /var/lib/arlowe/identity/ is reserved as mode 0700 arlowe:arlowe; Phase 8
+#   pairing daemon will write to it (as root one-shot at first boot per research §9).
+# - /var/lib/arlowe/.ssh/ is intentionally NOT created — Phase 10 (support mode)
+#   creates it at runtime when support mode activates.
+# - The assertion scripts are env-var-driven from the start (ARLOWE_USER /
+#   ARLOWE_GROUP / ARLOWE_HOME / ARLOWE_OPT defaults). Plan 03-05's staging
+#   harness re-uses these assertions by exporting ARLOWE_USER=arlowe-staging
+#   before invocation — no edit-back required.
+
+must_haves:
+  truths:
+    - "With no env exports, on a fresh Debian bookworm container, `bash 01-user-shape.sh` passes: `id arlowe` returns a system user (uid in 100..999) with HOME=/var/lib/arlowe and shell=/usr/sbin/nologin"
+    - "`getent passwd focal55` returns nothing (founder account absent)"
+    - "`id -nG arlowe` includes audio, gpio, spi (and dialout + video as speculative; flagged for Phase 3 plan 05 hardware verification)"
+    - "Assertion scripts are env-var-driven: setting `ARLOWE_USER=arlowe-staging` (and the derived ARLOWE_GROUP/ARLOWE_HOME/ARLOWE_OPT) re-points every assertion at the staging tree without further edits — this is what plan 03-05 consumes"
+    - "After running install-arlowe-fs.sh, /opt/arlowe/ is root:arlowe 0750 and /var/lib/arlowe/ is arlowe:arlowe 0750"
+    - "/var/lib/arlowe/identity/ exists with mode 0700 owned by arlowe:arlowe (reserved for Phase 7 PKI)"
+    - "/var/lib/arlowe/conversations/ exists with mode 0700 owned by arlowe:arlowe (sensitive owner state)"
+    - "/etc/arlowe/ directory exists (root:arlowe 0755) but /etc/arlowe/config.yml is ABSENT (its absence is the Phase 8 pairing trigger per CONFIG-03)"
+    - "/opt/arlowe/config/ directory exists (root:arlowe 0755) but /opt/arlowe/config/defaults.yml is ABSENT (Phase 4 owns the file content; plan 01 only reserves the parent directory)"
+    - "Both install scripts are idempotent: re-running succeeds and does not change perms or duplicate group membership"
+    - "Docker testbed runs the install scripts in a debian:bookworm-slim container under systemd-as-PID-1 and the SC1+SC2 assertion scripts pass cleanly"
+  artifacts:
+    - path: "scripts/provision/install-arlowe-user.sh"
+      provides: "Idempotent `useradd --system` of arlowe with HOME=/var/lib/arlowe, shell=/usr/sbin/nologin, supplementary groups audio gpio spi dialout video"
+      min_lines: 60
+      contains: "useradd"
+    - path: "scripts/provision/install-arlowe-fs.sh"
+      provides: "Creates /opt/arlowe/{runtime,third_party,models,venvs,config}/, /var/lib/arlowe/{logs,conversations,identity,state,wake-word,dashboard/cache}/, /etc/arlowe/; sets ownership and modes per research §4 layout table"
+      min_lines: 80
+      contains: "install -d"
+    - path: "tests/phase-3/docker/Dockerfile"
+      provides: "debian:bookworm-slim base with systemd, useradd, python3, nodejs installed; entrypoint=systemd as PID 1"
+      min_lines: 15
+    - path: "tests/phase-3/docker/run-tests.sh"
+      provides: "Runs `docker run --privileged ...`, executes install scripts, runs assertions; exits non-zero on any assertion failure"
+      min_lines: 40
+    - path: "tests/phase-3/assertions/01-user-shape.sh"
+      provides: "SC1 assertions, env-var-parameterized (ARLOWE_USER default 'arlowe'): uid range, HOME, shell, founder-absent, group memberships"
+      min_lines: 20
+    - path: "tests/phase-3/assertions/02-fs-layout.sh"
+      provides: "SC2 assertions, env-var-parameterized (ARLOWE_USER / ARLOWE_OPT / ARLOWE_HOME defaults): ownership and mode of every path in the layout table; does NOT assert /opt/arlowe/config/defaults.yml (Phase 4 owns content; plan 01 only reserves parent dir)"
+      min_lines: 30
+    - path: "tests/phase-3/README.md"
+      provides: "How to run the Docker harness; how to interpret pass/fail; pointer to plan 05 for arlowe-1 hardware verification"
+      min_lines: 30
+    - path: "docs/operations/phase-3-layout.md"
+      provides: "Path × owner × mode × purpose × phase-that-populates reference table; explicitly documents `/var/lib/arlowe/.ssh/` as a Phase-10-owned path Phase 3 does NOT create"
+      min_lines: 60
+  key_links:
+    - from: "scripts/provision/install-arlowe-user.sh"
+      to: "/etc/passwd"
+      via: "useradd --system --user-group --create-home --home-dir /var/lib/arlowe --shell /usr/sbin/nologin"
+      pattern: "useradd .*--system.*--home-dir /var/lib/arlowe"
+    - from: "scripts/provision/install-arlowe-fs.sh"
+      to: "/opt/arlowe and /var/lib/arlowe"
+      via: "install -d -o root -g arlowe -m 0750 /opt/arlowe; install -d -o arlowe -g arlowe -m 0750 /var/lib/arlowe"
+      pattern: "install -d -o"
+    - from: "tests/phase-3/assertions/01-user-shape.sh"
+      to: "env-var parameterization (ARLOWE_USER / ARLOWE_GROUP / ARLOWE_HOME)"
+      via: "${VAR:-default} header substitutions used by every assertion below"
+      pattern: 'ARLOWE_USER:-arlowe'
+    - from: "tests/phase-3/docker/run-tests.sh"
+      to: "tests/phase-3/assertions/*.sh"
+      via: "loop in container"
+      pattern: "for a in /arlowe-firmware/tests/phase-3/assertions/\\*.sh"
+---
+
+<objective>
+Provision the `arlowe` system user and the on-disk filesystem layout (`/opt/arlowe/`, `/var/lib/arlowe/`, `/etc/arlowe/`) via two idempotent shell scripts, and stand up a Docker-based testbed that validates SC1 (user shape) and SC2 (filesystem layout) on a clean debian:bookworm-slim rootfs under systemd-as-PID-1.
+
+Purpose: This is the foundation every other Phase 3 plan stacks on (units, udev/polkit, CLI symlinks, hardware staging). Phase 6 (image build) consumes these scripts unchanged as a pi-gen overlay stage. Phase 9 (OTA), Phase 7 (PKI), and Phase 8 (pairing) all assume the directory ownership and mode contract established here.
+
+Output: Two install scripts (`scripts/provision/install-arlowe-{user,fs}.sh`), a Docker testbed (`tests/phase-3/docker/`), two env-var-parameterized assertion scripts that pass against the testbed, a README explaining how to run, and a layout-reference doc that downstream phases cite when they add files to the tree.
+</objective>
+
+<execution_context>
+@~/.claude/get-shit-done/workflows/execute-plan.md
+@~/.claude/get-shit-done/templates/summary.md
+
+This is the arlowe-firmware workforce. QA writes failing tests; DEV makes them pass; pr-reviewer reviews. For this plan:
+- The assertion scripts (`01-user-shape.sh`, `02-fs-layout.sh`) ARE the tests. QA writes them as failing first (against an empty Docker container — they fail because the user and dirs don't exist).
+- DEV then implements `install-arlowe-user.sh` and `install-arlowe-fs.sh` until `docker run ... && run-tests.sh` exits zero.
+
+One atomic PR. Estimated ≤400 net LOC.
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/REQUIREMENTS.md
+@.planning/phases/03-service-user-and-filesystem-layout/03-RESEARCH.md
+
+# Layout source-of-truth: research §3 (user recipe), §4 (filesystem tree), §11 (assertions)
+# Banlist (Phase 2): scripts/sanitize/banlist.txt — do NOT introduce focal55, /home/focal55, etc.
+# Test pattern reference: Phase 2 plan 02-01 used a similar "self-test asserts a planted failure" pattern.
+@scripts/sanitize/check.sh
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: QA writes failing SC1 + SC2 assertion scripts and Docker harness scaffold</name>
+  <files>
+    tests/phase-3/docker/Dockerfile
+    tests/phase-3/docker/run-tests.sh
+    tests/phase-3/assertions/01-user-shape.sh
+    tests/phase-3/assertions/02-fs-layout.sh
+    tests/phase-3/README.md
+  </files>
+  <action>
+Write the Docker testbed and assertion scripts FIRST. They must FAIL when run before Task 2 implements the install scripts.
+
+`tests/phase-3/docker/Dockerfile`:
+- Base: `debian:bookworm-slim`
+- Install: `systemd systemd-sysv python3 python3-venv nodejs npm` via apt
+- Configure systemd-as-PID-1 (remove `getty@.service` symlinks, set up STOPSIGNAL=SIGRTMIN+3)
+- ENTRYPOINT `/sbin/init`
+
+`tests/phase-3/docker/run-tests.sh` — **AUTO-DISCOVERY DESIGN, important for parallel-wave plans**:
+- Build image `arlowe-phase3-testbed`.
+- Inside the container, the harness must:
+  1. Loop over `/arlowe-firmware/scripts/provision/install-arlowe-*.sh` (sorted), SKIPPING any with `staging` in the name, and invoke each in order. This means plans 03-02, 03-03, 03-04 just drop their installers in `scripts/provision/` and run-tests.sh picks them up automatically — no run-tests.sh edits in those plans.
+  2. Invoke `/arlowe-firmware/units/install-units.sh` if it exists (plan 03-02 owns this file). Guard with `[[ -f ... ]]` so this plan (03-01) ships with the script absent and tests still pass.
+  3. Single-condition pre-stage: **If `/arlowe-firmware/scripts/provision/install-arlowe-cli.sh` exists, pre-stage marker files under `/opt/arlowe/runtime/cli/` BEFORE invoking that installer** (so install-arlowe-cli.sh can symlink to them). Files: face speak stt record boot-check purge-logs run-logrotate wake-train. Prefer `cp` from `/arlowe-firmware/runtime/cli/<name>` if it exists; fall back to `touch` if absent. Set 0755 mode + root:arlowe ownership on the staged files so plan 04's assertion can assert ownership matches the production contract.
+  4. Loop over `/arlowe-firmware/tests/phase-3/assertions/*.sh` (sorted) and bash each one. Exit non-zero on any failure.
+- Concrete invocation: `docker run --rm --privileged --tmpfs /run --tmpfs /tmp -v $(pwd)/../..:/arlowe-firmware:ro arlowe-phase3-testbed /bin/bash -c '<harness-body>'`.
+- Accept env var `PHASE_3_TESTBED_KEEP=1` to leave the container running for debugging (`docker run -d` then `docker exec`).
+
+This auto-discovery design is what lets plans 03-02, 03-03, 03-04 run in parallel without sharing files_modified on run-tests.sh.
+
+`tests/phase-3/assertions/01-user-shape.sh` — **env-var-driven from the start**:
+- Header: define the parameterization block at the top of the script. This is the substrate plan 03-05's staging harness reuses without edit-back:
+  ```bash
+  #!/bin/bash
+  set -euo pipefail
+  fail() { echo "FAIL: $*" >&2; exit 1; }
+
+  ARLOWE_USER="${ARLOWE_USER:-arlowe}"
+  ARLOWE_GROUP="${ARLOWE_GROUP:-${ARLOWE_USER}}"
+  ARLOWE_HOME="${ARLOWE_HOME:-/var/lib/${ARLOWE_USER}}"
+  ```
+- Lift the SC1 assertion semantics from research §11 (lines 820-829 of 03-RESEARCH.md) but replace the hard-coded `arlowe` / `focal55` / `/var/lib/arlowe` / `/usr/sbin/nologin` literals with the env-var expansions above.
+  - Exception: the founder-absent check stays a literal `getent passwd focal55` — that assertion is *about* a specific banned identity, not about the runtime user.
+- Assertions: uid<1000, HOME=$ARLOWE_HOME, shell=/usr/sbin/nologin, no focal55 user, audio/gpio/spi groups present on $ARLOWE_USER.
+- Note: dialout + video are speculative — assert them but mark with a comment `# Speculative; plan 05 confirms on hardware. Remove if plan 05 finds unnecessary.`
+
+`tests/phase-3/assertions/02-fs-layout.sh` — **env-var-driven from the start**:
+- Same parameterization header (ARLOWE_USER / ARLOWE_GROUP / ARLOWE_HOME), plus:
+  ```bash
+  ARLOWE_OPT="${ARLOWE_OPT:-/opt/${ARLOWE_USER}}"
+  ARLOWE_ETC="${ARLOWE_ETC:-/etc/${ARLOWE_USER}}"
+  ```
+- Lift the SC2 assertion semantics from research §11 (lines 833-849) but replace literal paths with `$ARLOWE_OPT` / `$ARLOWE_HOME` / `$ARLOWE_ETC` expansions.
+- **Critical omission when lifting from research §11: OMIT the `/opt/arlowe/config/defaults.yml` row.** Phase 4 owns the file content (per research §4 layout table, "Phase that populates" column for `defaults.yml` is "Phase 4"). Plan 03-01 only ensures the *parent directory* exists. Replace the omitted assertion with an assertion that `$ARLOWE_OPT/config/` exists as `root:$ARLOWE_GROUP 0755` and that `$ARLOWE_OPT/config/defaults.yml` is ABSENT. Do NOT create a placeholder file.
+- Use `stat -c '%U:%G %a'` for each path; grep against expected `^owner:group mode$` using the env-derived owner/group.
+- Assert `$ARLOWE_ETC/config.yml` is ABSENT (mirrors the defaults.yml absence — Phase 8 pairing creates).
+- Assert `$ARLOWE_HOME/.ssh/` is ABSENT (research §12.8 — Phase 10's job).
+- Assert `$ARLOWE_HOME/identity/` mode is exactly 0700.
+
+`tests/phase-3/README.md`:
+- One-line summary of what the harness validates.
+- Quickstart: `bash tests/phase-3/docker/run-tests.sh`.
+- Env-var override note: `ARLOWE_USER=arlowe-staging bash tests/phase-3/assertions/01-user-shape.sh` re-targets assertions at the staging tree; this is the contract plan 03-05 consumes.
+- Failure interpretation table: assertion script → which SC → which install script likely missing.
+- Pointer: "Hardware-loop validation (SC4 negative-write on real Pi) is owned by plan 03-05, not the Docker testbed."
+
+Use `bash` shebang; `set -euo pipefail`; no emojis. Run `bash -n` (syntax check) on each script as you write it.
+
+Verify they fail correctly: `cd tests/phase-3 && docker build -t arlowe-phase3-testbed docker/ && docker run --rm --privileged arlowe-phase3-testbed /bin/bash -c 'bash /arlowe-firmware/tests/phase-3/assertions/01-user-shape.sh'` should exit non-zero with "FAIL: ..." messages.
+  </action>
+  <verify>
+`bash -n tests/phase-3/assertions/01-user-shape.sh && bash -n tests/phase-3/assertions/02-fs-layout.sh && bash -n tests/phase-3/docker/run-tests.sh` — syntax-checks pass.
+
+`docker build -t arlowe-phase3-testbed tests/phase-3/docker/` — builds clean.
+
+Env-var contract: `ARLOWE_USER=arlowe-staging bash -n tests/phase-3/assertions/01-user-shape.sh` is a no-op syntax check (verifies the script parses with the env override; actual execution requires a staging-provisioned host).
+
+`docker run --rm --privileged arlowe-phase3-testbed /bin/bash -c 'sleep 1; bash -e' < tests/phase-3/assertions/01-user-shape.sh 2>&1 | grep -q "FAIL"` — assertions fail in a vanilla container (no arlowe user yet) when invoked with defaults.
+  </verify>
+  <done>
+Docker image builds. All four scripts pass `bash -n`. Assertion scripts exit non-zero in a container that hasn't yet had install scripts run. Assertions are env-var-driven (ARLOWE_USER / ARLOWE_GROUP / ARLOWE_HOME / ARLOWE_OPT / ARLOWE_ETC) with default values that match the production `arlowe` user. No `/opt/arlowe/config/defaults.yml` assertion present. README explains run/interpret. No emojis. No banned literals (`grep -E 'focal55|arlowe-1|casa_ybarra|/home/focal55|joe@focal55|iol-monorepo' tests/phase-3/` returns only the founder-absent assertion which is itself the negative check).
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 2: DEV implements install-arlowe-user.sh and install-arlowe-fs.sh until assertions pass</name>
+  <files>
+    scripts/provision/install-arlowe-user.sh
+    scripts/provision/install-arlowe-fs.sh
+  </files>
+  <action>
+Implement the two install scripts to make Task 1's assertions pass.
+
+`scripts/provision/install-arlowe-user.sh`:
+- Shebang `#!/bin/bash`, `set -euo pipefail`.
+- Header comment block describing purpose, idempotency contract, and invocation patterns (pi-gen stage, Docker testbed, plan 05 staging variant).
+- Constants: `ARLOWE_HOME=/var/lib/arlowe`, `ARLOWE_SHELL=/usr/sbin/nologin`.
+- If `! id -u arlowe >/dev/null 2>&1`, run `useradd --system --user-group --create-home --home-dir "$ARLOWE_HOME" --shell "$ARLOWE_SHELL" --comment "Arlowe runtime service account" arlowe`.
+- For each `grp in audio gpio spi dialout video`: if `getent group "$grp"` exists, `usermod -aG "$grp" arlowe` (idempotent — usermod is fine to re-run).
+- `chmod 0750 "$ARLOWE_HOME"`; `chown arlowe:arlowe "$ARLOWE_HOME"` (useradd defaults to 0755; we want 0750 per research §3).
+- Emit a single `echo "[install-arlowe-user] arlowe user provisioned (uid=$(id -u arlowe), groups=$(id -nG arlowe | tr ' ' ','))"` line so logs are diagnosable.
+- Do NOT use color codes; no emojis.
+
+`scripts/provision/install-arlowe-fs.sh`:
+- Shebang `#!/bin/bash`, `set -euo pipefail`.
+- Header comment block: purpose, idempotency, mount-point caveat (in Phase 6 `/var/lib/arlowe` is a separate partition mount-point — this script runs AFTER mount and creates directory contents).
+- Assert `getent passwd arlowe >/dev/null` or exit with "must run install-arlowe-user.sh first".
+- Create `/opt/arlowe/` tree per research §4 using `install -d -o root -g arlowe -m <mode>`:
+  - `/opt/arlowe` (0750)
+  - `/opt/arlowe/runtime` (0755)
+  - `/opt/arlowe/runtime/{voice,face,stt,tts,llm,dashboard,wake-word,cli}` (0755)
+  - `/opt/arlowe/third_party` (0755)
+  - `/opt/arlowe/models` (0755)
+  - `/opt/arlowe/venvs` (0755) — empty in Phase 3; Phase 6 populates
+  - `/opt/arlowe/config` (0755) — directory only; defaults.yml NOT created (Phase 4 owns content)
+- Create `/var/lib/arlowe/` tree using `install -d -o arlowe -g arlowe -m <mode>`:
+  - `/var/lib/arlowe` (0750)
+  - `/var/lib/arlowe/logs` (0750)
+  - `/var/lib/arlowe/logs/{voice,face,stt,tts,llm,dashboard}` (0750)
+  - `/var/lib/arlowe/conversations` (0700)
+  - `/var/lib/arlowe/identity` (0700)
+  - `/var/lib/arlowe/state` (0750)
+  - `/var/lib/arlowe/wake-word` (0750)
+  - `/var/lib/arlowe/dashboard/cache` (0750)
+- Create `/etc/arlowe` (`install -d -o root -g arlowe -m 0755 /etc/arlowe`). Do NOT create `config.yml`.
+- Do NOT create `/opt/arlowe/config/defaults.yml` (Phase 4 owns content).
+- Do NOT create `/var/lib/arlowe/.ssh/` (research §12.8).
+- Emit a `tree -L 2 /opt/arlowe /var/lib/arlowe` summary at the end (gracefully skip if `tree` not installed: `command -v tree >/dev/null && tree ... || ls -la ...`).
+- Final `echo "[install-arlowe-fs] layout provisioned"`.
+
+Run `tests/phase-3/docker/run-tests.sh` and iterate until assertions pass. Common gotchas:
+- Mode 0700 vs 0750 mismatches on identity/ and conversations/.
+- `install -d` does NOT recursively set mode on existing parent dirs — set them explicitly.
+- Re-running the script must not bump perms; assert idempotency by running twice and checking `stat` outputs match.
+  </action>
+  <verify>
+`bash -n scripts/provision/install-arlowe-user.sh && bash -n scripts/provision/install-arlowe-fs.sh` — syntax clean.
+
+`bash tests/phase-3/docker/run-tests.sh` — Docker testbed builds, runs install scripts inside container, all assertions pass (exit 0).
+
+Idempotency: re-run via `docker run --rm --privileged arlowe-phase3-testbed /bin/bash -c 'bash /arlowe-firmware/scripts/provision/install-arlowe-user.sh && bash /arlowe-firmware/scripts/provision/install-arlowe-user.sh && bash /arlowe-firmware/scripts/provision/install-arlowe-fs.sh && bash /arlowe-firmware/scripts/provision/install-arlowe-fs.sh && bash /arlowe-firmware/tests/phase-3/assertions/02-fs-layout.sh'` — second run still passes assertions.
+
+Banlist: `bash scripts/sanitize/check.sh --grep-only scripts/provision/ tests/phase-3/` returns clean.
+  </verify>
+  <done>
+Both install scripts implemented and idempotent. `/opt/arlowe/config/` directory created (root:arlowe 0755); `/opt/arlowe/config/defaults.yml` NOT created (Phase 4 owns). Docker testbed run-tests.sh exits 0. Re-running install scripts does not change ownership/mode. Phase 2 sanitization gate (`scripts/sanitize/check.sh`) passes on all new files.
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Layout reference doc + cross-phase contract notes</name>
+  <files>
+    docs/operations/phase-3-layout.md
+  </files>
+  <action>
+Write `docs/operations/phase-3-layout.md`. This is the canonical reference downstream phases will cite when adding files to `/opt/arlowe/` or `/var/lib/arlowe/`. Lift the path × owner × mode table from research §4 verbatim and adapt for clarity.
+
+Required sections:
+
+1. **Overview** (1 short paragraph): What Phase 3 owns vs. what later phases own. Mention this doc is the contract.
+
+2. **Layout tree** (ASCII tree from research §4, lightly annotated).
+
+3. **Path × owner × mode × purpose × phase-that-populates** table (research §4 table verbatim). Every row.
+
+4. **What Phase 3 does NOT do** (numbered list):
+   - Does NOT create `/etc/arlowe/config.yml` (its absence is the CONFIG-03 pairing trigger).
+   - Does NOT create `/opt/arlowe/config/defaults.yml` (Phase 4 owns content; plan 03-01 only reserves the parent dir).
+   - Does NOT create `/var/lib/arlowe/.ssh/` (Phase 10 owns; support mode creates at runtime).
+   - Does NOT create venv contents (Phase 6 populates from runtime/*/requirements.txt).
+   - Does NOT create model files (Phase 6 stages).
+   - Does NOT write Axera udev rule or polkit rule (plan 03-03 owns).
+   - Does NOT install CLI symlinks (plan 03-04 owns).
+
+5. **OTA-01 amendment notice**: Quote the original OTA-01 wording, then state the amendment:
+   > "OTA-01 (original): OTA agent runs as a systemd service on the `arlowe` user.
+   >
+   > **OTA-01 (amended, assumed by Phase 3 plan 01)**: OTA agent runs as a system-level systemd service with strictly sandboxed root: `ProtectSystem=strict`, `ReadWritePaths=/opt/arlowe`, `NoNewPrivileges=yes`, tight `SystemCallFilter=`. Rationale: `/opt/arlowe/` is root-owned and read-only at runtime; the only writer is the OTA agent. Running OTA as `arlowe` would require either making `/opt/arlowe` writable by `arlowe` (defeats USER-02) or wiring polkit grants (more complex, harder to audit). Phase 9 must honor this contract or raise an ADR amendment when it lands."
+
+6. **Phase 8 pairing daemon reservation**: One paragraph noting Phase 8 will need to write `/var/lib/arlowe/identity/` and `/etc/arlowe/config.yml`. Phase 3 leaves identity/ writable by arlowe (mode 0700 arlowe:arlowe) — that path is fine. For `/etc/arlowe/config.yml` the recommendation is a root-one-shot pairing daemon (per research §9 + §12.2). Phase 8 may revise.
+
+7. **Verification**: Pointer to `tests/phase-3/docker/run-tests.sh` and to plan 03-05 for hardware-loop validation.
+
+No emojis. Use Markdown tables. Cite line ranges from `03-RESEARCH.md` where helpful for source-of-truth.
+
+Sanity-check against the Phase 2 sanitize gate.
+  </action>
+  <verify>
+`bash scripts/sanitize/check.sh --grep-only docs/operations/phase-3-layout.md` — clean.
+
+`grep -c "Phase " docs/operations/phase-3-layout.md` — at least 6 phase references (3, 4, 6, 7, 8, 9, 10).
+
+Manual: file is a single self-contained reference, not duplicative of research.md.
+  </verify>
+  <done>
+Layout doc written, sanitization-clean, covers SC1+SC2 paths plus the OTA-01 amendment and Phase 8 pairing-daemon reservation explicitly. Downstream phase planners can cite this doc instead of the long research file.
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+End-to-end:
+
+```bash
+# SC1 + SC2 must pass:
+bash tests/phase-3/docker/run-tests.sh
+
+# Env-var contract is honored (re-targets at a hypothetical staging tree without edits):
+ARLOWE_USER=arlowe-staging bash -n tests/phase-3/assertions/01-user-shape.sh
+ARLOWE_USER=arlowe-staging bash -n tests/phase-3/assertions/02-fs-layout.sh
+
+# Phase 2 sanitization gate must pass on all new files:
+bash scripts/sanitize/check.sh --grep-only scripts/provision/ tests/phase-3/ docs/operations/phase-3-layout.md
+
+# Idempotency:
+docker run --rm --privileged arlowe-phase3-testbed /bin/bash -c 'bash /arlowe-firmware/scripts/provision/install-arlowe-user.sh && bash /arlowe-firmware/scripts/provision/install-arlowe-user.sh && bash /arlowe-firmware/tests/phase-3/assertions/01-user-shape.sh'
+
+# Atomic-PR check:
+git diff --shortstat origin/main..HEAD  # Should be <= ~400 net LOC
+```
+</verification>
+
+<success_criteria>
+- `id arlowe` in the Docker testbed returns uid<1000, HOME=/var/lib/arlowe, shell=/usr/sbin/nologin (SC1)
+- `/opt/arlowe/` is root:arlowe 0750; `/var/lib/arlowe/` is arlowe:arlowe 0750; `/etc/arlowe/config.yml` absent; `/opt/arlowe/config/defaults.yml` absent (SC2 partial — units come in plan 02)
+- Assertion scripts honor ARLOWE_USER / ARLOWE_GROUP / ARLOWE_HOME / ARLOWE_OPT / ARLOWE_ETC env vars with defaults matching the production tree
+- Install scripts are idempotent (verified by running twice)
+- Layout doc cites OTA-01 amendment, Phase 8 pairing reservation, and Phase 10 .ssh/ deferral explicitly
+- Phase 2 sanitization gate green on all new files
+- PR is ≤400 net LOC (hard cap 600)
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/03-service-user-and-filesystem-layout/03-01-SUMMARY.md` following the SUMMARY template. Frontmatter must include `provides:` entries for:
+- `/opt/arlowe/` and `/var/lib/arlowe/` directory contracts (cite docs/operations/phase-3-layout.md)
+- OTA-01 amendment (so the GSD frontmatter scanner picks it up for Phase 9)
+- Phase 8 pairing-daemon reservation note
+- The Docker testbed (so plans 02-05 know it exists)
+- The env-var contract on the assertion scripts (ARLOWE_USER / ARLOWE_GROUP / ARLOWE_HOME / ARLOWE_OPT / ARLOWE_ETC) — plan 03-05's staging harness consumes this without edit-back
+</output>
+</output>

--- a/.planning/phases/03-service-user-and-filesystem-layout/03-02-PLAN.md
+++ b/.planning/phases/03-service-user-and-filesystem-layout/03-02-PLAN.md
@@ -1,0 +1,384 @@
+---
+phase: 03-service-user-and-filesystem-layout
+plan: 02
+type: execute
+wave: 2
+depends_on:
+  - "03-01"
+files_modified:
+  - units/arlowe-face.service
+  - units/arlowe-voice.service
+  - units/arlowe-dashboard.service
+  - units/qwen-tokenizer.service
+  - units/qwen-api.service
+  - units/whisper-stt.service
+  - units/install-units.sh
+  - tests/phase-3/assertions/03-unit-syntax.sh
+autonomous: true
+estimated_loc: 440
+requirements_covered:
+  - USER-04
+  - USER-05
+
+# Split-trigger note for the executor: if mid-implementation the diff is
+# tracking toward >550 LOC, split into 03-02a (face + voice + dashboard +
+# install-units.sh + assertion) and 03-02b (qwen-tokenizer + qwen-api +
+# whisper-stt). Same wave, no file overlap, both depend only on 03-01.
+# Don't pre-split; the unit files are mostly identical boilerplate so one PR is fine.
+
+must_haves:
+  truths:
+    - "Six systemd unit files exist under units/: arlowe-face.service, arlowe-voice.service, arlowe-dashboard.service, qwen-tokenizer.service, qwen-api.service, whisper-stt.service"
+    - "Every shipping unit declares User=arlowe and Group=arlowe (USER-04: no --user units)"
+    - "Every shipping unit declares PrivateTmp=yes, ProtectSystem=strict, ProtectHome=yes, NoNewPrivileges=yes (USER-05 baseline)"
+    - "Every unit declares unit-appropriate ReadWritePaths under /var/lib/arlowe/ (USER-05 per-unit)"
+    - "Hardware-touching units (arlowe-face, arlowe-voice, qwen-api) declare PrivateDevices=no plus explicit DeviceAllow= entries; network-only units (dashboard, qwen-tokenizer, whisper-stt) declare PrivateDevices=yes"
+    - "`systemd-analyze verify` returns no errors for every unit (warnings acceptable but logged)"
+    - "`systemd-analyze security <unit>` score is ≤ 4.5 for hardware-touching units (face/voice/qwen-api) and ≤ 3.5 for network-only units (dashboard/qwen-tokenizer/whisper-stt). Thresholds are slightly looser than research's aspirational targets to allow real-world Docker variance without a re-tuning loop in plan 05."
+    - "No unit name matches the Phase 2 banlist (`openclaw-*`, `trace-*`, `workforce-metrics-snapshot.*`); `scripts/sanitize/check.sh --units-only --scan-dir units/` passes"
+    - "install-units.sh copies all six units into /etc/systemd/system/, runs `systemctl daemon-reload`, and is idempotent"
+    - "The Docker testbed (run-tests.sh from plan 01) auto-discovers `units/install-units.sh` and the new `03-unit-syntax.sh` assertion via its glob loops — plan 03-02 does NOT edit run-tests.sh"
+    - "RemoveIPC is set to `no` on arlowe-voice (and inherited from systemd default elsewhere) per research §12.7 to avoid POSIX shmem disruption with pyaudio/ALSA"
+  artifacts:
+    - path: "units/arlowe-face.service"
+      provides: "Face display service unit; User=arlowe, SupplementaryGroups=gpio spi video, PrivateDevices=no, DeviceAllow for /dev/spidev*, /dev/gpiomem, /dev/gpiochip0, /dev/gpiochip4, /dev/fb0, ReadWritePaths=/var/lib/arlowe/state /var/lib/arlowe/logs/face"
+      min_lines: 40
+      contains: "User=arlowe"
+    - path: "units/arlowe-voice.service"
+      provides: "Voice orchestrator unit; User=arlowe, SupplementaryGroups=audio dialout, PrivateDevices=no, DeviceAllow=/dev/snd/* rw, RestrictRealtime=no, RemoveIPC=no, ReadWritePaths=/var/lib/arlowe/state /var/lib/arlowe/logs /var/lib/arlowe/conversations, After=arlowe-face.service whisper-stt.service qwen-api.service"
+      min_lines: 45
+      contains: "RemoveIPC=no"
+    - path: "units/arlowe-dashboard.service"
+      provides: "Next.js standalone dashboard unit; User=arlowe, PrivateDevices=yes, ExecStart=/usr/bin/node /opt/arlowe/runtime/dashboard/server.js, NEXT_PRIVATE_CACHE_DIR=/var/lib/arlowe/dashboard/cache, ReadWritePaths=/var/lib/arlowe/dashboard /var/lib/arlowe/logs/dashboard, FIXME comment about Phase 4 /etc/arlowe/config.yml write path"
+      min_lines: 40
+      contains: "NEXT_PRIVATE_CACHE_DIR"
+    - path: "units/qwen-tokenizer.service"
+      provides: "Tokenizer HTTP service; baseline hardening; ReadWritePaths=/var/lib/arlowe/logs/llm"
+      min_lines: 30
+    - path: "units/qwen-api.service"
+      provides: "ax-llm API server unit; PrivateDevices=no, DeviceAllow=/dev/axcl_host /dev/ax_mmb_dev rw, After=qwen-tokenizer.service, Requires=qwen-tokenizer.service, explicit PATH= including /opt/arlowe/third_party/axcl/bin"
+      min_lines: 35
+      contains: "DeviceAllow=/dev/axcl_host"
+    - path: "units/whisper-stt.service"
+      provides: "STT HTTP service; baseline hardening; PrivateDevices=yes; ReadWritePaths=/var/lib/arlowe/logs/stt"
+      min_lines: 30
+    - path: "units/install-units.sh"
+      provides: "Copies units/*.service to /etc/systemd/system/, runs daemon-reload; idempotent (cp -f is fine, but skip if no changes via cmp)"
+      min_lines: 30
+    - path: "tests/phase-3/assertions/03-unit-syntax.sh"
+      provides: "SC3 assertion: systemd-analyze verify + systemd-analyze security per unit with threshold gates; checks User=arlowe present; sanitization unit-name check"
+      min_lines: 50
+  key_links:
+    - from: "units/arlowe-voice.service"
+      to: "arlowe-face.service, whisper-stt.service, qwen-api.service"
+      via: "After= and Wants= directives (Requires=arlowe-face hardest)"
+      pattern: "After=arlowe-face.service whisper-stt.service qwen-api.service"
+    - from: "units/install-units.sh"
+      to: "/etc/systemd/system/"
+      via: "install -m 0644 units/*.service /etc/systemd/system/ && systemctl daemon-reload"
+      pattern: "systemctl daemon-reload"
+---
+
+<objective>
+Author six systemd service units (`arlowe-face`, `arlowe-voice`, `arlowe-dashboard`, `qwen-tokenizer`, `qwen-api`, `whisper-stt`), an install helper, and an assertion script that gates SC3 (system-level, runs as arlowe, sandboxed). Validate via `systemd-analyze verify` and `systemd-analyze security` inside the Phase 3 Docker testbed.
+
+Purpose: SC3 is the heart of Phase 3. Once these six units exist and pass `systemd-analyze`, every later phase has a stable systemd contract to extend. Phase 4 (config overlay) updates `Environment=` lines and `ReadWritePaths`. Phase 5 (audio) consumes `arlowe-voice`'s sound-device permissions. Phase 6 (image build) ships these unit files via pi-gen unchanged. Phase 11 (boot health) layers a oneshot `arlowe-boot-check.service` on top.
+
+Output: Six `.service` files under `units/`, one `install-units.sh`, one assertion script. The Docker testbed (run-tests.sh from plan 01) picks up install-units.sh and the new assertion via its auto-discovery loops — this plan does NOT touch run-tests.sh, which keeps Wave 2 plans (02, 03, 04) file-conflict-free.
+</objective>
+
+<execution_context>
+@~/.claude/get-shit-done/workflows/execute-plan.md
+@~/.claude/get-shit-done/templates/summary.md
+
+QA writes the assertion script first (which fails because the units don't exist). DEV authors the units until `systemd-analyze verify` and `systemd-analyze security <threshold>` pass.
+
+This is borderline-spec-heavy work; TDD value is moderate. The assertion-first pattern still works because `systemd-analyze` is a concrete, scriptable verifier.
+
+Atomic PR ≤440 LOC estimated. If the diff trends >550 LOC during implementation, split into 03-02a (face + voice + dashboard + install-units + assertion) and 03-02b (qwen-tokenizer + qwen-api + whisper-stt). Same wave, no file overlap.
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/REQUIREMENTS.md
+@.planning/phases/03-service-user-and-filesystem-layout/03-RESEARCH.md
+@.planning/phases/03-service-user-and-filesystem-layout/03-01-PLAN.md
+@docs/operations/phase-3-layout.md
+
+# Unit specifications live in research §7 (lines 320-708). Read those before writing.
+# Phase 2 sanitization gate (.dev-stash/arlowe-1/systemd-* contains the legacy --user units; do NOT copy from there — research §7 has the authoritative system-level rewrite).
+@scripts/sanitize/check.sh
+@runtime/voice/voice_client.py
+@runtime/face/face_service.py
+@runtime/dashboard/package.json
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: QA writes 03-unit-syntax.sh assertion script (fails before units exist)</name>
+  <files>
+    tests/phase-3/assertions/03-unit-syntax.sh
+  </files>
+  <action>
+Write the SC3 assertion script. It must:
+
+1. Define `fail() { echo "FAIL: $*" >&2; exit 1; }` at top.
+
+2. Define unit list: `UNITS=(arlowe-face arlowe-voice arlowe-dashboard qwen-tokenizer qwen-api whisper-stt)`.
+
+3. For each unit:
+   - Assert `/etc/systemd/system/<unit>.service` exists (this catches "install-units.sh didn't run").
+   - Run `systemd-analyze verify /etc/systemd/system/<unit>.service`. Exit non-zero on error. Allow warnings (capture and print but don't fail).
+   - Run `systemd-analyze security <unit>.service --no-pager | tee /tmp/sec-<unit>.txt`; extract the overall exposure score (look for "Overall exposure level for <unit>.service: <score>").
+   - Compare against threshold table:
+     ```bash
+     declare -A MAX_SCORE
+     MAX_SCORE[arlowe-face]=4.5
+     MAX_SCORE[arlowe-voice]=4.5
+     MAX_SCORE[qwen-api]=4.5
+     MAX_SCORE[arlowe-dashboard]=3.5
+     MAX_SCORE[qwen-tokenizer]=3.5
+     MAX_SCORE[whisper-stt]=3.5
+     ```
+     (Slightly looser than research §11's 4.0/3.0 to allow real-world variance — research's targets are aspirational; these are gate-level.)
+   - Use `awk -v s="$score" -v m="$max" 'BEGIN { exit !(s+0 <= m+0) }'` for the float comparison.
+
+4. Assert `User=arlowe` and `Group=arlowe` are literally present in every unit file (`grep -q '^User=arlowe$'`).
+
+5. Assert no unit name in the Phase 2 banlist: run `bash /arlowe-firmware/scripts/sanitize/check.sh --units-only --scan-dir /arlowe-firmware/units/` and require exit 0.
+
+6. Assert no `--user` systemd directories on the container: `test ! -d /home/arlowe/.config/systemd/user && test ! -d /var/lib/arlowe/.config/systemd/user`.
+
+7. Special-case assertions:
+   - `arlowe-voice.service` MUST contain `RemoveIPC=no` (research §12.7).
+   - `arlowe-face.service` MUST contain `DeviceAllow=/dev/gpiochip0` AND `DeviceAllow=/dev/gpiochip4` (research §12.4 — both Pi 5 chips covered until plan 05 confirms which).
+   - `qwen-api.service` MUST contain `DeviceAllow=/dev/axcl_host` AND `DeviceAllow=/dev/ax_mmb_dev`.
+   - `arlowe-dashboard.service` MUST contain `NEXT_PRIVATE_CACHE_DIR=/var/lib/arlowe/dashboard/cache`.
+   - `arlowe-dashboard.service` MUST NOT contain `/etc/arlowe/config.yml` in any `ReadWritePaths=` line (Phase 4 owns the write path).
+
+8. Print a summary table at the end: unit name | verify result | security score | threshold | pass/fail.
+
+Run `bash -n tests/phase-3/assertions/03-unit-syntax.sh` to check syntax.
+
+Plan 03-02 does NOT modify `tests/phase-3/docker/run-tests.sh`. Plan 01's auto-discovery design picks up `units/install-units.sh` and any new assertion `*.sh` under `tests/phase-3/assertions/` automatically (see plan 03-01 Task 1 description).
+  </action>
+  <verify>
+`bash -n tests/phase-3/assertions/03-unit-syntax.sh` — clean.
+
+Manual: against a Docker container with arlowe user provisioned but no units installed, this script exits non-zero with "FAIL: /etc/systemd/system/arlowe-face.service missing" or similar.
+
+No banned literals in the file (`bash scripts/sanitize/check.sh --grep-only tests/phase-3/assertions/03-unit-syntax.sh`).
+  </verify>
+  <done>
+Assertion script written, syntax-clean, exits non-zero against a container that has only plan 01's install scripts run (no units yet). All special-case requirements (RemoveIPC=no on voice, both gpiochip nodes on face, DeviceAllow for axcl on qwen-api, NEXT_PRIVATE_CACHE_DIR on dashboard) are checked.
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 2: DEV authors six unit files + install-units.sh</name>
+  <files>
+    units/arlowe-face.service
+    units/arlowe-voice.service
+    units/arlowe-dashboard.service
+    units/qwen-tokenizer.service
+    units/qwen-api.service
+    units/whisper-stt.service
+    units/install-units.sh
+  </files>
+  <action>
+Author the six unit files following research §7 verbatim, with the following adjustments and additions:
+
+**Common baseline (every unit):**
+```ini
+[Unit]
+Description=...
+After=...
+
+[Service]
+Type=simple
+User=arlowe
+Group=arlowe
+WorkingDirectory=...
+Environment=PYTHONUNBUFFERED=1
+ExecStart=...
+Restart=on-failure
+RestartSec=5
+
+# Sandbox hardening
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=strict
+ProtectHome=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+ProtectKernelLogs=yes
+ProtectClock=yes
+ProtectHostname=yes
+LockPersonality=yes
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged @resources
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+
+# Per-unit deltas below
+
+[Install]
+WantedBy=multi-user.target
+```
+
+**Unit-specific deltas (lift from research §7, lines 358-680):**
+
+- `arlowe-face.service`: `SupplementaryGroups=gpio spi video`, `PrivateDevices=no`, `DeviceAllow=` lines for `/dev/spidev0.0`, `/dev/spidev0.1`, `/dev/gpiomem`, `/dev/gpiochip0`, `/dev/gpiochip4`, `/dev/fb0` (each `rw`), `ReadWritePaths=/var/lib/arlowe/state /var/lib/arlowe/logs/face`, `ExecStart=/opt/arlowe/venvs/voice/bin/python -m face.face_service`. Add a `# FIXME(F1, Phase 4): port 8080 hardcoded in face_service.py` comment block above the [Install] section.
+
+- `arlowe-voice.service`: `SupplementaryGroups=audio dialout`, `PrivateDevices=no`, `DeviceAllow=/dev/snd/* rw`, `DeviceAllow=/dev/snd/seq rw`, `DeviceAllow=/dev/snd/timer r`, `RestrictRealtime=no` (override baseline), `RemoveIPC=no` (research §12.7), `ReadWritePaths=/var/lib/arlowe/state /var/lib/arlowe/logs /var/lib/arlowe/conversations`, `RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX AF_NETLINK` (override baseline to add AF_NETLINK for ALSA enumeration), `SystemCallFilter=~@privileged` only (drop `@resources` for now per research §10 friction note about Python subprocess), Requires/Wants/After=arlowe-face.service whisper-stt.service qwen-api.service. Add a `# FIXME(F4, Phase 4): voice_client.py shells out to 'sudo tee' for fan control; will break under NoNewPrivileges. Tracked as a Phase 4 cleanup.` comment.
+
+- `arlowe-dashboard.service`: `PrivateDevices=yes`, no `DeviceAllow=`, env vars include `NODE_ENV=production`, `PORT=3000`, `HOSTNAME=0.0.0.0`, `NEXT_TELEMETRY_DISABLED=1`, `NEXT_PRIVATE_CACHE_DIR=/var/lib/arlowe/dashboard/cache`, `ARLOWE_CONFIG_PATH=/etc/arlowe/config.yml`, `ARLOWE_LOGS_DIR=/var/lib/arlowe/logs`, `ARLOWE_SYSTEMCTL_MODE=system`, `ExecStart=/usr/bin/node /opt/arlowe/runtime/dashboard/server.js`, `ReadWritePaths=/var/lib/arlowe/dashboard /var/lib/arlowe/logs/dashboard`. Add a `# FIXME(Phase 4): /etc/arlowe/config.yml writes go through a privileged helper, not ReadWritePaths.` comment.
+
+- `qwen-tokenizer.service`: full baseline, `PrivateDevices=yes`, `ExecStart=/opt/arlowe/venvs/llm/bin/python /opt/arlowe/runtime/llm/qwen2.5_tokenizer_uid.py`, `ReadWritePaths=/var/lib/arlowe/logs/llm`.
+
+- `qwen-api.service`: `PrivateDevices=no`, `DeviceAllow=/dev/axcl_host rw`, `DeviceAllow=/dev/ax_mmb_dev rw`, `Environment=PATH=/opt/arlowe/third_party/axcl/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin` (research §10 friction-class), `ExecStart=/opt/arlowe/runtime/llm/run_api.sh`, `After=qwen-tokenizer.service network.target`, `Requires=qwen-tokenizer.service`, `ReadWritePaths=/var/lib/arlowe/logs/llm`. Drop `ProtectKernelModules` from this unit (research §7 note about ax-llm).
+
+- `whisper-stt.service`: full baseline, `PrivateDevices=yes`, `ExecStart=/opt/arlowe/venvs/stt/bin/python /opt/arlowe/runtime/stt/stt_server.py`, `ReadWritePaths=/var/lib/arlowe/logs/stt`.
+
+**`units/install-units.sh`:**
+```bash
+#!/bin/bash
+# Idempotent installer for arlowe systemd units. Copies units/*.service to
+# /etc/systemd/system/ and runs daemon-reload. Invoked by pi-gen and by the
+# Phase 3 Docker testbed.
+set -euo pipefail
+
+UNIT_SRC_DIR="$(cd "$(dirname "$0")" && pwd)"
+TARGET=/etc/systemd/system
+
+install -d -m 0755 "$TARGET"
+
+for unit in "$UNIT_SRC_DIR"/*.service; do
+    name=$(basename "$unit")
+    # Skip copy if identical (idempotent, no daemon-reload churn)
+    if ! cmp -s "$unit" "$TARGET/$name" 2>/dev/null; then
+        install -m 0644 -o root -g root "$unit" "$TARGET/$name"
+        CHANGED=1
+    fi
+done
+
+if [[ "${CHANGED:-0}" == "1" ]]; then
+    systemctl daemon-reload
+fi
+
+echo "[install-units] $(ls "$UNIT_SRC_DIR"/*.service | wc -l) units present in $TARGET"
+```
+
+After writing, run `systemd-analyze verify <unit>` on each unit (locally if you have systemd, else in the Docker testbed) to catch typos. Common errors:
+- Trailing whitespace on `ExecStart=` lines.
+- `User=arlowe` declared but `Group=arlowe` missing.
+- `DeviceAllow=` line without `PrivateDevices=no` (silently ignored).
+
+NO banned literals in any unit file. Run `bash scripts/sanitize/check.sh --grep-only units/` after writing.
+  </action>
+  <verify>
+`for f in units/*.service; do test -f "$f"; done` — six files present.
+
+In Docker testbed: `docker run --rm --privileged -v $(pwd):/arlowe-firmware:ro arlowe-phase3-testbed /bin/bash -c 'bash /arlowe-firmware/scripts/provision/install-arlowe-user.sh && bash /arlowe-firmware/scripts/provision/install-arlowe-fs.sh && bash /arlowe-firmware/units/install-units.sh && systemctl daemon-reload && for u in arlowe-face arlowe-voice arlowe-dashboard qwen-tokenizer qwen-api whisper-stt; do systemd-analyze verify /etc/systemd/system/$u.service; done'` — all six verify clean.
+
+`bash scripts/sanitize/check.sh --grep-only units/` — clean.
+
+`bash scripts/sanitize/check.sh --units-only --scan-dir units/` — clean (no banlisted prefixes).
+
+Idempotency: run install-units.sh twice; second run prints "[install-units] 6 units present" without triggering daemon-reload (verified by `journalctl --grep="Reloading"` or inferred from CHANGED variable behavior).
+  </verify>
+  <done>
+Six unit files exist and `systemd-analyze verify` returns clean for each. install-units.sh is idempotent. Sanitization gate green. All special-case requirements (RemoveIPC=no, both gpiochips, axcl DeviceAllow, NEXT_PRIVATE_CACHE_DIR) present. FIXMEs flagged for Phase 4 cleanups (face port-8080, voice sudo tee, dashboard config.yml write path).
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Run SC3 end-to-end via plan-01's auto-discovery run-tests.sh</name>
+  <files>
+  </files>
+  <action>
+No file edits in this task — plan 01's `run-tests.sh` already loops over `units/install-units.sh` (if present) and `tests/phase-3/assertions/*.sh` (any new `.sh` file). With this plan's six unit files + install-units.sh + 03-unit-syntax.sh on disk, run-tests.sh picks them up on next invocation.
+
+Run end-to-end: `bash tests/phase-3/docker/run-tests.sh` — should pass all three assertion scripts (01-user-shape, 02-fs-layout, 03-unit-syntax).
+
+Common failure modes and fixes:
+- `systemd-analyze security` returns score worse than threshold → tighten the unit. Common culprits: missing `RestrictAddressFamilies`, missing `LockPersonality`, `PrivateDevices=no` without enough `DeviceAllow` justification. Look at `systemd-analyze security <unit> --no-pager` output for the per-directive impact.
+- `RestrictAddressFamilies=AF_NETLINK` added but score still penalized — that's expected; AF_NETLINK has a known small score penalty.
+- `RestrictRealtime=no` (voice unit) takes ~0.1 off the score — accepted.
+
+If a unit's score is borderline, document the trade-off as an inline comment in the unit file (e.g., `# Score: 4.2 — RestrictRealtime=no required for pyaudio realtime scheduling`).
+
+DO NOT loosen the threshold table to make units pass; tighten the units. The threshold was set deliberately at 4.5/3.5 with research's 4.0/3.0 as aspirational. If a unit exceeds 4.5, that's a real concern and worth a CHECKPOINT or a follow-up.
+  </action>
+  <verify>
+`bash tests/phase-3/docker/run-tests.sh` — full SC1 + SC2 + SC3 testbed passes. Output should show:
+```
+=== /arlowe-firmware/tests/phase-3/assertions/01-user-shape.sh ===
+[pass output]
+=== /arlowe-firmware/tests/phase-3/assertions/02-fs-layout.sh ===
+[pass output]
+=== /arlowe-firmware/tests/phase-3/assertions/03-unit-syntax.sh ===
+[pass output with per-unit verify + security score table]
+```
+
+Verify the assertion summary table at the bottom of 03-unit-syntax.sh output shows all six units green.
+
+Run sanitization gate end-to-end: `bash scripts/sanitize/check.sh` — clean repo-wide.
+  </verify>
+  <done>
+Docker testbed run-tests.sh runs all three assertion suites and passes. All six units verify clean and score under their thresholds. Phase 2 sanitization gate green on the full repo (units/ included). PR ≤440 LOC.
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+```bash
+# Full Phase 3 SC1 + SC2 + SC3 (synthetic, in Docker):
+bash tests/phase-3/docker/run-tests.sh
+
+# Per-unit syntax + security (manual, inside the container):
+docker run --rm --privileged -v $(pwd):/arlowe-firmware:ro arlowe-phase3-testbed /bin/bash -c '
+    bash /arlowe-firmware/scripts/provision/install-arlowe-user.sh
+    bash /arlowe-firmware/scripts/provision/install-arlowe-fs.sh
+    bash /arlowe-firmware/units/install-units.sh
+    for u in arlowe-face arlowe-voice arlowe-dashboard qwen-tokenizer qwen-api whisper-stt; do
+        echo "--- $u ---"
+        systemd-analyze verify /etc/systemd/system/$u.service
+        systemd-analyze security $u.service --no-pager | grep "Overall exposure"
+    done
+'
+
+# Sanitization gate:
+bash scripts/sanitize/check.sh
+
+# Atomic-PR LOC sanity:
+git diff --shortstat origin/main..HEAD
+```
+</verification>
+
+<success_criteria>
+- Six shipping unit files exist and pass `systemd-analyze verify` (SC3 syntax)
+- Every unit declares `User=arlowe`, `Group=arlowe`, plus the hardening baseline (USER-04, USER-05)
+- Hardware-touching units (face/voice/qwen-api) score ≤ 4.5 on `systemd-analyze security`; network-only units (dashboard/qwen-tokenizer/whisper-stt) score ≤ 3.5
+- `arlowe-voice.service` has `RemoveIPC=no` (research §12.7)
+- `arlowe-face.service` covers both `/dev/gpiochip0` and `/dev/gpiochip4` (research §12.4)
+- `qwen-api.service` has `DeviceAllow=` for both `/dev/axcl_host` and `/dev/ax_mmb_dev`
+- `arlowe-dashboard.service` sets `NEXT_PRIVATE_CACHE_DIR=/var/lib/arlowe/dashboard/cache`
+- install-units.sh is idempotent (no spurious daemon-reload on no-op runs)
+- Phase 2 sanitization gate green (no banned literals, no banned unit-name prefixes)
+- PR ≤440 net LOC (hard cap 600)
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/03-service-user-and-filesystem-layout/03-02-SUMMARY.md`. Frontmatter `provides:` must include:
+- The six unit names + their hardening contracts (so Phase 5/Phase 11/Phase 9 can grep frontmatter to find them)
+- The systemd-analyze security thresholds used (so plan 05's hardware run knows what to re-verify)
+- The FIXMEs flagged for Phase 4 (face port 8080, voice sudo tee fan control, dashboard /etc/arlowe/config.yml write path)
+</output>

--- a/.planning/phases/03-service-user-and-filesystem-layout/03-03-PLAN.md
+++ b/.planning/phases/03-service-user-and-filesystem-layout/03-03-PLAN.md
@@ -1,0 +1,416 @@
+---
+phase: 03-service-user-and-filesystem-layout
+plan: 03
+type: execute
+wave: 2
+depends_on:
+  - "03-01"
+files_modified:
+  - provision/udev/90-arlowe-axera.rules
+  - provision/udev/91-arlowe-gpio-spi.rules
+  - provision/polkit/50-arlowe-systemctl.rules
+  - scripts/provision/install-arlowe-udev-polkit.sh
+  - scripts/provision/extract-axcl-udev-from-deb.sh
+  - tests/phase-3/assertions/04-udev-polkit-shape.sh
+autonomous: true
+estimated_loc: 220
+requirements_covered:
+  - USER-05
+
+# Recommendations baked in (per open-questions §3, §5, §6 from research):
+# - Polkit rule grants `arlowe` group members the right to systemctl
+#   start/stop/restart/reload `arlowe-*.service` and `qwen-*.service` and
+#   `whisper-stt.service`. Cleaner now in Phase 3 than fragmenting across
+#   Phase 4 (config-driven restart) and Phase 8 (pairing restart).
+# - Axera device permissions: extract `axcl_host_aarch64_V3.10.2.deb` postinst,
+#   inspect for udev rules. If the deb ships its own, copy verbatim with our
+#   group amendment. If not, ship our own rule.
+# - GPIO chip coverage: both `/dev/gpiochip0` AND `/dev/gpiochip4` are chowned
+#   to root:gpio 0660 until plan 05 confirms which the WhisPlay driver opens.
+
+must_haves:
+  truths:
+    - "udev rule `/etc/udev/rules.d/90-arlowe-axera.rules` chowns Axera device nodes (/dev/axcl_host and /dev/ax_mmb_dev) to root:arlowe 0660"
+    - "udev rule `/etc/udev/rules.d/91-arlowe-gpio-spi.rules` ensures /dev/gpiochip0 AND /dev/gpiochip4 are root:gpio 0660; /dev/spidev* root:spi 0660 (defense-in-depth; Pi OS's 99-com.rules usually covers this, but we don't trust pi-gen ordering)"
+    - "Polkit rule `/etc/polkit-1/rules.d/50-arlowe-systemctl.rules` allows the `arlowe` user to systemctl start/stop/restart/reload units matching `arlowe-*`, `qwen-*`, or `whisper-stt`"
+    - "Polkit rule does NOT grant anything beyond systemctl unit-manage for the named patterns (no daemon-reload from arlowe, no editing units, no journalctl bypass)"
+    - "install-arlowe-udev-polkit.sh copies the three rule files to /etc/udev/rules.d/ and /etc/polkit-1/rules.d/, triggers `udevadm control --reload` and `udevadm trigger`"
+    - "extract-axcl-udev-from-deb.sh inspects third_party/axcl/axcl_host_aarch64_V3.10.2.deb (or whatever is pinned) and prints any udev rules its postinst would install. Used at planning time to confirm the 90-arlowe-axera.rules content is correct; not invoked at install time."
+    - "04-udev-polkit-shape.sh assertion: validates rule files exist, polkit rule JavaScript syntax is valid (via `pkaction --verbose` or a syntax-check), assertion runs cleanly in the Docker testbed (acknowledging udev itself doesn't fire in Docker)"
+  artifacts:
+    - path: "provision/udev/90-arlowe-axera.rules"
+      provides: "Chown rules for /dev/axcl_host and /dev/ax_mmb_dev to root:arlowe 0660"
+      min_lines: 10
+      contains: "axcl_host"
+    - path: "provision/udev/91-arlowe-gpio-spi.rules"
+      provides: "Chown rules for /dev/gpiochip[04] to root:gpio 0660 and /dev/spidev* to root:spi 0660"
+      min_lines: 10
+      contains: "gpiochip"
+    - path: "provision/polkit/50-arlowe-systemctl.rules"
+      provides: "Polkit JS rule allowing arlowe user to manage arlowe-*, qwen-*, whisper-stt units"
+      min_lines: 25
+      contains: "manage-units"
+    - path: "scripts/provision/install-arlowe-udev-polkit.sh"
+      provides: "Idempotent installer that copies all three rule files and reloads udev"
+      min_lines: 40
+    - path: "scripts/provision/extract-axcl-udev-from-deb.sh"
+      provides: "Diagnostic helper: dpkg -x the axcl deb to a temp dir, grep for udev rules, print to stdout. Run at planning/audit time to confirm the deb doesn't ship conflicting rules."
+      min_lines: 30
+    - path: "tests/phase-3/assertions/04-udev-polkit-shape.sh"
+      provides: "Validates rule files installed at expected paths with expected mode; checks polkit JS syntax via `pkaction` if available; gracefully skips udev runtime check in Docker (note plan 05 owns the real-hardware verification)"
+      min_lines: 35
+  key_links:
+    - from: "/etc/polkit-1/rules.d/50-arlowe-systemctl.rules"
+      to: "systemd1 manage-units action"
+      via: "polkit JS callback that returns polkit.Result.YES when subject.user=='arlowe' AND action.id=='org.freedesktop.systemd1.manage-units' AND unit matches the prefix list"
+      pattern: "org.freedesktop.systemd1.manage-units"
+    - from: "/etc/udev/rules.d/90-arlowe-axera.rules"
+      to: "/dev/axcl_host and /dev/ax_mmb_dev"
+      via: "KERNEL== or SUBSYSTEM== match → MODE='0660', OWNER='root', GROUP='arlowe'"
+      pattern: "GROUP=\"arlowe\""
+    - from: "scripts/provision/install-arlowe-udev-polkit.sh"
+      to: "udev daemon"
+      via: "udevadm control --reload && udevadm trigger"
+      pattern: "udevadm control --reload"
+---
+
+<objective>
+Ship the udev rules that grant `arlowe`-group access to the Axera (`/dev/axcl_host`, `/dev/ax_mmb_dev`) and GPIO/SPI device nodes, plus a polkit rule that lets the dashboard (running as `arlowe`) issue `systemctl restart arlowe-voice` (and siblings) without sudo. Provide a diagnostic helper that confirms the axcl deb doesn't ship its own conflicting udev rule.
+
+Purpose: USER-05 ("Service capabilities/sandboxing applied per unit") implicitly requires the device-node permissions story to work — `DeviceAllow=` in a unit file does nothing if the kernel's device-node permissions deny `arlowe` from opening the node in the first place. The polkit rule unblocks the dashboard's `POST /api/voice` restart endpoint (Phase 1 inherited dashboard code) AND saves Phase 4 (config overlay) and Phase 8 (pairing) from having to fragment the same rule across multiple PRs.
+
+Output: Two udev rule files, one polkit rule file, an install helper, a diagnostic extract script, and an assertion script. All shipped under `provision/` (new top-level dir) so Phase 6's pi-gen overlay stage installs them in one pass.
+</objective>
+
+<execution_context>
+@~/.claude/get-shit-done/workflows/execute-plan.md
+@~/.claude/get-shit-done/templates/summary.md
+
+This plan is parallel-eligible with plan 03-02 and 03-04 (same wave, no shared files).
+
+QA writes 04-udev-polkit-shape.sh first (asserts the rule files at expected paths); DEV writes the rules and installer until the assertion passes.
+
+Docker testbed limitations: udev does NOT fire in privileged containers without `--cgroup-rule=...` and even then it's flaky. The Docker assertion validates rule file installation but cannot validate the rules actually applied to a device node. Plan 03-05 owns the real-hardware verification. Document this clearly.
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/REQUIREMENTS.md
+@.planning/phases/03-service-user-and-filesystem-layout/03-RESEARCH.md
+@.planning/phases/03-service-user-and-filesystem-layout/03-01-PLAN.md
+@docs/operations/phase-3-layout.md
+@third_party/axcl/manifest.yml
+@scripts/verify-third-party.sh
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Diagnostic — inspect the axcl deb's existing udev rules (if any)</name>
+  <files>
+    scripts/provision/extract-axcl-udev-from-deb.sh
+  </files>
+  <action>
+Write `scripts/provision/extract-axcl-udev-from-deb.sh`. Purpose: when Phase 6's pi-gen build installs `axcl_host_aarch64_V3.10.2.deb`, the deb's postinst may install its own `/etc/udev/rules.d/*` files for the Axera devices. If those rules conflict with our `90-arlowe-axera.rules` (e.g., they chown to `video` group instead of our `arlowe` group), we need to know now, not at Phase 6 build time.
+
+Script behavior:
+```bash
+#!/bin/bash
+# Diagnostic: extract the axcl deb to a temp dir and print any udev rules
+# it would install. Used at planning/audit time to confirm 90-arlowe-axera.rules
+# doesn't conflict with the deb's postinst. NOT invoked by install scripts.
+#
+# Usage: bash extract-axcl-udev-from-deb.sh [path/to/axcl_host.deb]
+#        Defaults to inspecting third_party/axcl/<pinned-deb-name>
+set -euo pipefail
+
+DEB_PATH="${1:-}"
+if [[ -z "$DEB_PATH" ]]; then
+    # Resolve from third_party/axcl/manifest.yml
+    MANIFEST=third_party/axcl/manifest.yml
+    if [[ ! -f "$MANIFEST" ]]; then
+        echo "manifest not found; pass deb path explicitly"; exit 1
+    fi
+    DEB_NAME=$(grep -E '^\s*file:' "$MANIFEST" | head -1 | awk '{print $2}')
+    DEB_PATH="third_party/axcl/$DEB_NAME"
+fi
+
+if [[ ! -f "$DEB_PATH" ]]; then
+    echo "axcl deb not present at $DEB_PATH"
+    echo "Per third_party/axcl/manifest.yml (Strategy C), the deb is user-supplied;"
+    echo "Joe must download it before running this diagnostic."
+    exit 2
+fi
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+dpkg-deb -x "$DEB_PATH" "$TMP/contents"
+dpkg-deb -e "$DEB_PATH" "$TMP/control"
+
+echo "=== Searching for udev rules in deb contents ==="
+find "$TMP/contents" -path '*udev*' -type f -print -exec cat {} \;
+
+echo ""
+echo "=== Searching control scripts (postinst, postrm) for udev/chown ==="
+for script in "$TMP/control"/{postinst,postrm,prerm,preinst}; do
+    [[ -f "$script" ]] && { echo "--- $script ---"; grep -nE 'udev|chown|chmod|MKNOD|/dev/' "$script" || echo "(none)"; }
+done
+
+echo ""
+echo "=== Summary ==="
+RULE_FILES=$(find "$TMP/contents" -path '*udev*' -type f | wc -l)
+echo "udev rule files in deb: $RULE_FILES"
+if [[ "$RULE_FILES" -eq 0 ]]; then
+    echo "Decision: ship our own 90-arlowe-axera.rules (no conflict)."
+else
+    echo "Decision: review the above. If the deb's rules match our group/mode, drop ours."
+    echo "          If they conflict (different group, different mode), keep ours with a comment"
+    echo "          explaining the override. If they conflict on path, raise a CHECKPOINT."
+fi
+```
+
+Note: this is a diagnostic helper, not part of the install path. Joe runs it once during plan 03-03 execution to confirm the deb's behavior, then commits the script for future re-runs (e.g., if the deb gets a version bump).
+
+If Joe hasn't supplied the axcl deb yet (likely — research notes Strategy C user-supplied), the script exits 2 with a clear message. The plan still ships the assumed-no-conflict `90-arlowe-axera.rules`; plan 05's hardware test on arlowe-1 will catch any real conflict.
+  </action>
+  <verify>
+`bash -n scripts/provision/extract-axcl-udev-from-deb.sh` — syntax clean.
+
+If `third_party/axcl/axcl_host_aarch64_V3.10.2.deb` exists locally on Joe's machine: `bash scripts/provision/extract-axcl-udev-from-deb.sh` runs and prints whatever the deb ships. Either result (rules present or absent) is acceptable for the plan to proceed; document the finding in the SUMMARY.
+
+If the deb isn't local: script exits 2 with a clear "Joe must supply" message.
+  </verify>
+  <done>
+Diagnostic script written, syntax-clean, gracefully handles the user-supplied-deb (Strategy C) case. If Joe runs it and finds the deb ships conflicting rules, raise a CHECKPOINT before authoring 90-arlowe-axera.rules (Task 2).
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 2: QA writes assertion + DEV authors the udev + polkit rule files and installer</name>
+  <files>
+    provision/udev/90-arlowe-axera.rules
+    provision/udev/91-arlowe-gpio-spi.rules
+    provision/polkit/50-arlowe-systemctl.rules
+    scripts/provision/install-arlowe-udev-polkit.sh
+    tests/phase-3/assertions/04-udev-polkit-shape.sh
+  </files>
+  <action>
+**First: write `tests/phase-3/assertions/04-udev-polkit-shape.sh` (QA-step):**
+
+```bash
+#!/bin/bash
+set -euo pipefail
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# Rule files installed at expected paths
+test -f /etc/udev/rules.d/90-arlowe-axera.rules    || fail "axera rule missing"
+test -f /etc/udev/rules.d/91-arlowe-gpio-spi.rules  || fail "gpio/spi rule missing"
+test -f /etc/polkit-1/rules.d/50-arlowe-systemctl.rules || fail "polkit rule missing"
+
+# Modes: udev rules 0644; polkit rules 0644
+test "$(stat -c %a /etc/udev/rules.d/90-arlowe-axera.rules)" = "644"     || fail "axera rule mode"
+test "$(stat -c %a /etc/udev/rules.d/91-arlowe-gpio-spi.rules)" = "644"   || fail "gpio rule mode"
+test "$(stat -c %a /etc/polkit-1/rules.d/50-arlowe-systemctl.rules)" = "644" || fail "polkit rule mode"
+
+# Polkit rule: javascript syntax check via node -c (polkit uses spidermonkey but
+# node's check is close enough for our purposes — JS parse errors here are real)
+if command -v node >/dev/null 2>&1; then
+    node --check /etc/polkit-1/rules.d/50-arlowe-systemctl.rules \
+        || fail "polkit rule JS syntax error"
+fi
+
+# Polkit rule: contains the right action ID and matches arlowe user
+grep -q "org.freedesktop.systemd1.manage-units" /etc/polkit-1/rules.d/50-arlowe-systemctl.rules \
+    || fail "polkit rule does not reference manage-units"
+grep -q '"arlowe"' /etc/polkit-1/rules.d/50-arlowe-systemctl.rules \
+    || fail "polkit rule does not reference arlowe user"
+
+# Polkit rule does NOT reference focal55 or any banned literal
+grep -E 'focal55|/home/focal55|joe@focal55|iol-monorepo' /etc/polkit-1/rules.d/50-arlowe-systemctl.rules \
+    && fail "polkit rule contains a banned literal" || true
+
+# Udev rule covers both gpiochip0 and gpiochip4 (research §12.4)
+grep -q 'gpiochip0' /etc/udev/rules.d/91-arlowe-gpio-spi.rules || fail "gpiochip0 not covered"
+grep -q 'gpiochip4' /etc/udev/rules.d/91-arlowe-gpio-spi.rules || fail "gpiochip4 not covered"
+
+# Axera udev rule covers both axcl_host and ax_mmb_dev
+grep -q 'axcl_host' /etc/udev/rules.d/90-arlowe-axera.rules || fail "axcl_host not covered"
+grep -q 'ax_mmb_dev' /etc/udev/rules.d/90-arlowe-axera.rules || fail "ax_mmb_dev not covered"
+
+# Note: device-node application of rules requires real udev, which doesn't run
+# in Docker. Plan 03-05 verifies on arlowe-1.
+echo "[04-udev-polkit-shape] PASS (file shape only; runtime application verified in plan 05)"
+```
+
+**Then: author the three rule files (DEV step):**
+
+`provision/udev/90-arlowe-axera.rules`:
+```
+# Arlowe Phase 3: Axera device permissions
+# Grants the `arlowe` group read/write to the AXCL device nodes installed by
+# axcl_host_aarch64_V3.10.2.deb. The deb itself may or may not ship udev rules
+# (see scripts/provision/extract-axcl-udev-from-deb.sh). If the deb ships
+# conflicting rules, this file's higher number (90 vs typical 60s) wins on
+# last-rule-applied semantics for matching attributes.
+#
+# Verified on real hardware: plan 03-05 / tests/phase-3/staging/.
+
+KERNEL=="axcl_host",  OWNER="root", GROUP="arlowe", MODE="0660"
+KERNEL=="ax_mmb_dev", OWNER="root", GROUP="arlowe", MODE="0660"
+```
+
+`provision/udev/91-arlowe-gpio-spi.rules`:
+```
+# Arlowe Phase 3: GPIO and SPI device permissions (defense-in-depth)
+#
+# Pi OS's stock /etc/udev/rules.d/99-com.rules typically sets these to
+# group=gpio/spi 0660 already. We re-assert with a higher number (91 vs 99)
+# in case pi-gen ordering or a stripped Pi OS Lite image omits 99-com.rules.
+# This rule is intentionally defensive; plan 05 reports if it's redundant.
+#
+# Covers both gpiochip0 (main bank, legacy) and gpiochip4 (RP1 chip on Pi 5).
+# Research §12.4 documents the Pi 5 RP1 chip enumeration; plan 05 confirms
+# which chip the WhisPlay driver actually opens.
+
+KERNEL=="gpiochip[0-9]*", OWNER="root", GROUP="gpio", MODE="0660"
+KERNEL=="gpiomem",         OWNER="root", GROUP="gpio", MODE="0660"
+KERNEL=="spidev*",         OWNER="root", GROUP="spi",  MODE="0660"
+```
+
+`provision/polkit/50-arlowe-systemctl.rules`:
+```javascript
+// Arlowe Phase 3: allow the `arlowe` user (which dashboard, voice, etc. run as)
+// to start/stop/restart/reload arlowe-*, qwen-*, and whisper-stt units via
+// systemctl, WITHOUT sudo. Required by:
+//   - dashboard POST /api/voice (Phase 1 inherited; restarts arlowe-voice)
+//   - dashboard POST /api/config (Phase 4 will use; restarts affected services)
+//   - pairing daemon completion (Phase 8 will use; starts runtime services)
+//
+// This rule does NOT grant:
+//   - daemon-reload (units don't change at runtime; only OTA / install scripts touch them)
+//   - editing unit files (those are root-owned and read-only at runtime)
+//   - managing system units OUTSIDE the arlowe/qwen/whisper-stt prefixes
+//   - any action on any non-arlowe user's behalf
+//
+// References:
+//   - https://www.freedesktop.org/software/polkit/docs/latest/polkit.8.html
+//   - https://www.freedesktop.org/software/systemd/man/systemd.directives.html#org.freedesktop.systemd1.manage-units
+
+polkit.addRule(function(action, subject) {
+    if (action.id !== "org.freedesktop.systemd1.manage-units") {
+        return;
+    }
+    if (subject.user !== "arlowe") {
+        return;
+    }
+    var unit = action.lookup("unit");
+    if (!unit) {
+        return;
+    }
+    if (unit.indexOf("arlowe-") === 0 ||
+        unit.indexOf("qwen-") === 0 ||
+        unit === "whisper-stt.service") {
+        return polkit.Result.YES;
+    }
+});
+```
+
+`scripts/provision/install-arlowe-udev-polkit.sh`:
+```bash
+#!/bin/bash
+# Installs arlowe udev rules and polkit rule. Idempotent.
+set -euo pipefail
+
+SRC_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+UDEV_SRC="$SRC_ROOT/provision/udev"
+POLKIT_SRC="$SRC_ROOT/provision/polkit"
+
+install -d -m 0755 /etc/udev/rules.d
+install -d -m 0755 /etc/polkit-1/rules.d
+
+install -m 0644 -o root -g root "$UDEV_SRC"/*.rules    /etc/udev/rules.d/
+install -m 0644 -o root -g root "$POLKIT_SRC"/*.rules  /etc/polkit-1/rules.d/
+
+# Reload udev (no-op in containers without /dev access; safe to invoke regardless)
+if command -v udevadm >/dev/null 2>&1; then
+    udevadm control --reload 2>/dev/null || echo "[install-udev-polkit] udevadm reload skipped (no running udev daemon — Docker testbed?)"
+    udevadm trigger 2>/dev/null || true
+fi
+
+echo "[install-udev-polkit] installed $(ls /etc/udev/rules.d/9?-arlowe-*.rules /etc/polkit-1/rules.d/5?-arlowe-*.rules 2>/dev/null | wc -l) rules"
+```
+
+Note the `SRC_ROOT` resolution: this script lives at `scripts/provision/install-arlowe-udev-polkit.sh`, and the rule files live at `provision/{udev,polkit}/`. The `cd "$(dirname "$0")/.."` from `scripts/provision/` gets us to `scripts/`, then we need to go up once more to reach repo root. Use `cd "$(dirname "$0")/../.."` instead — verify the path resolution carefully when implementing.
+
+Plan 03-03 does NOT modify `tests/phase-3/docker/run-tests.sh`. Plan 01's auto-discovery loop over `scripts/provision/install-arlowe-*.sh` picks up `install-arlowe-udev-polkit.sh` automatically on next run.
+
+Run sanitization gate on everything.
+  </action>
+  <verify>
+`bash -n scripts/provision/install-arlowe-udev-polkit.sh && bash -n tests/phase-3/assertions/04-udev-polkit-shape.sh` — syntax clean.
+
+In Docker testbed:
+```bash
+docker run --rm --privileged -v $(pwd):/arlowe-firmware:ro arlowe-phase3-testbed /bin/bash -c '
+    bash /arlowe-firmware/scripts/provision/install-arlowe-user.sh
+    bash /arlowe-firmware/scripts/provision/install-arlowe-fs.sh
+    bash /arlowe-firmware/scripts/provision/install-arlowe-udev-polkit.sh
+    bash /arlowe-firmware/tests/phase-3/assertions/04-udev-polkit-shape.sh
+'
+```
+Exit 0; "[04-udev-polkit-shape] PASS" printed.
+
+Polkit JS syntax check (with node available): `node --check provision/polkit/50-arlowe-systemctl.rules` — clean.
+
+Sanitization: `bash scripts/sanitize/check.sh --grep-only provision/ scripts/provision/install-arlowe-udev-polkit.sh scripts/provision/extract-axcl-udev-from-deb.sh tests/phase-3/assertions/04-udev-polkit-shape.sh` — clean.
+
+Idempotency: re-run install-arlowe-udev-polkit.sh; second run is a no-op (no error).
+  </verify>
+  <done>
+Three rule files installed at expected paths with mode 0644. Polkit rule JS is syntactically valid. Assertion script passes in Docker testbed. Sanitization gate green. PR ≤220 LOC.
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+```bash
+# Plan-level testbed:
+docker run --rm --privileged -v $(pwd):/arlowe-firmware:ro arlowe-phase3-testbed /bin/bash -c '
+    bash /arlowe-firmware/scripts/provision/install-arlowe-user.sh
+    bash /arlowe-firmware/scripts/provision/install-arlowe-fs.sh
+    bash /arlowe-firmware/scripts/provision/install-arlowe-udev-polkit.sh
+    bash /arlowe-firmware/tests/phase-3/assertions/04-udev-polkit-shape.sh
+'
+
+# Polkit JS syntax (uses node as a shake-out — polkit uses spidermonkey but JS parse errors are universal):
+node --check provision/polkit/50-arlowe-systemctl.rules
+
+# Sanitization gate:
+bash scripts/sanitize/check.sh
+
+# Optional: run the axcl-deb diagnostic if Joe has the deb locally
+bash scripts/provision/extract-axcl-udev-from-deb.sh
+```
+</verification>
+
+<success_criteria>
+- Three rule files exist and install at expected paths (`/etc/udev/rules.d/9*-arlowe-*.rules`, `/etc/polkit-1/rules.d/50-arlowe-systemctl.rules`) with mode 0644
+- Polkit rule: JS syntactically valid; references `org.freedesktop.systemd1.manage-units`; only grants `arlowe` user; only matches `arlowe-*`, `qwen-*`, `whisper-stt` units
+- Axera udev rule: covers `/dev/axcl_host` AND `/dev/ax_mmb_dev`, chowns to root:arlowe 0660
+- GPIO/SPI udev rule: covers `/dev/gpiochip[0-9]*` (catches both gpiochip0 and gpiochip4), `/dev/gpiomem`, `/dev/spidev*`
+- Diagnostic helper (`extract-axcl-udev-from-deb.sh`) is committed and gracefully handles deb-not-present
+- 04-udev-polkit-shape.sh assertion passes in Docker testbed
+- Phase 2 sanitization gate green
+- PR ≤220 net LOC
+
+If the axcl-deb diagnostic reveals the deb ships rules that conflict with ours on group/mode/path → CHECKPOINT before committing 90-arlowe-axera.rules.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/03-service-user-and-filesystem-layout/03-03-SUMMARY.md`. Frontmatter `provides:` must include:
+- Polkit rule details (so Phase 4 dashboard restart endpoint and Phase 8 pairing daemon know it exists and what it covers)
+- Udev rule paths and what they chown (so Phase 5 audio auto-detect and Phase 11 boot-check know the device-perms contract)
+- Result of the axcl-deb diagnostic (conflict found? no conflict? deb not yet present?) — informs Phase 6 image build
+</output>

--- a/.planning/phases/03-service-user-and-filesystem-layout/03-04-PLAN.md
+++ b/.planning/phases/03-service-user-and-filesystem-layout/03-04-PLAN.md
@@ -1,0 +1,269 @@
+---
+phase: 03-service-user-and-filesystem-layout
+plan: 04
+type: execute
+wave: 2
+depends_on:
+  - "03-01"
+files_modified:
+  - scripts/provision/install-arlowe-cli.sh
+  - runtime/cli/boot-check
+  - tests/phase-3/assertions/05-cli-symlinks.sh
+autonomous: true
+estimated_loc: 100
+requirements_covered:
+  - USER-04  # boot-check default flip aligns CLI behavior with system-level units
+
+must_haves:
+  truths:
+    - "After install-arlowe-cli.sh runs, /usr/local/sbin/arlowe-{face,speak,stt,record,boot-check,purge-logs,run-logrotate,wake-train} all exist as symlinks pointing into /opt/arlowe/runtime/cli/"
+    - "Each symlink resolves (`readlink -e`) to an existing file under /opt/arlowe/runtime/cli/ (Phase 6 will populate the targets; Phase 3 Docker testbed pre-stages the targets as empty marker files)"
+    - "Each symlink is owned by root (root:root); CLI target files exist with mode 0755 (pre-staged by plan 01's run-tests.sh harness in Docker with root:arlowe ownership; in production Phase 6 sets root:arlowe ownership at image-build time)"
+    - "runtime/cli/boot-check defaults ARLOWE_SYSTEMCTL_FLAGS to '' (empty string, system-level), not '--user'"
+    - "boot-check is backward-compatible: setting `ARLOWE_SYSTEMCTL_FLAGS=--user` still works for ad-hoc test invocations against pre-Phase-3 `--user` units"
+    - "Install script is idempotent: re-running succeeds; existing symlinks are not duplicated; missing symlinks are recreated"
+    - "Assertion 05-cli-symlinks.sh validates all 8 symlinks, target resolution, and the boot-check default-flip; passes in the Docker testbed"
+  artifacts:
+    - path: "scripts/provision/install-arlowe-cli.sh"
+      provides: "Idempotent installer that creates 8 root-owned symlinks in /usr/local/sbin/arlowe-* pointing into /opt/arlowe/runtime/cli/<name>"
+      min_lines: 30
+      contains: "ln -sf"
+    - path: "runtime/cli/boot-check"
+      provides: "Default for ARLOWE_SYSTEMCTL_FLAGS flipped from '--user' to '' (system-level); the TODO(phase-11) comment updated to reference Phase 3 plan 04 completion"
+      contains: 'ARLOWE_SYSTEMCTL_FLAGS:-'
+    - path: "tests/phase-3/assertions/05-cli-symlinks.sh"
+      provides: "Validates 8 symlinks exist at expected paths; validates each resolves to /opt/arlowe/runtime/cli/<unprefixed-name>; validates boot-check's default flip via grep"
+      min_lines: 30
+  key_links:
+    - from: "/usr/local/sbin/arlowe-boot-check"
+      to: "/opt/arlowe/runtime/cli/boot-check"
+      via: "symlink (ln -sf)"
+      pattern: "ln -sf /opt/arlowe/runtime/cli/"
+    - from: "runtime/cli/boot-check"
+      to: "system-level systemctl"
+      via: "ARLOWE_SYSTEMCTL_FLAGS default is now '' (empty), which means `systemctl status` queries system-level units; was '--user' in Phase 1"
+      pattern: 'ARLOWE_SYSTEMCTL_FLAGS:-\}'
+---
+
+<objective>
+Install root-owned symlinks at `/usr/local/sbin/arlowe-*` pointing into `/opt/arlowe/runtime/cli/`, and flip `runtime/cli/boot-check`'s `ARLOWE_SYSTEMCTL_FLAGS` default from `--user` (Phase 1 pre-system-units state) to `""` (Phase 3+ system-level state).
+
+Purpose: The CLI helpers (face, speak, stt, record, boot-check, purge-logs, run-logrotate, wake-train) are how support-mode SSH (Phase 10) and ad-hoc debugging invoke arlowe internals. They need to be discoverable in PATH and prefixed (`arlowe-*`) to avoid namespace pollution. The boot-check flip is a one-line change that makes the script work against the units plan 02 ships — without it, Phase 11 boot health surfaces would all read "service not found (--user mode)".
+
+Output: One install script, one one-line edit to boot-check, one assertion script.
+</objective>
+
+<execution_context>
+@~/.claude/get-shit-done/workflows/execute-plan.md
+@~/.claude/get-shit-done/templates/summary.md
+
+Parallel-eligible with plan 03-02 and 03-03 (same wave, no file overlap).
+
+Smallest plan in the phase. TDD pattern straightforward: assertion script written first checks for symlinks and the boot-check default; install script and edit make it pass.
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/REQUIREMENTS.md
+@.planning/phases/03-service-user-and-filesystem-layout/03-RESEARCH.md
+@.planning/phases/03-service-user-and-filesystem-layout/03-01-PLAN.md
+@docs/operations/phase-3-layout.md
+@runtime/cli/boot-check
+@runtime/cli/README.md
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: QA writes assertion + DEV implements install-arlowe-cli.sh and boot-check flip</name>
+  <files>
+    scripts/provision/install-arlowe-cli.sh
+    runtime/cli/boot-check
+    tests/phase-3/assertions/05-cli-symlinks.sh
+  </files>
+  <action>
+**Step 1: Write `tests/phase-3/assertions/05-cli-symlinks.sh` (QA, fails before Step 2 & 3):**
+
+```bash
+#!/bin/bash
+set -euo pipefail
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+CLIS=(face speak stt record boot-check purge-logs run-logrotate wake-train)
+
+for cli in "${CLIS[@]}"; do
+    link="/usr/local/sbin/arlowe-$cli"
+    target="/opt/arlowe/runtime/cli/$cli"
+
+    test -L "$link"               || fail "$link is not a symlink"
+    actual=$(readlink "$link")
+    test "$actual" = "$target"    || fail "$link points to $actual, expected $target"
+
+    # Target file must exist (Docker testbed pre-stages empty marker files;
+    # in production Phase 6 populates with the real CLI scripts)
+    test -e "$target"             || fail "$link target $target does not exist"
+
+    # Symlink owner: root
+    sym_owner=$(stat -c %U "$link")
+    test "$sym_owner" = "root"    || fail "$link owned by $sym_owner, expected root"
+done
+
+# Boot-check default-flip: ARLOWE_SYSTEMCTL_FLAGS default must be '' not '--user'
+# Look for the literal default-substitution syntax pattern.
+grep -E '^\s*SYSTEMCTL_FLAGS="\$\{ARLOWE_SYSTEMCTL_FLAGS:-\}"' /opt/arlowe/runtime/cli/boot-check \
+    || fail "boot-check did not flip default from --user to '' (system-level)"
+
+# Backward-compat: --user mode is still supported by env override
+# (we don't run boot-check here; that would require live systemctl. Just check
+# the variable expansion preserves the override).
+grep -q 'ARLOWE_SYSTEMCTL_FLAGS:-' /opt/arlowe/runtime/cli/boot-check \
+    || fail "boot-check no longer honors ARLOWE_SYSTEMCTL_FLAGS override"
+
+# Sanitization spot-check
+grep -E 'focal55|/home/focal55|joe@focal55|iol-monorepo' /opt/arlowe/runtime/cli/boot-check \
+    && fail "boot-check contains a banned literal" || true
+
+echo "[05-cli-symlinks] PASS"
+```
+
+The Docker testbed needs to pre-stage `/opt/arlowe/runtime/cli/<name>` files so the `readlink -e` resolution passes. Plan 01's `install-arlowe-fs.sh` creates `/opt/arlowe/runtime/cli/` (empty dir). For this assertion to pass in Docker without Phase 6's full population, plan 01's `run-tests.sh` harness pre-stages 8 CLI marker files (one per helper) before invoking `install-arlowe-cli.sh`, with mode 0755 and root:arlowe ownership.
+
+Plan 03-04 does NOT modify `tests/phase-3/docker/run-tests.sh`. Plan 03-01's auto-discovery harness already includes the pre-stage step for `/opt/arlowe/runtime/cli/` marker files (gated on `install-arlowe-cli.sh` existing). When this plan's `scripts/provision/install-arlowe-cli.sh` lands, plan 01's auto-discovery loop runs it and the pre-stage step fires.
+
+The pre-stage step (already inside run-tests.sh per plan 01 Task 1 step 3) copies real `runtime/cli/<name>` files into `/opt/arlowe/runtime/cli/` so symlinks resolve cleanly; falls back to `touch` if the source is absent.
+
+**Step 2: Write `scripts/provision/install-arlowe-cli.sh` (DEV):**
+
+```bash
+#!/bin/bash
+# Install arlowe CLI symlinks at /usr/local/sbin/arlowe-* pointing into
+# /opt/arlowe/runtime/cli/. Idempotent. Invoked by pi-gen and the Docker testbed.
+set -euo pipefail
+
+CLIS=(face speak stt record boot-check purge-logs run-logrotate wake-train)
+TARGET_DIR=/opt/arlowe/runtime/cli
+LINK_DIR=/usr/local/sbin
+
+install -d -m 0755 "$LINK_DIR"
+
+for cli in "${CLIS[@]}"; do
+    link="$LINK_DIR/arlowe-$cli"
+    target="$TARGET_DIR/$cli"
+    # ln -sf is idempotent: it replaces an existing symlink without error.
+    # We don't check target existence here — Phase 6 populates after this
+    # script in the pi-gen stage ordering; the symlink can dangle briefly.
+    ln -sf "$target" "$link"
+done
+
+echo "[install-arlowe-cli] installed ${#CLIS[@]} symlinks in $LINK_DIR"
+```
+
+**Step 3: Flip `runtime/cli/boot-check` default (DEV, one-line surgical edit):**
+
+Current Phase 1 state (lines 7-11 per the Bash output above):
+```bash
+# Env overrides:
+#   ARLOWE_SYSTEMCTL_FLAGS  Flags passed to systemctl (default: --user)
+#                           Set to empty string for system-level units (Phase 11+)
+
+# TODO(phase-11): --user mode flips to system-level when image build lands.
+SYSTEMCTL_FLAGS="${ARLOWE_SYSTEMCTL_FLAGS:---user}"
+```
+
+New state:
+```bash
+# Env overrides:
+#   ARLOWE_SYSTEMCTL_FLAGS  Flags passed to systemctl
+#                           Default: '' (system-level units, Phase 3+ image)
+#                           Set to '--user' for ad-hoc test invocations
+#                           against legacy --user units in dev-stash/.
+
+# Phase 3 plan 04: default flipped from '--user' to '' to align with
+# the system-level unit files shipped in plan 03-02.
+SYSTEMCTL_FLAGS="${ARLOWE_SYSTEMCTL_FLAGS:-}"
+```
+
+This is a minimal surgical edit: one default value changes (`---user` → empty), the comment block above gets a 4-line update to reflect the new contract.
+
+Sanitization sweep on all three files.
+  </action>
+  <verify>
+`bash -n scripts/provision/install-arlowe-cli.sh && bash -n tests/phase-3/assertions/05-cli-symlinks.sh` — syntax clean.
+
+`bash -n runtime/cli/boot-check` — script still parses cleanly (one-line default change cannot break syntax).
+
+Run the boot-check assertion (without systemctl): `ARLOWE_SYSTEMCTL_FLAGS=--user bash -c 'echo $0; grep "SYSTEMCTL_FLAGS=" runtime/cli/boot-check'` — env override path still works syntactically.
+
+Full Docker run:
+```bash
+docker run --rm --privileged -v $(pwd):/arlowe-firmware:ro arlowe-phase3-testbed /bin/bash -c '
+    bash /arlowe-firmware/scripts/provision/install-arlowe-user.sh
+    bash /arlowe-firmware/scripts/provision/install-arlowe-fs.sh
+    # Pre-stage cli targets:
+    for f in face speak stt record boot-check purge-logs run-logrotate wake-train; do
+        cp /arlowe-firmware/runtime/cli/$f /opt/arlowe/runtime/cli/$f 2>/dev/null || touch /opt/arlowe/runtime/cli/$f
+    done
+    chmod 0755 /opt/arlowe/runtime/cli/*
+    bash /arlowe-firmware/scripts/provision/install-arlowe-cli.sh
+    bash /arlowe-firmware/tests/phase-3/assertions/05-cli-symlinks.sh
+'
+```
+Exit 0 with "[05-cli-symlinks] PASS".
+
+Sanitization: `bash scripts/sanitize/check.sh --grep-only scripts/provision/install-arlowe-cli.sh runtime/cli/boot-check tests/phase-3/assertions/05-cli-symlinks.sh` — clean.
+
+Idempotency: re-running install-arlowe-cli.sh twice succeeds; second run does not error on existing symlinks.
+  </verify>
+  <done>
+- 8 symlinks under /usr/local/sbin/arlowe-* installed, root-owned, resolving to /opt/arlowe/runtime/cli/<name>.
+- boot-check default flipped from `--user` to `` (system-level), backward-compat preserved.
+- Assertion passes in Docker testbed.
+- Phase 2 sanitization gate green.
+- PR ≤100 net LOC.
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+```bash
+# Plan-level testbed
+docker run --rm --privileged -v $(pwd):/arlowe-firmware:ro arlowe-phase3-testbed /bin/bash -c '
+    bash /arlowe-firmware/scripts/provision/install-arlowe-user.sh
+    bash /arlowe-firmware/scripts/provision/install-arlowe-fs.sh
+    for f in face speak stt record boot-check purge-logs run-logrotate wake-train; do
+        cp /arlowe-firmware/runtime/cli/$f /opt/arlowe/runtime/cli/$f 2>/dev/null || touch /opt/arlowe/runtime/cli/$f
+    done
+    chmod 0755 /opt/arlowe/runtime/cli/*
+    bash /arlowe-firmware/scripts/provision/install-arlowe-cli.sh
+    bash /arlowe-firmware/tests/phase-3/assertions/05-cli-symlinks.sh
+'
+
+# boot-check default flip:
+grep 'ARLOWE_SYSTEMCTL_FLAGS:-' runtime/cli/boot-check
+# Expect:    SYSTEMCTL_FLAGS="${ARLOWE_SYSTEMCTL_FLAGS:-}"
+# NOT:       SYSTEMCTL_FLAGS="${ARLOWE_SYSTEMCTL_FLAGS:---user}"
+
+# Sanitization:
+bash scripts/sanitize/check.sh
+```
+</verification>
+
+<success_criteria>
+- 8 symlinks `/usr/local/sbin/arlowe-{face,speak,stt,record,boot-check,purge-logs,run-logrotate,wake-train}` exist after install-arlowe-cli.sh runs
+- Each symlink is root-owned and resolves to `/opt/arlowe/runtime/cli/<unprefixed-name>`
+- `runtime/cli/boot-check` has its `ARLOWE_SYSTEMCTL_FLAGS` default flipped from `--user` to `` (empty)
+- Backward-compat preserved: `ARLOWE_SYSTEMCTL_FLAGS=--user` env override still works
+- Install script idempotent
+- 05-cli-symlinks.sh assertion passes in Docker
+- Phase 2 sanitization gate green
+- PR ≤100 net LOC
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/03-service-user-and-filesystem-layout/03-04-SUMMARY.md`. Frontmatter `provides:` must include:
+- The 8 `/usr/local/sbin/arlowe-*` symlinks (Phase 10 support-mode invocation pattern depends on these)
+- The boot-check default-flip (Phase 11 boot-health depends on this; Phase 5 audio auto-detect calls boot-check)
+- Confirmation that no Phase 1 runtime/cli/* file behavior changed except boot-check's default (other CLI scripts ride the symlinks without modification)
+</output>
+</output>

--- a/.planning/phases/03-service-user-and-filesystem-layout/03-05-PLAN.md
+++ b/.planning/phases/03-service-user-and-filesystem-layout/03-05-PLAN.md
@@ -1,0 +1,774 @@
+---
+phase: 03-service-user-and-filesystem-layout
+plan: 05
+type: execute
+wave: 3
+depends_on:
+  - "03-01"
+  - "03-02"
+  - "03-03"
+  - "03-04"
+files_modified:
+  - scripts/provision/install-arlowe-on-arlowe1-staging.sh
+  - scripts/provision/uninstall-arlowe-on-arlowe1-staging.sh
+  - tests/phase-3/staging/run-staging.sh
+  - tests/phase-3/staging/06-sandbox-write-deny.sh
+  - tests/phase-3/staging/07-hardware-speculative.sh
+  - tests/phase-3/staging/README.md
+  - docs/operations/phase-3-staging.md
+  - .sanitize-allowlist
+autonomous: false  # requires Joe at the keyboard on arlowe-1
+estimated_loc: 330
+requirements_covered:
+  - USER-04
+  - USER-05
+
+# Closes SC4 (sandbox write-deny on real hardware) and resolves the
+# speculative-group + gpiochip questions from research §12 (open questions 3, 4, 5).
+# Also re-verifies SC1/SC2/SC3 against a real arlowe-1 system to catch anything
+# the Docker testbed missed.
+#
+# Why a parallel `arlowe-staging` user: the existing arlowe-1 setup runs services
+# as `focal55` daily-driver. We do NOT want to install the real `arlowe` user and
+# real `arlowe-*.service` units until Phase 6's image flow does it on a clean Pi.
+# So plan 05 installs everything as `arlowe-staging` user with `arlowe-staging-*`
+# unit names — side-by-side, non-disruptive — exercises SC4 against real
+# hardware, then tears down with the uninstall script.
+#
+# Plan 03-01 ships env-var-aware assertion scripts (ARLOWE_USER / ARLOWE_GROUP /
+# ARLOWE_HOME / ARLOWE_OPT / ARLOWE_ETC defaults). The staging harness re-uses
+# those assertions by exporting ARLOWE_USER=arlowe-staging before invocation.
+# Plan 03-05 does NOT edit any of plan 03-01's scripts.
+
+# LOC contingency: estimate 330; checker projects 380–440 actual. Hard cap 400.
+# If actual blows past 400, split into 03-05a (install/uninstall scripts) and
+# 03-05b (test runner + assertions + docs/staging.md). 05b depends on 05a.
+
+must_haves:
+  truths:
+    - "scripts/provision/install-arlowe-on-arlowe1-staging.sh provisions a parallel `arlowe-staging` user on arlowe-1 with HOME=/var/lib/arlowe-staging, sandboxed identically to the production `arlowe` user, and layout under /opt/arlowe-staging/ + /var/lib/arlowe-staging/"
+    - "Six staging unit files exist at /etc/systemd/system/arlowe-staging-*.service, qwen-staging-*, whisper-stt-staging — same as the production units but with `User=arlowe-staging`, ports remapped to avoid collision with existing focal55-owned services (face: 8081, dashboard: 3001, stt: 8083, qwen: 8001, qwen-tokenizer: 12346)"
+    - "scripts/provision/uninstall-arlowe-on-arlowe1-staging.sh cleanly removes the user, layout, units, and udev/polkit rules — leaves arlowe-1 in its pre-staging state"
+    - "tests/phase-3/staging/06-sandbox-write-deny.sh verifies SC4 against real systemd on arlowe-1 — confirms `arlowe-staging` cannot write outside /var/lib/arlowe-staging/ under the production sandbox directives"
+    - "tests/phase-3/staging/07-hardware-speculative.sh resolves three open questions from research §12: (1) dialout group needed for audio? (2) video group needed for WhisPlay? (3) does WhisPlay open /dev/gpiochip0 OR /dev/gpiochip4 OR both?"
+    - "Outcome of 07-hardware-speculative.sh is documented in docs/operations/phase-3-staging.md, and if any group/device coverage is wrong in plans 01 or 02, the SUMMARY for THIS plan flags it as a follow-up issue for Phase 4 cleanup (not a re-open of Phase 3)"
+    - "Plan 03-01's assertion scripts (01-user-shape.sh, 02-fs-layout.sh) are re-run on arlowe-1 with ARLOWE_USER=arlowe-staging exported — they pass with no edits to those scripts because they were authored env-var-aware from the start"
+    - "Tear-down via uninstall-arlowe-on-arlowe1-staging.sh leaves the system clean: `id arlowe-staging` returns no-such-user; `getent passwd focal55` still returns focal55; all arlowe-staging-*.service files removed from /etc/systemd/system/"
+    - "Plan SUMMARY documents whether plan 03-03's 90-arlowe-axera.rules conflicts with the axcl_host deb (running extract-axcl-udev-from-deb.sh against the on-arlowe-1 deb installation)"
+    - "`.sanitize-allowlist` gains two new entries (tests/phase-3/staging/06-sandbox-write-deny.sh and docs/operations/phase-3-staging.md) so the sanitize gate passes despite the negative-test data and dev-unit ops doc containing `focal55` / `/home/focal55` / `arlowe-1`"
+  artifacts:
+    - path: "scripts/provision/install-arlowe-on-arlowe1-staging.sh"
+      provides: "End-to-end staging install: arlowe-staging user, /opt/arlowe-staging/, /var/lib/arlowe-staging/, six remapped staging units, udev + polkit rules with -staging suffix variants"
+      min_lines: 100
+    - path: "scripts/provision/uninstall-arlowe-on-arlowe1-staging.sh"
+      provides: "Paired cleanup: stops + disables staging units, removes unit files, removes /opt/arlowe-staging + /var/lib/arlowe-staging trees, deluser arlowe-staging, removes -staging udev/polkit rules"
+      min_lines: 60
+    - path: "tests/phase-3/staging/run-staging.sh"
+      provides: "Top-level runner: ssh into arlowe-1, scp install script, run install, run staging assertions (exports ARLOWE_USER=arlowe-staging so plan 01's existing assertions re-target the staging tree), capture output, run tear-down. Joe invokes from his Mac."
+      min_lines: 50
+    - path: "tests/phase-3/staging/06-sandbox-write-deny.sh"
+      provides: "SC4 verification under real systemd: positive test (arlowe-staging writes to /var/lib/arlowe-staging/logs/ succeed) + negative tests (arlowe-staging writes to /opt/arlowe-staging/, /etc/, /root/, /home/focal55/ all denied with EROFS or EACCES)"
+      min_lines: 50
+    - path: "tests/phase-3/staging/07-hardware-speculative.sh"
+      provides: "Hardware-loop verification: enumerate device nodes (/dev/snd/*, /dev/gpiochip*, /dev/spidev*, /dev/axcl_host), check arlowe-staging can open each per its DeviceAllow + udev rule, report which groups are actually used (drop unused supplementary groups in a future iteration), report which gpiochip the WhisPlay driver opens (via lsof on a started arlowe-staging-face service)"
+      min_lines: 70
+    - path: "tests/phase-3/staging/README.md"
+      provides: "How to run the staging harness; SSH prereqs; WhisPlay-hardware-contention prereq (stop focal55's user-mode arlowe-face before running 07); what to do with the output report; tear-down protocol"
+      min_lines: 30
+    - path: "docs/operations/phase-3-staging.md"
+      provides: "Staging-procedure write-up: setup, what got installed where, observed-run section with results of 06+07, decision on dialout/video/gpiochip4 confirmations or removals, axcl deb conflict status, WhisPlay hardware-contention prereq for hardware-bound test"
+      min_lines: 50
+    - path: ".sanitize-allowlist"
+      provides: "Two new path globs allowing `focal55` / `/home/focal55` / `arlowe-1` literals in plan 05's negative-test data and operational doc; precedent: docs/operations/phase-1-smoke-test.md and scripts/dev-pull-from-pi.sh already allow-listed"
+  key_links:
+    - from: "scripts/provision/install-arlowe-on-arlowe1-staging.sh"
+      to: "production install scripts (plans 01, 03, 04)"
+      via: "shell sed-then-temp-file approach (strategy A); orders path-specific substitutions before broad arlowe→arlowe-staging substitution to avoid redundant no-op seds"
+      pattern: "sed.*arlowe-staging"
+    - from: "tests/phase-3/staging/run-staging.sh"
+      to: "plan 03-01's assertion scripts (re-used unmodified)"
+      via: "ARLOWE_USER=arlowe-staging bash 01-user-shape.sh && ARLOWE_USER=arlowe-staging bash 02-fs-layout.sh — env-var contract authored in plan 01, consumed here"
+      pattern: "ARLOWE_USER=arlowe-staging"
+    - from: "tests/phase-3/staging/06-sandbox-write-deny.sh"
+      to: "real systemd sandbox enforcement on Pi OS"
+      via: "systemd-run --uid=arlowe-staging --gid=arlowe-staging -p ProtectSystem=strict ..."
+      pattern: "systemd-run --uid=arlowe-staging"
+    - from: "tests/phase-3/staging/07-hardware-speculative.sh"
+      to: "WhisPlay driver actually loaded"
+      via: "systemctl start arlowe-staging-face && lsof -p $(pidof -s python3 ...) | grep -E 'gpiochip|spidev'"
+      pattern: "lsof.*gpiochip"
+---
+
+<objective>
+Run the production Phase 3 install on real arlowe-1 hardware — under a parallel `arlowe-staging` user so the live `focal55`-owned daily-driver setup remains untouched — and verify (a) SC4 sandbox write-denial against real systemd, (b) the speculative-group + gpiochip-enumeration open questions from research §12, and (c) Docker-vs-Pi-OS-Bookworm parity for SC1+SC2+SC3.
+
+Purpose: SC4 is "a test on the dev image verifies that the runtime cannot write outside `/var/lib/arlowe/`." The Docker testbed validated this synthetically. SC4 the requirement, as Joe wrote it in ROADMAP, calls for "the dev image" — i.e., a real Pi. This plan closes that gap without paying the cost of a full Phase 6 image build and without disrupting the existing arlowe-1 setup that other phases still need for their own validation.
+
+Output: Two staging install/uninstall scripts, three staging test scripts (runner + SC4 + speculative-hardware), one staging README, an updated `.sanitize-allowlist` with two new entries, and a docs/operations/phase-3-staging.md that records the observed-run results — analogous to Phase 1 plan 13's `phase-1-smoke-test.md` pattern.
+</objective>
+
+<execution_context>
+@~/.claude/get-shit-done/workflows/execute-plan.md
+@~/.claude/get-shit-done/templates/summary.md
+
+**This plan is NOT autonomous.** Joe must be present at the keyboard to:
+1. SSH into arlowe-1 (`ssh arlowe-1`) — the workforce-mac has SSH key auth.
+2. Run `bash tests/phase-3/staging/run-staging.sh` from his Mac (which SSHes to arlowe-1, runs the install, runs assertions, tears down).
+3. Review the output report.
+4. Confirm tear-down restored arlowe-1 to clean state (re-checks `getent passwd arlowe-staging` is gone, all -staging units removed).
+
+The QA/DEV split for this plan is unusual: there's no failing-test-then-implement loop because the hardware is the system-under-test. The structure is:
+- DEV implements the staging install scripts (parameterized variants of plans 01-04 install scripts).
+- QA implements the staging assertion scripts (NEW for SC4 + hardware-speculative; existing SC1/SC2 assertions are re-used unmodified via env-var override).
+- Joe runs the harness manually on arlowe-1 and records observations.
+
+Atomic-PR LOC estimated 330. Hard cap 400 per the LOC contingency in frontmatter; if actual exceeds, split into 03-05a (install/uninstall) + 03-05b (assertions + docs).
+
+Special handling: this plan's SUMMARY is the **closure document for Phase 3**. It records the observed-run results from the hardware test and either:
+- Confirms all open questions resolved cleanly → Phase 3 closes pass.
+- Documents follow-up issues for Phase 4 (e.g., "drop video group; WhisPlay doesn't use framebuffer") as Phase-4 cleanup tasks → Phase 3 closes passed-with-notes (like Phase 1 plan 13).
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/REQUIREMENTS.md
+@.planning/phases/03-service-user-and-filesystem-layout/03-RESEARCH.md
+@.planning/phases/03-service-user-and-filesystem-layout/03-01-PLAN.md
+@.planning/phases/03-service-user-and-filesystem-layout/03-02-PLAN.md
+@.planning/phases/03-service-user-and-filesystem-layout/03-03-PLAN.md
+@.planning/phases/03-service-user-and-filesystem-layout/03-04-PLAN.md
+@docs/operations/phase-3-layout.md
+@.planning/phases/01-runtime-extraction/01-13-SUMMARY.md
+@.sanitize-allowlist
+# Phase 1 plan 13 SUMMARY is the model for how this plan's SUMMARY records
+# observed-run results (passed-with-notes pattern).
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: DEV authors install + uninstall staging scripts (parameterized variants of plans 01-04)</name>
+  <files>
+    scripts/provision/install-arlowe-on-arlowe1-staging.sh
+    scripts/provision/uninstall-arlowe-on-arlowe1-staging.sh
+  </files>
+  <action>
+Author the two staging scripts. **Key design choice: do NOT duplicate the production install scripts.** The staging install copies-then-seds the production scripts into temp files, replacing `arlowe` with `arlowe-staging` and `/opt/arlowe/` with `/opt/arlowe-staging/`, etc., then runs the temp scripts. This avoids modifying plans 01-04's scripts after they've been committed.
+
+**Sed substitution ordering (avoid no-op seds):** run path-specific substitutions BEFORE the broad `arlowe` → `arlowe-staging` substitution. The broad substitution then only touches references that weren't already covered by the path-specific ones. Earlier iteration drafted redundant `s|/opt/arlowe-staging/|/opt/arlowe-staging/|g` lines after the broad sub; those are now unnecessary because the broad sub handles them in a single pass.
+
+Script structure for `install-arlowe-on-arlowe1-staging.sh`:
+
+```bash
+#!/bin/bash
+# Phase 3 plan 05: install a parallel arlowe-staging user + layout + units on
+# arlowe-1 for SC4 + hardware-speculative verification. Side-by-side with the
+# existing focal55-owned daily-driver setup; does NOT touch it.
+#
+# Run from arlowe-1 directly OR remotely: `ssh arlowe-1 'bash -s' < install-arlowe-on-arlowe1-staging.sh`.
+# Tear down with uninstall-arlowe-on-arlowe1-staging.sh.
+set -euo pipefail
+
+# Sanity check: must run on arlowe-1
+if [[ ! -f /etc/hostname ]] || ! grep -qE '^arlowe' /etc/hostname; then
+    echo "Refusing to run on a host whose hostname doesn't start with 'arlowe'" >&2
+    echo "This script is hard-scoped to the arlowe-1 staging-user pattern." >&2
+    exit 1
+fi
+
+# Refuse if production arlowe user exists — that's the Phase 6 image, not the staging path
+if id arlowe >/dev/null 2>&1; then
+    echo "Production 'arlowe' user exists. This is a Phase 6 image, not the dev/staging Pi." >&2
+    echo "Refusing to run side-by-side with a production install." >&2
+    exit 1
+fi
+
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+# Generate staging variants of plans 01-04 scripts via sed.
+# Substitution ordering: the broad `arlowe` → `arlowe-staging` substitution
+# subsumes the path-specific cases (/opt/arlowe → /opt/arlowe-staging,
+# /var/lib/arlowe → /var/lib/arlowe-staging, /etc/arlowe → /etc/arlowe-staging).
+# So we just run the broad sub once. No redundant no-op lines.
+for script in install-arlowe-user.sh install-arlowe-fs.sh install-arlowe-udev-polkit.sh install-arlowe-cli.sh; do
+    sed 's|arlowe|arlowe-staging|g' \
+        "$REPO_ROOT/scripts/provision/$script" > "$TMP/${script%.sh}-staging.sh"
+    chmod +x "$TMP/${script%.sh}-staging.sh"
+done
+
+bash "$TMP/install-arlowe-user-staging.sh"
+bash "$TMP/install-arlowe-fs-staging.sh"
+bash "$TMP/install-arlowe-udev-polkit-staging.sh"
+
+# Install staging unit files with port remaps to avoid collision with existing
+# focal55-owned --user services (face: 8080, dashboard: 3000, stt: 8082, qwen: 8000).
+# Same ordering rule: path-specific User=/Group=/PORT= seds first, then broad
+# arlowe-prefix substitution baked into the same sed expression via -e chaining.
+for unit in "$REPO_ROOT/units/"*.service; do
+    name=$(basename "$unit" .service)
+    case "$name" in
+        arlowe-*|qwen-*|whisper-stt)
+            target_name="${name}-staging.service"
+            ;;
+        *)
+            echo "Unexpected unit name: $name" >&2; exit 1
+            ;;
+    esac
+
+    sed \
+        -e 's|User=arlowe|User=arlowe-staging|g' \
+        -e 's|Group=arlowe|Group=arlowe-staging|g' \
+        -e 's|/opt/arlowe/|/opt/arlowe-staging/|g' \
+        -e 's|/var/lib/arlowe/|/var/lib/arlowe-staging/|g' \
+        -e 's|=arlowe-face.service|=arlowe-face-staging.service|g' \
+        -e 's|=whisper-stt.service|=whisper-stt-staging.service|g' \
+        -e 's|=qwen-api.service|=qwen-api-staging.service|g' \
+        -e 's|=qwen-tokenizer.service|=qwen-tokenizer-staging.service|g' \
+        -e 's|PORT=3000|PORT=3001|g' \
+        -e 's|:8080|:8081|g' \
+        -e 's|:8082|:8083|g' \
+        -e 's|:8000|:8001|g' \
+        "$unit" > "$TMP/$target_name"
+    install -m 0644 -o root -g root "$TMP/$target_name" "/etc/systemd/system/$target_name"
+done
+
+systemctl daemon-reload
+
+# Install CLI symlinks with -staging suffix
+for cli in face speak stt record boot-check purge-logs run-logrotate wake-train; do
+    ln -sf "/opt/arlowe-staging/runtime/cli/$cli" "/usr/local/sbin/arlowe-staging-$cli"
+done
+
+# Pre-stage runtime/cli marker files so symlinks resolve (Phase 6 populates these
+# on a real image; here we copy from the repo)
+install -d -o root -g arlowe-staging -m 0755 /opt/arlowe-staging/runtime/cli
+for cli in face speak stt record boot-check purge-logs run-logrotate wake-train; do
+    if [[ -f "$REPO_ROOT/runtime/cli/$cli" ]]; then
+        install -m 0755 -o root -g arlowe-staging "$REPO_ROOT/runtime/cli/$cli" "/opt/arlowe-staging/runtime/cli/$cli"
+    fi
+done
+
+echo "[install-arlowe-on-arlowe1-staging] staging environment provisioned. Run tests/phase-3/staging/06-sandbox-write-deny.sh and 07-hardware-speculative.sh."
+```
+
+Caveat about the sed approach: the substitution `s|arlowe|arlowe-staging|g` runs on every match, including in comments. That's fine for the install scripts but be careful with the polkit rule — its `subject.user === "arlowe"` becomes `subject.user === "arlowe-staging"` which is what we want. Same for the udev `GROUP="arlowe"` → `GROUP="arlowe-staging"`. Verify by `grep` after sed.
+
+**`uninstall-arlowe-on-arlowe1-staging.sh`:** mirror image.
+```bash
+#!/bin/bash
+# Paired tear-down for install-arlowe-on-arlowe1-staging.sh.
+set -euo pipefail
+
+# Refuse if arlowe-staging user doesn't exist
+if ! id arlowe-staging >/dev/null 2>&1; then
+    echo "No arlowe-staging user; nothing to tear down."
+    exit 0
+fi
+
+# Stop and disable all staging units
+for unit in /etc/systemd/system/*-staging.service; do
+    [[ -f "$unit" ]] || continue
+    name=$(basename "$unit")
+    systemctl stop "$name" 2>/dev/null || true
+    systemctl disable "$name" 2>/dev/null || true
+    rm -f "$unit"
+done
+
+systemctl daemon-reload
+
+# Remove CLI symlinks
+for cli in face speak stt record boot-check purge-logs run-logrotate wake-train; do
+    rm -f "/usr/local/sbin/arlowe-staging-$cli"
+done
+
+# Remove udev + polkit -staging rules (anything containing "arlowe-staging")
+rm -f /etc/udev/rules.d/9*-arlowe-staging-*.rules 2>/dev/null || true
+rm -f /etc/polkit-1/rules.d/5*-arlowe-staging-*.rules 2>/dev/null || true
+udevadm control --reload 2>/dev/null || true
+
+# Remove trees
+rm -rf /opt/arlowe-staging
+rm -rf /var/lib/arlowe-staging
+rm -rf /etc/arlowe-staging
+
+# Delete user
+deluser --remove-home arlowe-staging 2>/dev/null || userdel -r arlowe-staging 2>/dev/null || true
+
+echo "[uninstall] arlowe-staging tear-down complete. Verify with: id arlowe-staging (should fail)."
+```
+
+After writing, run `bash -n` on both. Sanitization sweep.
+  </action>
+  <verify>
+`bash -n scripts/provision/install-arlowe-on-arlowe1-staging.sh && bash -n scripts/provision/uninstall-arlowe-on-arlowe1-staging.sh` — syntax clean.
+
+Sanitization: `bash scripts/sanitize/check.sh --grep-only scripts/provision/install-arlowe-on-arlowe1-staging.sh scripts/provision/uninstall-arlowe-on-arlowe1-staging.sh` — clean.
+
+Manual review: confirm the sed substitutions don't break the production install scripts' invariants (e.g., polkit rule's `org.freedesktop.systemd1.manage-units` is unchanged; `useradd --system` syntax preserved). Confirm no redundant no-op sed lines (every substitution actually changes something).
+  </verify>
+  <done>
+Two scripts authored, syntax-clean, sanitization-clean. Install script refuses to run on a non-arlowe-named host AND refuses if the production `arlowe` user already exists (defensive). Uninstall script is idempotent (no-op when user absent). Sed substitution chains contain no redundant no-op lines.
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 2: QA authors staging assertion scripts + runner + .sanitize-allowlist update</name>
+  <files>
+    tests/phase-3/staging/run-staging.sh
+    tests/phase-3/staging/06-sandbox-write-deny.sh
+    tests/phase-3/staging/07-hardware-speculative.sh
+    .sanitize-allowlist
+  </files>
+  <action>
+Write the staging-side test harness, plus update the sanitize allowlist for the two staging files that contain banned literals by design.
+
+**`.sanitize-allowlist` update (do this first so the gate doesn't fire on the new files during commit):**
+
+Add two new entries to `.sanitize-allowlist`. Group them logically with the existing entries and follow the precedent of `docs/operations/phase-1-smoke-test.md` and `scripts/dev-pull-from-pi.sh`:
+
+```
+# --- Phase 3 plan 05 staging allow-list ---
+# 06-sandbox-write-deny.sh is the SC4 negative-test assertion: it MUST contain
+# the literal `/home/focal55` so it can prove the sandbox denies writes to the
+# founder home. Removing the literal would defeat the test's purpose.
+# Precedent: scripts/sanitize/test-check.sh (gate self-test) is allow-listed
+# for the same reason.
+tests/phase-3/staging/06-sandbox-write-deny.sh
+
+# phase-3-staging.md is a dev-unit operational doc referencing the daily-driver
+# user (focal55) and dev hostname (arlowe-1) because hardware contention is a
+# real prereq for the staging harness. Never ships in the firmware image.
+# Precedent: docs/operations/phase-1-smoke-test.md.
+docs/operations/phase-3-staging.md
+```
+
+Place these in `.sanitize-allowlist` near the existing `docs/operations/phase-1-smoke-test.md` and `scripts/dev-pull-from-pi.sh` blocks. Match the existing comment style.
+
+**`tests/phase-3/staging/run-staging.sh`** (Joe's invocation point, runs from Mac):
+
+```bash
+#!/bin/bash
+# Phase 3 plan 05 staging harness. Runs on Joe's Mac; SSHes into arlowe-1.
+# Pre-req: SSH alias 'arlowe-1' configured (per ~/.claude/CLAUDE.md Arlowe-1
+# section); key-based auth working.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+SSH_HOST="${ARLOWE_STAGING_HOST:-arlowe-1}"
+
+echo "=== Phase 3 plan 05 staging harness ==="
+echo "Target: $SSH_HOST"
+echo ""
+
+# Sanity: can we reach the host?
+ssh -o ConnectTimeout=5 -o BatchMode=yes "$SSH_HOST" 'hostname && uname -m && systemctl --version | head -1' \
+    || { echo "Cannot reach $SSH_HOST. Check SSH config."; exit 1; }
+
+# Copy the repo (minus heavy stuff) to /tmp/arlowe-firmware on arlowe-1
+echo "=== Syncing repo to $SSH_HOST:/tmp/arlowe-firmware ==="
+rsync -az --delete \
+    --exclude '.git' --exclude 'node_modules' --exclude '__pycache__' \
+    --exclude 'runtime/dashboard/.next' \
+    "$REPO_ROOT/" "$SSH_HOST:/tmp/arlowe-firmware/"
+
+# Run install
+echo "=== Installing arlowe-staging on $SSH_HOST ==="
+ssh "$SSH_HOST" 'sudo bash /tmp/arlowe-firmware/scripts/provision/install-arlowe-on-arlowe1-staging.sh'
+
+# Re-run plan 01's SC1+SC2 assertions against the staging tree.
+# These scripts are env-var-aware from the start (plan 01 authored them that
+# way per the plan 01 frontmatter contract); we simply export ARLOWE_USER and
+# the derived paths follow. NO edits to plan 01's scripts are needed or made.
+echo "=== Running SC1+SC2 assertions against staging (env-var override) ==="
+ssh "$SSH_HOST" '
+    export ARLOWE_USER=arlowe-staging
+    export ARLOWE_GROUP=arlowe-staging
+    export ARLOWE_HOME=/var/lib/arlowe-staging
+    export ARLOWE_OPT=/opt/arlowe-staging
+    export ARLOWE_ETC=/etc/arlowe-staging
+    for a in /tmp/arlowe-firmware/tests/phase-3/assertions/01-user-shape.sh /tmp/arlowe-firmware/tests/phase-3/assertions/02-fs-layout.sh; do
+        echo "--- $a ---"
+        sudo -E bash "$a" || exit 1
+    done
+'
+
+echo "=== Running SC4 sandbox write-deny ==="
+ssh "$SSH_HOST" 'sudo bash /tmp/arlowe-firmware/tests/phase-3/staging/06-sandbox-write-deny.sh'
+
+echo "=== Running speculative hardware verification ==="
+ssh "$SSH_HOST" 'sudo bash /tmp/arlowe-firmware/tests/phase-3/staging/07-hardware-speculative.sh' \
+    | tee "$REPO_ROOT/.planning/phases/03-service-user-and-filesystem-layout/staging-observed-run.txt"
+
+echo ""
+echo "=== Staging run complete. ==="
+echo "Observed-run output captured at: .planning/phases/03-service-user-and-filesystem-layout/staging-observed-run.txt"
+echo ""
+echo "Review the output, then tear down with:"
+echo "  ssh $SSH_HOST 'sudo bash /tmp/arlowe-firmware/scripts/provision/uninstall-arlowe-on-arlowe1-staging.sh'"
+echo ""
+echo "After tear-down, fold findings into .planning/phases/03-service-user-and-filesystem-layout/03-05-SUMMARY.md"
+echo "and docs/operations/phase-3-staging.md."
+```
+
+The SC1/SC2 assertions are reused **unmodified** — the env-var contract was authored into them by plan 03-01 from the start. Plan 03-05 contributes zero lines to plan 01's scripts.
+
+**`tests/phase-3/staging/06-sandbox-write-deny.sh`:**
+
+```bash
+#!/bin/bash
+# SC4: under the production sandbox directives, arlowe-staging cannot write
+# outside /var/lib/arlowe-staging/.
+set -euo pipefail
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+USER=arlowe-staging
+HOME_DIR=/var/lib/arlowe-staging
+RWPATH="$HOME_DIR/logs/face"
+
+# Positive: can write to a declared writable path
+sudo systemd-run --uid="$USER" --gid="$USER" --pty --wait \
+    -p ProtectSystem=strict -p ProtectHome=yes -p NoNewPrivileges=yes -p PrivateTmp=yes \
+    -p "ReadWritePaths=$RWPATH" \
+    /bin/sh -c "touch $RWPATH/positive-test && rm $RWPATH/positive-test" \
+    || fail "positive write-allow test failed (couldn't write to declared RW path)"
+
+# Negative: cannot write to /opt/arlowe-staging (would be /opt/arlowe in prod)
+if sudo systemd-run --uid="$USER" --gid="$USER" --pty --wait \
+        -p ProtectSystem=strict -p ProtectHome=yes -p NoNewPrivileges=yes -p PrivateTmp=yes \
+        -p "ReadWritePaths=$RWPATH" \
+        /bin/sh -c "touch /opt/arlowe-staging/runtime/voice/negative-test" 2>&1 | tee /tmp/sc4-neg-opt.txt; then
+    fail "negative test allowed write to /opt/arlowe-staging (sandbox not enforcing ProtectSystem=strict)"
+fi
+grep -qE 'Read-only file system|Permission denied' /tmp/sc4-neg-opt.txt \
+    || fail "negative test rejected without the expected error message"
+
+# Negative: cannot write to /etc/
+if sudo systemd-run --uid="$USER" --gid="$USER" --pty --wait \
+        -p ProtectSystem=strict -p ProtectHome=yes -p NoNewPrivileges=yes -p PrivateTmp=yes \
+        -p "ReadWritePaths=$RWPATH" \
+        /bin/sh -c "touch /etc/negative-test" 2>&1 | tee /tmp/sc4-neg-etc.txt; then
+    fail "negative test allowed write to /etc/"
+fi
+
+# Negative: cannot write to /home/focal55 (founder home — must NEVER be writable from staging)
+# NOTE: this is the assertion the sanitize-allowlist exists for.
+if sudo systemd-run --uid="$USER" --gid="$USER" --pty --wait \
+        -p ProtectSystem=strict -p ProtectHome=yes -p NoNewPrivileges=yes -p PrivateTmp=yes \
+        -p "ReadWritePaths=$RWPATH" \
+        /bin/sh -c "touch /home/focal55/negative-test" 2>&1 | tee /tmp/sc4-neg-focal.txt; then
+    fail "negative test allowed write to /home/focal55 — sandbox catastrophic failure"
+fi
+
+echo "[06-sandbox-write-deny] PASS (positive RW + 3 negative tests confirmed)"
+```
+
+**`tests/phase-3/staging/07-hardware-speculative.sh`:**
+
+```bash
+#!/bin/bash
+# Phase 3 open-questions resolution (research §12 #3, #4, #5):
+# - Does arlowe-staging actually need the `dialout` and `video` groups?
+# - Which gpiochip does the WhisPlay driver actually open: 0, 4, or both?
+# - Does the axcl_host deb's postinst conflict with our 90-arlowe-axera.rules?
+#
+# PREREQUISITE (see README): the daily-driver `arlowe-face` user-service (running
+# as focal55) MUST be stopped before this script runs. WhisPlay hardware is held
+# exclusively by whichever process opens the SPI/GPIO devices first; if focal55's
+# face service is holding it, this script's `systemctl start arlowe-staging-face`
+# will either fail or produce inconclusive lsof output.
+set -euo pipefail
+
+USER=arlowe-staging
+echo "=== Speculative-group verification ==="
+echo ""
+
+# Report on each supplementary group
+for grp in audio gpio spi dialout video; do
+    if id -nG "$USER" | grep -qw "$grp"; then
+        echo "  $grp: granted to $USER"
+    else
+        echo "  $grp: NOT granted"
+    fi
+done
+
+echo ""
+echo "=== Device-node enumeration ==="
+ls -la /dev/snd/ 2>/dev/null | head -20 || echo "  /dev/snd: absent (no audio HAT?)"
+ls -la /dev/gpiochip* 2>/dev/null || echo "  /dev/gpiochip*: absent"
+ls -la /dev/spidev* 2>/dev/null    || echo "  /dev/spidev*: absent"
+ls -la /dev/axcl_host /dev/ax_mmb_dev 2>/dev/null || echo "  /dev/axcl*: absent (axcl_host deb installed?)"
+ls -la /dev/fb0 2>/dev/null        || echo "  /dev/fb0: absent"
+
+echo ""
+echo "=== Can arlowe-staging open each device? ==="
+for dev in /dev/snd/seq /dev/gpiochip0 /dev/gpiochip4 /dev/spidev0.0 /dev/axcl_host /dev/fb0; do
+    if [[ -e "$dev" ]]; then
+        if sudo -u "$USER" -- bash -c "test -r '$dev' && test -w '$dev' 2>/dev/null"; then
+            echo "  $dev: arlowe-staging can read+write (PASS)"
+        else
+            echo "  $dev: arlowe-staging CANNOT open (FAIL — udev rule or group missing?)"
+        fi
+    fi
+done
+
+echo ""
+echo "=== WhisPlay driver: which gpiochip does it actually use? ==="
+# Try to start arlowe-staging-face for 5s and see which gpiochip the python process opens.
+# If the service refuses to start (port conflict, missing deps, OR daily-driver
+# face still holding hardware), this whole section is informational only — log
+# the error and continue.
+if sudo systemctl start arlowe-staging-face.service 2>&1; then
+    sleep 5
+    PID=$(pgrep -u "$USER" -f 'face_service' | head -1)
+    if [[ -n "$PID" ]]; then
+        echo "  arlowe-staging-face running as pid $PID"
+        echo "  Open device fds:"
+        sudo lsof -p "$PID" 2>/dev/null | grep -E '/dev/(gpiochip|spidev|snd|fb)' || echo "    (none — driver not yet initialized?)"
+    else
+        echo "  arlowe-staging-face started but no process found (crashed immediately?)"
+        echo "  Check: did you stop the daily-driver arlowe-face user-service? (see README)"
+    fi
+    sudo systemctl stop arlowe-staging-face.service 2>/dev/null || true
+else
+    echo "  arlowe-staging-face failed to start; review with: journalctl -u arlowe-staging-face.service -n 30"
+    echo "  Likely cause: daily-driver arlowe-face user-service is holding WhisPlay hardware. See README for stop procedure."
+fi
+
+echo ""
+echo "=== Recommendations from this run ==="
+echo "Examine the above output, then fold the conclusions into:"
+echo "  docs/operations/phase-3-staging.md (Observed-run section)"
+echo "  .planning/phases/03-service-user-and-filesystem-layout/03-05-SUMMARY.md (frontmatter provides)"
+echo ""
+echo "Specifically, decide:"
+echo "  1. Drop 'dialout' from useradd if no /dev/snd/seq or UART-controlled audio HAT in use."
+echo "  2. Drop 'video' from useradd if /dev/fb0 not opened by WhisPlay driver."
+echo "  3. Narrow gpiochip DeviceAllow if only one chip is opened."
+```
+
+After writing, sanitization: the `focal55` reference in 06 is already allow-listed by the `.sanitize-allowlist` edit above.
+  </action>
+  <verify>
+`bash -n tests/phase-3/staging/{run-staging.sh,06-sandbox-write-deny.sh,07-hardware-speculative.sh}` — all syntax-clean.
+
+Sanitization: `bash scripts/sanitize/check.sh`. With the two new `.sanitize-allowlist` entries in place, the gate must pass cleanly — no warnings, no failures.
+
+Manual: confirm `.sanitize-allowlist` was edited (`grep -E '^tests/phase-3/staging/06-sandbox-write-deny\.sh$' .sanitize-allowlist` returns a match; same for the docs path).
+
+Manual review: 06 covers positive + 3 negative cases. 07 enumerates devices, attempts to start the face service, captures lsof output. Both scripts work in a no-hardware fallback path (skip with informative output, don't hard-fail). 07 references the WhisPlay-contention prereq in its failure-path output.
+
+Plan 03-01 contract: confirm NO edits to `tests/phase-3/assertions/01-user-shape.sh` or `02-fs-layout.sh` (`git diff --stat tests/phase-3/assertions/` returns empty for this PR).
+  </verify>
+  <done>
+Four files authored (3 scripts + 1 allowlist edit). Sanitization gate green. Scripts run cleanly when invoked on arlowe-1 with arlowe-staging provisioned. No edits to plan 01's assertion scripts.
+  </done>
+</task>
+
+<task type="checkpoint:human-verify" gate="blocking">
+  <name>Task 3: Joe runs the staging harness on arlowe-1</name>
+  <what-built>
+End-to-end Phase 3 staging environment on real arlowe-1 hardware:
+- `arlowe-staging` user provisioned, parallel to the existing focal55 setup
+- Six staging units (arlowe-face-staging, arlowe-voice-staging, arlowe-dashboard-staging, qwen-tokenizer-staging, qwen-api-staging, whisper-stt-staging) installed at /etc/systemd/system/
+- Layout under /opt/arlowe-staging/ and /var/lib/arlowe-staging/ provisioned
+- Udev + polkit rules with -staging suffixes installed
+- CLI symlinks `/usr/local/sbin/arlowe-staging-*` installed
+
+Three test scripts ready to run:
+- Plan 01's SC1+SC2 assertions re-used unmodified (env-var-overridden to target staging tree)
+- SC4 sandbox write-deny (positive RW + 3 negative)
+- Speculative-hardware verification (groups, gpiochip, lsof on face service)
+  </what-built>
+  <how-to-verify>
+**PREREQ — stop daily-driver WhisPlay-holding service.** Before running the harness, stop the focal55 user-mode `arlowe-face` so the staging hardware-check can open the SPI/GPIO devices:
+
+```bash
+ssh arlowe-1 "systemctl --user stop arlowe-face"
+```
+
+(Restart it after the staging tear-down:
+```bash
+ssh arlowe-1 "systemctl --user start arlowe-face"
+```)
+
+From Joe's Mac, in the arlowe-firmware repo root:
+
+```bash
+# Run the full staging harness:
+bash tests/phase-3/staging/run-staging.sh
+
+# Review the captured output:
+cat .planning/phases/03-service-user-and-filesystem-layout/staging-observed-run.txt
+
+# Tear down:
+ssh arlowe-1 'sudo bash /tmp/arlowe-firmware/scripts/provision/uninstall-arlowe-on-arlowe1-staging.sh'
+
+# Verify clean tear-down:
+ssh arlowe-1 'id arlowe-staging 2>&1; ls /etc/systemd/system/*-staging.service 2>&1 | head'
+# Expect "no such user" and "No such file or directory"
+
+# Restart daily-driver face service:
+ssh arlowe-1 "systemctl --user start arlowe-face"
+
+# Verify focal55 setup untouched:
+ssh arlowe-1 'getent passwd focal55 && systemctl --user --no-pager list-unit-files | grep -c arlowe-'
+# Expect focal55 user present; count of existing --user arlowe- units unchanged
+```
+
+Expected outcomes:
+1. Install script runs without error (or with documented errors — e.g., axcl deb not present is fine).
+2. SC1+SC2 re-runs pass (or fail with diff-worthy variance from Docker — capture).
+3. SC4 sandbox write-deny: positive test passes, all 3 negative tests confirm sandbox blocks writes.
+4. 07-hardware-speculative.sh produces a report. Joe reads it and decides:
+   - Are `dialout` and `video` groups actually needed? (Drop in plan 01 if not.)
+   - Does WhisPlay open gpiochip0, gpiochip4, or both? (Tighten DeviceAllow in plan 02 if narrowing possible.)
+   - Did the axcl_host deb conflict with our udev rule? (If yes → CHECKPOINT before merging plan 03.)
+5. Tear-down leaves arlowe-1 clean.
+
+If 07-hardware-speculative.sh produces inconclusive output (no lsof against gpiochip), check whether the daily-driver `arlowe-face` was actually stopped per the prereq above.
+
+If any negative SC4 test allows the write, this is a sandbox enforcement failure — Phase 3 cannot close. Raise via standard PR review.
+
+If 07-hardware-speculative.sh reveals plans 01 or 02 had wrong group/device coverage, document the finding and treat the fix as a Phase 4 cleanup (or a follow-up PR in Phase 3 if blocking).
+  </how-to-verify>
+  <resume-signal>
+Type "approved" with a one-paragraph note summarizing the observed-run results and any follow-ups to fold into the SUMMARY, OR describe specific failures that block Phase 3 closure.
+  </resume-signal>
+</task>
+
+<task type="auto">
+  <name>Task 4: Author docs/operations/phase-3-staging.md with observed-run results + README</name>
+  <files>
+    docs/operations/phase-3-staging.md
+    tests/phase-3/staging/README.md
+  </files>
+  <action>
+After Task 3 completes and Joe approves, fold the staging-observed-run.txt findings into a permanent ops doc, and write the staging README.
+
+**`tests/phase-3/staging/README.md`** (30 lines, written alongside or right after the test scripts):
+
+Sections:
+1. **What this harness does**: one paragraph.
+2. **Prereqs**:
+   - SSH alias `arlowe-1` configured with key auth.
+   - **Hardware contention**: the daily-driver `arlowe-face` user-service (running as focal55) holds the WhisPlay SPI/GPIO devices. Before running this harness, stop it:
+     ```bash
+     ssh arlowe-1 "systemctl --user stop arlowe-face"
+     ```
+     Restart it after tear-down:
+     ```bash
+     ssh arlowe-1 "systemctl --user start arlowe-face"
+     ```
+   - If you skip this prereq, `07-hardware-speculative.sh` will produce inconclusive output (the staging face service will either fail to start or run without acquiring the hardware).
+3. **Invocation**: `bash run-staging.sh`.
+4. **Tear-down protocol**: explicit ssh command.
+5. **Output**: `.planning/phases/03-service-user-and-filesystem-layout/staging-observed-run.txt`.
+
+**`docs/operations/phase-3-staging.md`** structure (mirror Phase 1's `docs/operations/phase-1-smoke-test.md` pattern):
+
+1. **Overview**: 1 paragraph. What this doc records, why a side-by-side staging user, how it relates to Phase 6 image build and Phase 12 first-flash gate.
+
+2. **Procedure**:
+   - SSH prereqs.
+   - **Hardware-contention prereq**: same `systemctl --user stop arlowe-face` instructions as the README. Document explicitly here because this is the ops doc the workforce returns to; the README is for the human running the harness once.
+   - Invocation: `bash tests/phase-3/staging/run-staging.sh`.
+   - Tear-down protocol.
+
+3. **Observed-run** (this is the meat — fill from staging-observed-run.txt):
+   - Date of run, dev Pi hostname, systemd version.
+   - SC1+SC2 results (note: plan 01's assertion scripts re-used with env-var override; zero edits to plan 01).
+   - SC4 results (positive + 3 negatives).
+   - Speculative-hardware findings:
+     - dialout group: needed / not needed (decision)
+     - video group: needed / not needed (decision)
+     - gpiochip0 vs gpiochip4: which the WhisPlay driver opens
+     - axcl deb conflict: yes / no / deb not present
+   - Anything else surprising.
+
+4. **Decisions for follow-up phases**:
+   - If groups should be dropped, list as Phase 4 cleanup task.
+   - If unit DeviceAllow can be narrowed, list as Phase 4 cleanup.
+   - If axcl deb has conflicting rules, list as Phase 6 pi-gen-build CHECKPOINT.
+
+5. **Limits**:
+   - Staging user shares hardware with daily-driver, so audio tests may be affected by which mic/speaker the focal55 services are holding (the WhisPlay-stop prereq mitigates the GPIO/SPI case but not the audio case).
+   - Staging units use port-remapped sockets (3001, 8081, etc.) — does NOT validate the production ports (3000, 8080) work, which is OK because Phase 12 owns end-to-end port verification.
+
+Sanitize-gate: this doc explicitly references `focal55` (the daily-driver user we share hardware with) and `arlowe-1` (the dev Pi hostname). It is allow-listed by the `.sanitize-allowlist` entry added in Task 2.
+  </action>
+  <verify>
+Files written. `bash scripts/sanitize/check.sh` passes.
+
+Doc structure mirrors phase-1-smoke-test.md.
+
+All speculative open questions (research §12 #3, #4, #5) have a decision recorded.
+
+README explicitly documents the `systemctl --user stop arlowe-face` prereq and its rationale.
+  </verify>
+  <done>
+phase-3-staging.md committed with observed-run results filled in. README ships with the WhisPlay-hardware-contention prereq prominently documented. Open questions §12.3/4/5 resolved. Any follow-ups assigned to Phase 4 or Phase 6.
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+```bash
+# Full plan 05 invocation (from Joe's Mac, after stopping the daily-driver face service):
+ssh arlowe-1 "systemctl --user stop arlowe-face"
+bash tests/phase-3/staging/run-staging.sh
+
+# Verify SC4 closure (in the run-staging.sh output):
+grep "06-sandbox-write-deny.*PASS" .planning/phases/03-service-user-and-filesystem-layout/staging-observed-run.txt
+
+# Verify clean tear-down:
+ssh arlowe-1 'id arlowe-staging' 2>&1 | grep -q 'no such user'
+ssh arlowe-1 'getent passwd focal55' 2>&1 | grep -q '^focal55:'
+
+# Restart daily-driver:
+ssh arlowe-1 "systemctl --user start arlowe-face"
+
+# Sanitization end-to-end (whole repo) — must pass with the new allowlist entries:
+bash scripts/sanitize/check.sh
+
+# Confirm zero edits to plan 01's assertion scripts:
+git diff --stat origin/main..HEAD -- tests/phase-3/assertions/  # expect empty
+
+# Atomic-PR LOC:
+git diff --shortstat origin/main..HEAD
+```
+</verification>
+
+<success_criteria>
+- arlowe-staging user provisioned on arlowe-1 without disrupting focal55 daily-driver
+- SC4 sandbox write-deny: positive test passes, all 3 negative tests confirm enforcement
+- Research §12 open questions #3, #4, #5 resolved: dialout/video/gpiochip decisions recorded
+- axcl_host deb conflict status recorded (yes / no / not yet tested)
+- Tear-down restores arlowe-1 to clean state
+- docs/operations/phase-3-staging.md captures observed-run results (Phase 1 plan 13 pattern); WhisPlay-contention prereq documented in both the README and the ops doc
+- Plan 03-01's assertion scripts UNMODIFIED by plan 05 (env-var contract honored)
+- `.sanitize-allowlist` updated with the two new entries; sanitize gate green
+- PR ≤330 net LOC; hard cap 400 — if exceeded, split into 03-05a + 03-05b
+- Phase 3 closes: pass if all assertions green; passed-with-notes if speculative-decisions identify Phase 4 cleanups
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/03-service-user-and-filesystem-layout/03-05-SUMMARY.md`. This is the **closure document for Phase 3 itself**. Frontmatter `provides:` must include:
+
+- "Phase 3 SC4 closure: real-hardware sandbox write-deny verified on arlowe-1 against arlowe-staging" with observed-run reference
+- "Resolution of speculative groups (dialout/video) and gpiochip enumeration — fold into Phase 4 cleanup if needed"
+- "Axera udev rule conflict status with axcl_host deb (yes/no/deb-absent)"
+- "arlowe-1 staging harness: install/uninstall scripts + 06+07 assertion scripts; reusable for re-verification after Phase 4-6 changes that touch user/layout/units"
+- "Env-var contract on plan 01's assertions verified in production-like setting (plan 05's runner exports ARLOWE_USER and the assertions retarget without edits)"
+
+Frontmatter `affects:` should list:
+- "Phase 4 (config overlay): pickup follow-up cleanups for speculative groups + face port-8080 + voice sudo tee"
+- "Phase 6 (image build): consumes plans 01-04 install scripts as a pi-gen stage; consumes plans 03-staging.md decisions on group narrowing"
+- "Phase 12 (first-flash integration): inherits the SC1-4 assertion suite for the real-hardware closure gate"
+
+Phase 3 closes after this plan ships AND Joe confirms the observed-run results align with the plan goals. Likely closure mode: "pass" or "passed-with-notes" mirroring Phase 1.
+</output>
+</output>

--- a/.planning/phases/03-service-user-and-filesystem-layout/03-RESEARCH.md
+++ b/.planning/phases/03-service-user-and-filesystem-layout/03-RESEARCH.md
@@ -1,0 +1,1008 @@
+# Phase 3: Service user and filesystem layout — Research
+
+**Researched:** 2026-05-26
+**Domain:** Debian/Pi OS system user provisioning + systemd hardening + read-only `/opt` runtime
+**Confidence:** HIGH on layout, user, units. MEDIUM on Next.js cache placement. MEDIUM on testbed choice (one option requires later real-Pi validation regardless).
+
+---
+
+## 1. TL;DR / Recommendations
+
+**Phase 3 is artifact-producing, not image-producing.** Phase 6 owns pi-gen and the actual `.img`. Phase 3 produces (a) a provisioning script (`scripts/provision/install-arlowe-user.sh`), (b) a layout-creation script (`scripts/provision/install-arlowe-fs.sh`), (c) a `units/` tree under the repo with the seven system-level service units, (d) a `units/install-units.sh` install helper, and (e) a docs/layout reference. These hand off cleanly to a single pi-gen stage in Phase 6 and to a deploy-to-Pi script today.
+
+**Strong recommendations, in priority order:**
+
+1. **Testbed: Docker container running `debian:bookworm-slim` with systemd-as-PID-1 (privileged), plus a "Phase-3-staging-on-arlowe-1" manual sub-target.** Reject systemd-nspawn (Pi 5's host kernel works, but the workforce already runs Docker on the Mac and Arlowe-1, and the goal is unit-syntax + filesystem-layout validation, not hardware-loop validation). Reject QEMU Pi-5 emulation (no usable QEMU machine model for Pi 5; Pi 4 model exists but boot delays + Wi-Fi/audio device mismatches make it net-cost over Docker). Reject "defer all to Phase 6" (we want to ship Phase 3 with a green test on a real systemd before Phase 6 schedules months of work). The Docker testbed validates SC1, SC2, SC3 (unit-syntax and `systemd-analyze security` scoring) and a synthetic SC4. The arlowe-1 staging sub-target validates SC1–SC4 against the real Pi hardware (SPI/GPIO/ALSA) under a side-by-side `arlowe-staging` user that does **not** disrupt the existing `focal55` daily-driver setup.
+
+2. **Create `arlowe` as a true system user via `useradd --system --user-group --create-home --home-dir /var/lib/arlowe --shell /usr/sbin/nologin arlowe`.** Supplementary groups: `audio`, `gpio`, `spi`, `dialout`, `video`. Do **not** use `DynamicUser=` — persistent state under `/var/lib/arlowe` and a stable UID for log/file ownership across reboots are non-negotiable.
+
+3. **Python venvs live at `/opt/arlowe/venvs/{voice,stt,tts,llm}/`, baked at image-build, root-owned, read-only.** App-only OTA (Phase 9) updates them by running as root with a narrow `ReadWritePaths=/opt/arlowe`. Reject mutable `/var/lib/arlowe/venvs/` (first-boot population is a 5–10 minute boot stall on Pi 5, and a network-dependent first boot is a UX disaster for pairing).
+
+4. **Dashboard: `next build` with `output: 'standalone'` baked into `/opt/arlowe/runtime/dashboard/.next/standalone/`.** Run via `node server.js`. Set `NEXT_PRIVATE_CACHE_DIR=/var/lib/arlowe/dashboard/cache` to relocate the runtime cache off the read-only mount. No `pnpm`/`npm` on the device.
+
+5. **Seven shipping units: `arlowe-face.service`, `arlowe-voice.service`, `arlowe-dashboard.service`, `qwen-tokenizer.service`, `qwen-api.service`, `whisper-stt.service`, `arlowe-wake-word.service` (split-out, see §7).** Phase 3 does **not** ship `qwen-openai.service` (ADR-0001 resolved; deprecated) and does **not** ship `arlowe-scheduled-summary` (ADR-0002). The pairing-daemon and OTA-agent units belong to Phase 8 and Phase 9 respectively, but Phase 3 documents the unit-name reservations.
+
+6. **Hardening baseline applied to every shipping unit, with per-unit `ReadWritePaths=` deltas.** Use systemd's `StateDirectory=arlowe/...` and `LogsDirectory=arlowe/...` directives **on top of** the `arlowe` user — systemd will create per-service writable subdirs under `/var/lib/arlowe/` and `/var/log/arlowe/` automatically. `ProtectSystem=strict`, `ProtectHome=yes`, `NoNewPrivileges=yes`, `PrivateTmp=yes`, plus per-unit `PrivateDevices=no` (face needs SPI; voice needs ALSA) with `DeviceAllow=` carving the device access tight. Target `systemd-analyze security` score ≤ 4.0 for the face/voice units (which need hardware) and ≤ 3.0 for everything else.
+
+7. **CLI helpers install via root-owned symlinks at `/usr/local/sbin/arlowe-{face,speak,stt,record,boot-check,purge-logs,run-logrotate,wake-train}` pointing into `/opt/arlowe/runtime/cli/`.** Owner shells into the device via the Phase-10 support-mode mechanism (which is a *founder* SSH key, not `arlowe`), and invokes CLI via `sudo -u arlowe -- /usr/local/sbin/arlowe-boot-check` etc. The `arlowe` user stays `nologin`; this is correct and not a problem.
+
+8. **Phase 3 reserves `/etc/arlowe/config.yml` and creates an empty `/etc/arlowe/` directory with mode 0755 owned by `root:arlowe`. The dashboard writes to it via a privileged-helper pattern (Phase 4 owns).** Do **not** put `/etc/arlowe/config.yml` in any unit's `ReadWritePaths=` — that's a Phase 4 problem and a polkit/sudoers rule is the right answer, not "loosen the sandbox."
+
+**Primary recommendation in one line:** Ship Phase 3 as a single PR introducing `scripts/provision/`, `units/`, and a Docker-based test harness; validate side-by-side on `arlowe-staging` user on arlowe-1 before claiming Phase 3 done; Phase 6 then consumes these artifacts unchanged.
+
+---
+
+## 2. Provisioning testbed decision
+
+### Decision: Docker (debian:bookworm-slim + systemd-as-PID-1) primary; arlowe-1 staging-user secondary.
+
+**Rationale:**
+
+| Option | Cost | Fidelity | Verdict |
+|---|---|---|---|
+| (a) Docker + systemd PID 1 | ~5 min container start; runs on Mac + arlowe-1 | Full systemd. Real `useradd`, real `systemctl`, real `systemd-analyze security`. **No SPI/GPIO/ALSA** — those are kernel devices the container can't fake without `--device` passthrough that would tie the test to a real Pi. | **Primary.** Validates everything except hardware-bound device-access. |
+| (b) QEMU aarch64 + Pi OS | 20-40% native perf; image setup tax; no Pi-5-specific QEMU machine | Better than Docker for kernel-y things, but we don't need kernel realism for Phase 3 (no kernel-module work, no boot-loader work). Adds tooling burden for marginal gain. | Rejected. |
+| (c) Clean dev Pi (not arlowe-1) | Hardware cost (need a second Pi); or repurpose arlowe-1 (disrupts dev) | Highest fidelity. But this is Phase 6's job. | Defer to Phase 6. |
+| (d) arlowe-1 with a side-by-side `arlowe-staging` user | Zero hardware cost; pollutes arlowe-1 user table mildly | Tests the **real** SPI/GPIO/ALSA permissions story against the actual hardware. The `focal55` daily-driver setup is untouched because `arlowe-staging` units are loaded by name and only when explicitly enabled. | **Secondary, gated on Joe running the script.** |
+| (e) Defer all to Phase 6 | Zero now, all-or-nothing later | Highest risk: Phase 6 is large and lots of things could break; you want Phase 3 already-green so Phase 6 can focus on image plumbing. | Rejected. |
+
+**The arlowe-1 sub-target is opt-in.** The Phase 3 verification script can run "fully" in Docker (passes everything except hardware-loop SC4) and "extended" on arlowe-1 (passes SC4 against real SPI/GPIO/ALSA). Phase 12 owns the factory-fresh first-flash gate; Phase 3 doesn't need to claim that ground.
+
+**Fallback if Docker-systemd is locally a pain:** systemd-nspawn from a Debian bookworm rootfs tarball. It runs as PID 1 cleanly without Docker's `--privileged` weirdness. But the workforce already uses Docker; pick Docker for the cognitive-load reasons unless it actually fails.
+
+**What the testbed validates:**
+
+| SC | Docker test | arlowe-1 staging test |
+|---|---|---|
+| SC1: `id arlowe` correct, no founder | YES — fresh container has no `focal55`, `id arlowe-staging` returns expected uid/home/shell | YES (against `arlowe-staging`, not `arlowe`, to avoid disturbing the live focal55-running `arlowe-*.service` units) |
+| SC2: `/opt/arlowe/` + `/var/lib/arlowe/` ownership and modes | YES — install script runs end-to-end, `ls -la` assertions pass | YES |
+| SC3: every unit system-level, runs as arlowe, applies sandbox directives | YES — `systemd-analyze security` per unit, unit-file lint, dry-run start (units may fail at runtime due to missing devices, but the syntax + sandbox-directives check independently of that) | YES — units actually start, services bind their ports, hardware reachable |
+| SC4: cannot write outside `/var/lib/arlowe/` | YES, synthetic — `systemd-run --uid=arlowe ... touch /opt/arlowe/runtime/test.txt` returns EROFS or EACCES | YES, real-hardware-backed |
+
+---
+
+## 3. User / group provisioning recipe
+
+### Idempotent install script (`scripts/provision/install-arlowe-user.sh`)
+
+```bash
+#!/bin/bash
+# Provisions the `arlowe` system user on Debian/Pi OS.
+# Idempotent: safe to re-run; exits 0 if user already exists with correct shape.
+# Runs as root (or via sudo) — invoked by pi-gen stage in Phase 6 and by the
+# Phase 3 Docker testbed.
+set -euo pipefail
+
+ARLOWE_HOME=/var/lib/arlowe
+ARLOWE_SHELL=/usr/sbin/nologin
+
+# Create the system user and matching group atomically.
+if ! id -u arlowe >/dev/null 2>&1; then
+    useradd \
+        --system \
+        --user-group \
+        --create-home \
+        --home-dir "$ARLOWE_HOME" \
+        --shell "$ARLOWE_SHELL" \
+        --comment "Arlowe runtime service account" \
+        arlowe
+fi
+
+# Idempotent supplementary group assignment. Each group is required by at
+# least one shipping service. (See `Group justification` below.)
+for grp in audio gpio spi dialout video; do
+    if getent group "$grp" >/dev/null 2>&1; then
+        usermod -aG "$grp" arlowe
+    fi
+done
+
+# Enforce HOME perms — useradd --create-home creates 0755 by default on Debian;
+# we want 0750 (group readable, world denied) so /var/lib/arlowe contents
+# default to "arlowe-only" with explicit group exposure where needed.
+chmod 0750 "$ARLOWE_HOME"
+chown arlowe:arlowe "$ARLOWE_HOME"
+```
+
+### Group justification
+
+| Group | Required by | Why |
+|---|---|---|
+| `audio` | `arlowe-voice.service`, `arlowe-wake-word.service` | ALSA `/dev/snd/*` access for pyaudio capture + playback. The pi-gen `audio` group is the standard Debian audio group. |
+| `gpio` | `arlowe-face.service` | Pi udev rules in `/etc/udev/rules.d/99-com.rules` chown `/dev/gpiomem` and `/dev/gpiochip*` to group `gpio` 0660. WhisPlay driver uses GPIO for SPI chip-select and backlight. |
+| `spi` | `arlowe-face.service` | Pi udev rules chown `/dev/spidev*` to group `spi` 0660. WhisPlay LCD is an SPI device. |
+| `dialout` | Possibly `arlowe-voice.service` (TTS playback via WhisPlay's onboard speaker over UART/I2C codec; verify on hardware) | Some Pi audio HAT codecs are managed via UART/I2C control planes that land in `dialout`. Cheap to grant; expensive to discover missing during pairing. |
+| `video` | `arlowe-face.service` | `/dev/fb0` framebuffer access on Pi OS Lite (the WhisPlay driver may use the framebuffer in some modes — confirm during Phase 3 implementation; remove if not needed). |
+
+**`netdev` is intentionally omitted** — NetworkManager is the canonical interface, and the dashboard mediates Wi-Fi configuration via `nmcli`. If the dashboard ever needs to invoke `nmcli` from inside `arlowe`'s context, polkit (`org.freedesktop.NetworkManager.network-control`) is the right path, not group membership.
+
+**Do not use `DynamicUser=yes`.** USER-03 demands persistent state ownership across reboots: conversation cache, identity files, logs all need a stable UID. `DynamicUser=` would relocate paths under `/var/lib/private/` and break Phase 4 (config overlay), Phase 7 (PKI persistence), and Phase 11 (log retention).
+
+**UID range:** Debian's `useradd --system` allocates from `SYS_UID_MIN..SYS_UID_MAX` (typically 100–999). Don't pin a specific UID; let the system choose. File ownership is by name; nothing in the repo references a UID.
+
+### Verification assertions
+
+```bash
+# SC1 assertions
+id arlowe                                        # expect uid in 100..999
+getent passwd arlowe | cut -d: -f6              # expect /var/lib/arlowe
+getent passwd arlowe | cut -d: -f7              # expect /usr/sbin/nologin
+getent passwd focal55 || true                    # expect "no such user"
+id -nG arlowe | tr ' ' '\n' | sort -u           # expect: arlowe audio dialout gpio spi video
+```
+
+---
+
+## 4. Filesystem layout reference
+
+### Tree
+
+```
+/opt/arlowe/                                 root:arlowe  0750  Read-only at runtime; OTA-mutable at update.
+├── runtime/                                 root:arlowe  0755
+│   ├── voice/                               root:arlowe  0755
+│   ├── face/                                root:arlowe  0755
+│   ├── stt/                                 root:arlowe  0755
+│   ├── tts/
+│   │   └── bin/piper                        root:arlowe  0755  TTS binary
+│   ├── llm/
+│   │   ├── router.py
+│   │   ├── run_api.sh                       root:arlowe  0755
+│   │   ├── qwen2.5_tokenizer_uid.py
+│   │   └── bin/
+│   │       └── main_api_axcl_aarch64        root:arlowe  0755  ax-llm binary
+│   ├── dashboard/
+│   │   └── .next/standalone/                root:arlowe  0755  Next.js standalone bundle
+│   ├── wake-word/                           root:arlowe  0755
+│   └── cli/                                 root:arlowe  0755
+├── third_party/
+│   ├── ax-llm/                              root:arlowe  0755  Submodule baked at build
+│   ├── whisplay-driver/                     root:arlowe  0755  Vendored at Phase 6
+│   └── axcl/                                root:arlowe  0755  axcl_host_aarch64 deb expanded
+├── models/                                  root:arlowe  0755  Populated by Phase 6
+│   ├── qwen2.5-7b-int4-ax650/
+│   ├── piper-voices/
+│   └── wake-word/heyarlowe-generic.onnx
+├── venvs/                                   root:arlowe  0755  Read-only Python venvs
+│   ├── voice/                               root:arlowe  0755  voice + wake-word + face deps
+│   ├── stt/                                 root:arlowe  0755  faster-whisper
+│   ├── tts/                                 root:arlowe  0755  piper helpers (if any)
+│   └── llm/                                 root:arlowe  0755  tokenizer service deps
+└── config/
+    └── defaults.yml                         root:arlowe  0644  Phase 4 owns content
+
+/etc/arlowe/                                 root:arlowe  0755  Reserved by Phase 3; Phase 4 owns content
+└── (config.yml absent in factory image — its absence is the "not yet paired" signal per CONFIG-03)
+
+/var/lib/arlowe/                             arlowe:arlowe  0750  Owner state; mount point of owner-state partition (Phase 6)
+├── logs/                                    arlowe:arlowe  0750  Per-service appenders; LogsDirectory creates subdirs
+│   ├── voice/voice_YYYY-MM-DD.log
+│   ├── face/face.log
+│   ├── stt/stt.log
+│   ├── llm/router-usage.log
+│   ├── dashboard/dashboard.log
+│   ├── ota.log                              (Phase 9 populates)
+│   └── support.log                          (Phase 10 populates)
+├── conversations/                           arlowe:arlowe  0700  Conversation cache; sensitive
+├── identity/                                arlowe:arlowe  0700  PKI cert/key (Phase 7); empty in Phase 3 image
+├── state/                                   arlowe:arlowe  0750  Service state (usage-stats.json, whisplay-config.json)
+├── wake-word/                               arlowe:arlowe  0750  Owner training samples + verifier.pkl (Phase 8 personalization)
+├── dashboard/
+│   └── cache/                               arlowe:arlowe  0750  NEXT_PRIVATE_CACHE_DIR target
+└── logrotate.status                         arlowe:arlowe  0640  logrotate state
+```
+
+### Path × owner × mode × purpose table
+
+| Path | Owner | Mode | Writable by arlowe? | Purpose | Phase that populates |
+|---|---|---|---|---|---|
+| `/opt/arlowe/` | root:arlowe | 0750 | NO | Code root | Phase 6 image build; Phase 9 OTA |
+| `/opt/arlowe/runtime/` | root:arlowe | 0755 | NO | Component runtimes | Phase 6 / OTA |
+| `/opt/arlowe/third_party/` | root:arlowe | 0755 | NO | Vendored deps | Phase 6 |
+| `/opt/arlowe/models/` | root:arlowe | 0755 | NO | LLM, TTS, wake-word models | Phase 6 |
+| `/opt/arlowe/venvs/` | root:arlowe | 0755 | NO | Python venvs | Phase 6 |
+| `/opt/arlowe/config/defaults.yml` | root:arlowe | 0644 | NO | Default config | Phase 4 |
+| `/etc/arlowe/` | root:arlowe | 0755 | NO | Config overlay dir | Phase 3 (empty) |
+| `/etc/arlowe/config.yml` | root:arlowe | 0640 | NO (privileged helper writes via Phase 4) | Owner overlay | Phase 8 pairing creates; Phase 4 schema-validates |
+| `/var/lib/arlowe/` | arlowe:arlowe | 0750 | YES (root) | Owner state mount point | Phase 6 ext4 partition |
+| `/var/lib/arlowe/logs/` | arlowe:arlowe | 0750 | YES | Per-service logs | Phase 3 reserve; Phase 11 retention defaults |
+| `/var/lib/arlowe/logs/<service>/` | arlowe:arlowe | 0750 | YES | systemd `LogsDirectory=arlowe/<service>` auto-creates | runtime |
+| `/var/lib/arlowe/conversations/` | arlowe:arlowe | 0700 | YES | Conversation cache | runtime; Phase 10 support tooling reads via mediator |
+| `/var/lib/arlowe/identity/` | arlowe:arlowe | 0700 | YES (writes one-shot at pairing) | Device cert + key | Phase 7 |
+| `/var/lib/arlowe/state/` | arlowe:arlowe | 0750 | YES | Service state files | runtime |
+| `/var/lib/arlowe/wake-word/` | arlowe:arlowe | 0750 | YES | Owner training data (NEVER committed) | Phase 8 |
+| `/var/lib/arlowe/dashboard/cache/` | arlowe:arlowe | 0750 | YES | Next.js runtime cache | runtime |
+
+**`/var/lib/arlowe/` is a separate ext4 partition** in Phase 6 (PART-04). Phase 3's install script must create the directory structure inside the partition mount-point, not assume the partition exists — when Phase 3 is tested in Docker, `/var/lib/arlowe` is just a directory; when Phase 6 provisions it, it's a mount-point. The install script's behavior is identical either way.
+
+**Why `0750` on `/var/lib/arlowe` and not `0755`:** keeps random unprivileged users (none ship in v1, but defense-in-depth) from reading conversation cache or log paths. Support-mode (Phase 10) is the *founder* SSH key, which has its own scoping via `ForceCommand`; it doesn't traverse `/var/lib/arlowe` directly.
+
+**Why `0750` on `/opt/arlowe`:** USER-02 says "readable by the arlowe group." 0755 would make code world-readable; 0750 makes it `arlowe`-group-readable and root-traversable, which is exactly USER-02.
+
+---
+
+## 5. Python venv strategy
+
+### Decision: pattern (a) — venvs baked into `/opt/arlowe/venvs/`, root-owned, read-only at runtime.
+
+**One venv per Python service.** Voice + face + wake-word can share `venvs/voice/` because their deps overlap heavily (numpy, scipy, requests, onnxruntime). STT gets its own (`faster-whisper` is heavy). TTS likely doesn't need one — `piper` is a native binary — but reserve `venvs/tts/` for any future Python helpers. LLM tokenizer needs one (`transformers`, `huggingface_hub` are large).
+
+**Why baked, not first-boot-populated:**
+
+- First-boot population would require ~5–10 minutes of `pip install` on Pi 5 (numpy + onnxruntime + scikit-learn are slow).
+- First boot is the pairing experience; making it network-dependent on `pip install` from PyPI is a UX cliff and a security risk.
+- Image reproducibility (IMAGE-03) requires the venv to be deterministic; baked at build time with pinned `requirements.txt` is the only way.
+- Disk cost: ~500 MB combined across all venvs — well within the 16 GB SD budget (PART-05).
+
+**OTA implications (Phase 9):**
+
+App-only OTA updates `runtime/` and may need to update `venvs/` if deps change. The OTA agent's options:
+
+1. **OTA agent runs as `root`** (separate from `arlowe`) with a tight sandbox: `ProtectSystem=strict`, `ReadWritePaths=/opt/arlowe`, `RestrictAddressFamilies=AF_INET AF_INET6`. This is the right answer.
+2. ~~OTA runs as `arlowe` with polkit/sudoers granting write to `/opt/arlowe`~~. Polkit can do this but it's more complex and harder to audit. Reject.
+
+Phase 9 reads "OTA agent runs as a systemd service under the `arlowe` user" (OTA-01) — **this requirement may need to be revisited**. Flag as an open question for the planner: do we run OTA as root with a narrow sandbox, or amend OTA-01? Strong recommendation: **amend OTA-01 to `OTA agent runs as a system-level systemd service with strictly sandboxed root, writes to /opt/arlowe only, with rsync-then-atomic-swap`.** The OTA agent is the *one* place where root + write-/opt is justified.
+
+### Install pattern in pi-gen stage (Phase 6 reference)
+
+```bash
+# Phase 6 will do roughly:
+install -d -o root -g arlowe -m 0755 /opt/arlowe/venvs
+for svc in voice stt tts llm; do
+    python3 -m venv /opt/arlowe/venvs/$svc
+    /opt/arlowe/venvs/$svc/bin/pip install --no-cache-dir -r /opt/arlowe/runtime/$svc/requirements.txt
+    chown -R root:arlowe /opt/arlowe/venvs/$svc
+    chmod -R u=rwX,g=rX,o= /opt/arlowe/venvs/$svc
+done
+```
+
+Phase 3's responsibility is to write `docs/operations/venv-build.md` documenting this; Phase 6 executes it.
+
+---
+
+## 6. Dashboard (Next.js) strategy
+
+### Decision: `next build` with `output: 'standalone'`; relocate cache via `NEXT_PRIVATE_CACHE_DIR`.
+
+**Required changes:**
+
+1. `runtime/dashboard/next.config.ts`:
+
+```typescript
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  output: 'standalone',
+  // Disable telemetry; we are an offline-first appliance.
+  // (Setting via env: NEXT_TELEMETRY_DISABLED=1 in the unit file.)
+};
+
+export default nextConfig;
+```
+
+2. Build at image-build time (Phase 6):
+
+```bash
+cd /tmp/build/dashboard
+pnpm install --frozen-lockfile
+pnpm build
+# .next/standalone/ contains server.js + minimal node_modules
+# .next/static/ + public/ must be copied separately
+mkdir -p /opt/arlowe/runtime/dashboard
+cp -r .next/standalone/* /opt/arlowe/runtime/dashboard/
+cp -r .next/static /opt/arlowe/runtime/dashboard/.next/static
+cp -r public /opt/arlowe/runtime/dashboard/public
+chown -R root:arlowe /opt/arlowe/runtime/dashboard
+```
+
+3. systemd unit launches `node /opt/arlowe/runtime/dashboard/server.js`. No `pnpm`, no `npm`, no `next start`. `node` is installed system-wide via apt during Phase 6 (apt installs `nodejs` — Pi OS Bookworm has Node 20).
+
+4. Runtime cache redirect via env:
+
+```
+Environment=NEXT_PRIVATE_CACHE_DIR=/var/lib/arlowe/dashboard/cache
+Environment=NEXT_TELEMETRY_DISABLED=1
+Environment=NODE_ENV=production
+Environment=PORT=3000
+Environment=HOSTNAME=0.0.0.0
+```
+
+**Note on `NEXT_PRIVATE_CACHE_DIR`:** This env var is documented in Next.js community discussions and is the standard read-only-rootfs workaround. It is marked "private" (unstable) in Next.js naming convention but is the only documented mechanism. If Next.js renames it in a future version, the layout still works because the cache is just non-essential.
+
+**Image-size impact:** standalone bundle for this dashboard (Next 16, React 19) is ~50 MB (Next.js standalone + minimal node_modules). Well within budget.
+
+**Alternative considered and rejected:** running `pnpm start` from `/opt/arlowe`. Requires `pnpm` on the device, the full `node_modules/` tree (~200 MB+), and a writable `.next/cache`. Standalone wins on every axis.
+
+---
+
+## 7. systemd unit conversion matrix
+
+### Hardening baseline (applied to every shipping unit)
+
+```ini
+[Service]
+User=arlowe
+Group=arlowe
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=strict
+ProtectHome=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+ProtectKernelLogs=yes
+ProtectClock=yes
+ProtectHostname=yes
+RestrictSUIDSGID=yes
+RestrictRealtime=yes
+LockPersonality=yes
+RestrictNamespaces=yes
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged @resources
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+# Per-unit additions: ReadWritePaths, SupplementaryGroups, DeviceAllow, etc.
+# Per-unit StateDirectory / LogsDirectory creates and chowns subdirs of
+# /var/lib/arlowe and /var/log/arlowe automatically (NB: LogsDirectory creates
+# under /var/log/private/<name> with strict perms when DynamicUser=yes, but
+# under /var/log/<name> with normal perms when we use User=arlowe — verify
+# this in the Docker testbed before committing the unit files).
+```
+
+**Note on `LogsDirectory` interaction with the partition layout:** systemd's `LogsDirectory=arlowe/voice` creates `/var/log/arlowe/voice` — NOT `/var/lib/arlowe/logs/voice`. The runtime expects logs under `/var/lib/arlowe/logs/` (per Phase 1 contracts: `ARLOWE_LOGS_DIR=/var/lib/arlowe/logs`). Two viable resolutions:
+
+1. **Don't use `LogsDirectory=`.** Instead use `ReadWritePaths=/var/lib/arlowe/logs` and let the apps create their own subdirs. Loses some systemd automation but keeps the layout simple.
+2. Use `LogsDirectory=arlowe/voice` and symlink `/var/lib/arlowe/logs/voice -> /var/log/arlowe/voice`. Adds a symlink and a layer of indirection.
+
+**Recommendation: option 1** — explicit `ReadWritePaths=/var/lib/arlowe/logs/<service>` for each unit, with the per-service log directory created by the install script at provision time. Simpler and matches what Phase 1's runtime already expects.
+
+### Unit 1: `arlowe-face.service`
+
+```ini
+[Unit]
+Description=Arlowe face display service
+Documentation=man:arlowe-face(8)
+After=network.target sound.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=arlowe
+Group=arlowe
+SupplementaryGroups=gpio spi video
+WorkingDirectory=/opt/arlowe/runtime
+Environment=PYTHONUNBUFFERED=1
+Environment=PYTHONPATH=/opt/arlowe/runtime
+Environment=ARLOWE_WHISPLAY_DRIVER_PATH=/opt/arlowe/third_party/whisplay-driver
+Environment=ARLOWE_STATE_DIR=/var/lib/arlowe/state
+Environment=ARLOWE_LOGS_DIR=/var/lib/arlowe/logs
+ExecStart=/opt/arlowe/venvs/voice/bin/python -m face.face_service
+Restart=on-failure
+RestartSec=5
+
+# Hardening baseline
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=strict
+ProtectHome=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+ProtectKernelLogs=yes
+ProtectClock=yes
+ProtectHostname=yes
+RestrictSUIDSGID=yes
+RestrictRealtime=yes
+LockPersonality=yes
+RestrictNamespaces=yes
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged @resources
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+
+# Per-unit: SPI + GPIO + framebuffer access; writable state + logs
+PrivateDevices=no
+DeviceAllow=/dev/spidev0.0 rw
+DeviceAllow=/dev/spidev0.1 rw
+DeviceAllow=/dev/gpiomem rw
+DeviceAllow=/dev/gpiochip0 rw
+DeviceAllow=/dev/gpiochip4 rw
+DeviceAllow=/dev/fb0 rw
+ReadWritePaths=/var/lib/arlowe/state /var/lib/arlowe/logs/face
+
+# Network: binds tcp/8080 (FIXME(F1): hardcoded; flag for Phase 4 config-driven)
+# AmbientCapabilities not needed: 8080 > 1024
+
+[Install]
+WantedBy=multi-user.target
+```
+
+**Notes on `arlowe-face.service`:**
+- TCP 8080 is hardcoded in `face_service.py` (todo F1). Phase 3 does NOT fix this; Phase 4 (config overlay) or Phase 5 owns. Flag in pitfall list.
+- Pi 5 has `/dev/gpiochip0` (main bank) and `/dev/gpiochip4` (RP1 chip). Both need to be allowed for the WhisPlay driver, which uses GPIO for SPI chip-select and backlight PWM.
+- `DeviceAllow` requires `PrivateDevices=no`. If `PrivateDevices=yes`, all `DeviceAllow=` entries are ignored.
+
+### Unit 2: `arlowe-voice.service`
+
+```ini
+[Unit]
+Description=Arlowe voice orchestrator (wake -> STT -> LLM -> TTS -> face)
+After=arlowe-face.service whisper-stt.service qwen-api.service network.target sound.target
+Wants=arlowe-face.service whisper-stt.service qwen-api.service
+Requires=arlowe-face.service
+
+[Service]
+Type=simple
+User=arlowe
+Group=arlowe
+SupplementaryGroups=audio dialout
+WorkingDirectory=/opt/arlowe/runtime
+Environment=PYTHONUNBUFFERED=1
+Environment=PYTHONPATH=/opt/arlowe/runtime
+Environment=ARLOWE_PIPER_PATH=/opt/arlowe/runtime/tts/bin/piper
+Environment=ARLOWE_PIPER_MODEL=/opt/arlowe/models/piper-voices/en_US-lessac-medium.onnx
+Environment=ARLOWE_VERIFIER_MODEL=/var/lib/arlowe/wake-word/verifier.pkl
+Environment=ARLOWE_FACE_URL=http://localhost:8080
+Environment=ARLOWE_STT_URL=http://localhost:8082/transcribe
+Environment=ARLOWE_LOGS_DIR=/var/lib/arlowe/logs
+Environment=ARLOWE_STATE_DIR=/var/lib/arlowe/state
+ExecStart=/opt/arlowe/venvs/voice/bin/python -m voice.voice_client
+Restart=on-failure
+RestartSec=10
+
+# Hardening baseline (same as face) plus:
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=strict
+ProtectHome=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+ProtectKernelLogs=yes
+LockPersonality=yes
+RestrictNamespaces=yes
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged
+# voice needs realtime for audio (~lower)
+RestrictRealtime=no
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX AF_NETLINK
+
+# Audio device access
+PrivateDevices=no
+DeviceAllow=/dev/snd/* rw
+DeviceAllow=/dev/snd/seq rw
+DeviceAllow=/dev/snd/timer r
+
+# Writable paths
+ReadWritePaths=/var/lib/arlowe/state /var/lib/arlowe/logs /var/lib/arlowe/conversations
+
+[Install]
+WantedBy=multi-user.target
+```
+
+**Notes on `arlowe-voice.service`:**
+- `RestrictRealtime=no` because pyaudio uses `SCHED_FIFO`-adjacent paths for low-latency capture. If this turns out unneeded, tighten in a follow-up.
+- `AF_NETLINK` included for ALSA's device-enumeration via the kernel. Test in the testbed — if the service starts and audio works without it, drop.
+- `RestrictSUIDSGID` intentionally omitted because the voice code currently shells out to `sudo tee` for fan control (noted in `runtime/voice/README.md` as a phase-4 cleanup). Phase 3 should NOT yet remove the sudo path — that's a Phase 4 task. Phase 3 should flag it.
+- After= ordering pulls up face + stt + qwen-api in the proven order. Wants= is soft, Requires=face is harder (voice with no face is useless).
+
+### Unit 3: `arlowe-dashboard.service`
+
+```ini
+[Unit]
+Description=Arlowe local dashboard (Next.js standalone)
+After=network.target
+
+[Service]
+Type=simple
+User=arlowe
+Group=arlowe
+WorkingDirectory=/opt/arlowe/runtime/dashboard
+Environment=NODE_ENV=production
+Environment=PORT=3000
+Environment=HOSTNAME=0.0.0.0
+Environment=NEXT_TELEMETRY_DISABLED=1
+Environment=NEXT_PRIVATE_CACHE_DIR=/var/lib/arlowe/dashboard/cache
+Environment=ARLOWE_CONFIG_PATH=/etc/arlowe/config.yml
+Environment=ARLOWE_LOGS_DIR=/var/lib/arlowe/logs
+Environment=ARLOWE_SYSTEMCTL_MODE=system
+ExecStart=/usr/bin/node /opt/arlowe/runtime/dashboard/server.js
+Restart=on-failure
+RestartSec=5
+
+# Hardening baseline
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=strict
+ProtectHome=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+ProtectKernelLogs=yes
+ProtectClock=yes
+ProtectHostname=yes
+LockPersonality=yes
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+PrivateDevices=yes
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged @resources
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+
+# Dashboard writes cache, logs. NOT /etc/arlowe/config.yml directly — Phase 4
+# wires a privileged-helper write path via polkit or a setuid helper.
+ReadWritePaths=/var/lib/arlowe/dashboard /var/lib/arlowe/logs/dashboard
+
+[Install]
+WantedBy=multi-user.target
+```
+
+**Notes on `arlowe-dashboard.service`:**
+- `PrivateDevices=yes` is safe — dashboard touches no hardware.
+- `/etc/arlowe/config.yml` is intentionally NOT in `ReadWritePaths`. The dashboard's `POST /api/config` will fail until Phase 4 implements the privileged-helper write path. Phase 3 leaves a clear FIXME in the unit comments.
+- `ARLOWE_SYSTEMCTL_MODE=system` flips the dashboard from `--user` to system-level systemctl queries. Phase 1 dashboard already supports both via env.
+
+### Unit 4: `qwen-tokenizer.service`
+
+```ini
+[Unit]
+Description=Qwen tokenizer HTTP service
+After=network.target
+
+[Service]
+Type=simple
+User=arlowe
+Group=arlowe
+WorkingDirectory=/opt/arlowe/runtime/llm
+Environment=PYTHONUNBUFFERED=1
+ExecStart=/opt/arlowe/venvs/llm/bin/python /opt/arlowe/runtime/llm/qwen2.5_tokenizer_uid.py
+Restart=on-failure
+RestartSec=5
+
+# Baseline hardening
+NoNewPrivileges=yes
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectSystem=strict
+ProtectHome=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+ProtectKernelLogs=yes
+LockPersonality=yes
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged @resources
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+
+ReadWritePaths=/var/lib/arlowe/logs/llm
+
+[Install]
+WantedBy=multi-user.target
+```
+
+### Unit 5: `qwen-api.service`
+
+```ini
+[Unit]
+Description=Qwen LLM API server (ax-llm native)
+After=qwen-tokenizer.service network.target
+Requires=qwen-tokenizer.service
+
+[Service]
+Type=simple
+User=arlowe
+Group=arlowe
+WorkingDirectory=/opt/arlowe/runtime/llm
+Environment=AX_LLM_BIN=/opt/arlowe/runtime/llm/bin/main_api_axcl_aarch64
+Environment=QWEN_MODEL_DIR=/opt/arlowe/models/qwen2.5-7b-int4-ax650
+ExecStart=/opt/arlowe/runtime/llm/run_api.sh
+Restart=on-failure
+RestartSec=10
+
+# Baseline hardening. ax-llm binary needs /dev/axcl_host + /dev/ax_mmb_dev
+NoNewPrivileges=yes
+PrivateTmp=yes
+PrivateDevices=no
+DeviceAllow=/dev/axcl_host rw
+DeviceAllow=/dev/ax_mmb_dev rw
+ProtectSystem=strict
+ProtectHome=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+LockPersonality=yes
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+
+ReadWritePaths=/var/lib/arlowe/logs/llm
+
+[Install]
+WantedBy=multi-user.target
+```
+
+**Notes on `qwen-api.service`:**
+- `/dev/axcl_host` and `/dev/ax_mmb_dev` are the Axera AX8850 device nodes. Confirm exact device names and perms on arlowe-1 during Phase 3 implementation — these may need a separate udev rule to chown to `arlowe` group, since Axera's `axcl_host.deb` may default to `root:root` ownership.
+- `ProtectKernelModules` deliberately omitted from this unit — ax-llm may need to load kernel modules at startup. Test and tighten.
+- `ProtectKernelLogs` and `ProtectClock` deliberately omitted from this unit too — pending hardware-loop verification.
+
+### Unit 6: `whisper-stt.service`
+
+```ini
+[Unit]
+Description=Whisper STT server (faster-whisper)
+After=network.target
+
+[Service]
+Type=simple
+User=arlowe
+Group=arlowe
+WorkingDirectory=/opt/arlowe/runtime/stt
+Environment=PYTHONUNBUFFERED=1
+ExecStart=/opt/arlowe/venvs/stt/bin/python /opt/arlowe/runtime/stt/stt_server.py
+Restart=on-failure
+RestartSec=5
+
+# Full baseline hardening
+NoNewPrivileges=yes
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectSystem=strict
+ProtectHome=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+ProtectKernelLogs=yes
+ProtectClock=yes
+ProtectHostname=yes
+LockPersonality=yes
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged @resources
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+
+ReadWritePaths=/var/lib/arlowe/logs/stt
+
+[Install]
+WantedBy=multi-user.target
+```
+
+### Unit 7: `arlowe-wake-word.service` (NEW; split out from voice)
+
+**This is an architectural decision, not a Phase 1 inheritance.** Today wake-word detection runs inside `voice_client.py`. Splitting it into its own unit is **optional for Phase 3**; the strong argument FOR splitting is that wake-word always-on listening should be the only audio-capture-holding process when voice is idle, releasing the audio device for other purposes. The strong argument AGAINST is that it adds complexity and an IPC dance with voice_client.
+
+**Recommendation for Phase 3: do NOT split.** Keep wake-word in voice_client.py for now. The split is a Phase 5 or later optimization. So the Phase 3 unit set is **six units**, not seven. Remove from the count.
+
+### Reserved unit names (Phase 3 documents; later phases author)
+
+- `arlowe-pairing.service` — Phase 8
+- `arlowe-ota.service` — Phase 9
+- `arlowe-support.service` — Phase 10
+- `arlowe-boot-check.service` (oneshot) — Phase 11
+
+### Unit-name sanitization check
+
+All seven proposed unit names pass `scripts/sanitize/check.sh --units-only`:
+
+| Unit | Prefix banned? |
+|---|---|
+| `arlowe-face.service` | No (banlist is `openclaw-*`, `trace-*`, `workforce-metrics-snapshot.*`) |
+| `arlowe-voice.service` | No |
+| `arlowe-dashboard.service` | No |
+| `qwen-tokenizer.service` | No |
+| `qwen-api.service` | No |
+| `whisper-stt.service` | No |
+
+All clear.
+
+---
+
+## 8. CLI helper install pattern
+
+### Decision: root-owned symlinks in `/usr/local/sbin/` pointing into `/opt/arlowe/runtime/cli/`, prefixed with `arlowe-`.
+
+```bash
+# Phase 3 install script does:
+for cli in face speak stt record boot-check purge-logs run-logrotate wake-train; do
+    ln -sf /opt/arlowe/runtime/cli/$cli /usr/local/sbin/arlowe-$cli
+done
+```
+
+**Why `/usr/local/sbin` not `/usr/local/bin`:** these are administrative tools, not user tools. `nologin` users can't run them anyway; they're invoked by support-mode SSH (Phase 10) or by `sudo -u arlowe`.
+
+**Why prefix with `arlowe-`:** the wake-train command currently is `wake-train`. If you symlink it into `/usr/local/sbin/wake-train`, you've polluted the PATH namespace for any other tool. `arlowe-wake-train` is clear about scope.
+
+**Invocation pattern (for documentation):**
+
+```bash
+# Support-mode SSH session as the founder:
+sudo -u arlowe -- /usr/local/sbin/arlowe-boot-check
+
+# Or via systemd-run:
+sudo systemd-run --uid=arlowe --gid=arlowe --working-directory=/opt/arlowe/runtime \
+    /usr/local/sbin/arlowe-boot-check
+```
+
+**CLI scripts that write to `/var/lib/arlowe/`:**
+
+| Script | Writes to | Implication |
+|---|---|---|
+| `purge-logs` | `/var/lib/arlowe/logs/` (deletes files) | Must run as `arlowe` (which can delete its own logs). |
+| `run-logrotate` | `/var/lib/arlowe/logrotate.status` | Must run as `arlowe`; logrotate state file is owned by arlowe. |
+| `wake-train` | `/var/lib/arlowe/wake-word/` (training data + verifier.pkl output) | Must run as `arlowe`; reads `/opt/arlowe/runtime/wake-word/` (RO) and writes `/var/lib/arlowe/wake-word/`. |
+| `boot-check` | nothing (read-only diagnostics) | Can run as anyone with `arlowe`-group read; conventionally invoked as arlowe. |
+
+**Boot-check `ARLOWE_SYSTEMCTL_FLAGS` flip (existing TODO in code):** Phase 3 flips the default from `--user` to `""` (empty) in `runtime/cli/boot-check` line 10, since after Phase 3 the services run system-level. This is a one-line code change that ships with the Phase 3 PR.
+
+---
+
+## 9. Cross-phase compatibility check
+
+| Future phase | What it needs | Phase 3 provides? | Notes |
+|---|---|---|---|
+| **Phase 4 (Config overlay)** | `/etc/arlowe/config.yml` overlay path readable by all services; defaults at `/opt/arlowe/config/defaults.yml`; atomic-write path for dashboard | YES (paths reserved, dir created); NO write path yet (Phase 4 wires polkit/setuid helper) | Phase 3 leaves a clear FIXME in `arlowe-dashboard.service` about the `/etc/arlowe/config.yml` write path. |
+| **Phase 5 (Audio auto-detect)** | `arlowe-voice.service` can read `/dev/snd/*` and enumerate devices; dashboard can read `/proc/asound/cards` | YES — voice has DeviceAllow=/dev/snd/* and SupplementaryGroups=audio | Phase 5 adds the auto-detect logic in voice_client.py. |
+| **Phase 6 (Image build)** | A pi-gen stage script that installs the user, layout, and units in one pass | YES — `scripts/provision/install-arlowe-user.sh`, `scripts/provision/install-arlowe-fs.sh`, `units/install-units.sh` are the three scripts that pi-gen runs in stage 4 (Arlowe overlay). | Phase 6 also handles the `/var/lib/arlowe` separate-partition mount, not Phase 3. |
+| **Phase 7 (PKI)** | `/var/lib/arlowe/identity/` exists, mode 0700, owned by arlowe; pairing daemon can write cert + key there | YES (dir created, perms set); Phase 7 unit adds itself to `ReadWritePaths=/var/lib/arlowe/identity` | The Phase 8 pairing daemon (which initiates the cert request) needs write access; the runtime services need read access. Both work because the dir is `arlowe:arlowe 0700` and all services run as arlowe. |
+| **Phase 8 (Pairing)** | Pairing daemon unit can write `/etc/arlowe/config.yml`; can write `/var/lib/arlowe/identity/`; can trigger restart of arlowe-voice etc. | NO write to `/etc/arlowe/`; YES write to `/var/lib/arlowe/identity/` | Phase 8 pairing daemon needs the same privileged-helper pattern as dashboard for `/etc/arlowe/config.yml`. Phase 4 owns the helper; Phase 8 consumes it. Service-restart capability needs `Type=dbus` + a polkit rule, OR pairing daemon runs as root with tight sandbox. Strong recommendation: run pairing daemon as root (one-shot at first boot) with `ReadWritePaths=/etc/arlowe /var/lib/arlowe/identity` and `Restart=no`. |
+| **Phase 9 (OTA)** | OTA agent can write `/opt/arlowe/runtime/`; can restart services | NO write path for arlowe to /opt; root+sandbox pattern (see §5) | OTA-01 says "arlowe user" — this needs amendment. See Open Questions §12. |
+| **Phase 10 (Support mode)** | sshd can write `/var/lib/arlowe/logs/support.log`; founder SSH key path | sshd runs as `root`; can write anywhere when explicitly told. Phase 3 reserves the path; Phase 10 wires sshd's `ChrootDirectory` or `ForceCommand` to log to that path. | The `arlowe` user's `~/.ssh/authorized_keys` lives at `/var/lib/arlowe/.ssh/authorized_keys`. Phase 3 should NOT create this file — its absence is a Phase 10 baseline assertion. |
+| **Phase 11 (Boot health, logs)** | Per-service log dirs writable by arlowe; boot-check works against system-level units | YES on both | boot-check's `ARLOWE_SYSTEMCTL_FLAGS=""` flip ships with Phase 3. |
+| **Phase 12 (First-flash integration)** | All of the above on real hardware | YES, as artifacts; SC4 hardware-loop validates here per Phase 1's deferral pattern | Phase 12 is the gate. |
+
+---
+
+## 10. Pitfalls and gotchas
+
+### Blocker-class
+
+| Issue | What goes wrong | How to avoid |
+|---|---|---|
+| **`PrivateDevices=yes` blocks ALL `DeviceAllow=` entries** | Face and voice services start but can't see SPI or audio devices; failure looks like "WhisPlay driver not found" or "PaError: no such audio device" | Always pair `PrivateDevices=no` with `DeviceAllow=` for hardware-touching units. Test in Docker (can't actually open device, but unit-syntax validates), confirm on arlowe-1 staging. |
+| **`ProtectSystem=strict` blocks `/etc/arlowe/config.yml` writes** | Dashboard `POST /api/config` returns EROFS; pairing daemon can't write config | Don't put `/etc/arlowe/config.yml` in `ReadWritePaths` — it's not the right pattern. Use a privileged helper (Phase 4 owns). Pairing daemon (Phase 8) runs as root one-shot. |
+| **`/var/lib/arlowe/` is a mount point in Phase 6** | The install script in Phase 3 creates the dir; Phase 6's pi-gen later mounts a partition over it, and the perms get reset to the partition's defaults | The pi-gen stage must run `install-arlowe-fs.sh` AFTER the partition is mounted and BEFORE the units start. Document the order. |
+| **`face_service.py` port 8080 hardcoded** | Phase 4 needs to change it; Phase 3 ships unit files assuming 8080; if Phase 4 changes the port, both code and unit need updates | Phase 3 explicitly leaves the port at 8080 and flags the F1 TODO. Phase 4 owns the fix and updates the unit file at that time. |
+| **`run_api.sh` may depend on PATH for `axcl-smi`** | ax-llm binary may shell out to vendor tooling that lives in `/opt/arlowe/third_party/axcl/bin/` or similar; if PATH doesn't include it, qwen-api crashes at startup | Phase 3 unit sets `Environment=PATH=/opt/arlowe/third_party/axcl/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin` explicitly. Verify against arlowe-1 install. |
+
+### Friction-class
+
+| Issue | What goes wrong | How to avoid |
+|---|---|---|
+| **`/dev/axcl_host` and `/dev/ax_mmb_dev` ownership** | Axera SDK installs may chown to root:root with 0600. `arlowe` user can't open them. | Phase 3 ships a udev rule (`/etc/udev/rules.d/90-arlowe-axcl.rules`) chowning Axera devices to `root:arlowe 0660`. Test on arlowe-1 staging. |
+| **systemd `LogsDirectory=` vs `/var/lib/arlowe/logs` mismatch** | Confusing two different log layouts (systemd's `/var/log/arlowe/` vs our chosen `/var/lib/arlowe/logs/`) | Use `ReadWritePaths=/var/lib/arlowe/logs/<service>` and let the apps create their own subdirs. Don't use `LogsDirectory=`. Document this. |
+| **Voice service `sudo tee` for fan control** | runtime/voice/voice_client.py shells out to `sudo tee /sys/class/hwmon/hwmon2/pwm1` for fan control. With `User=arlowe` + `NoNewPrivileges=yes`, `sudo` fails. | Phase 3 flag — leave the broken sudo path in place but document it as a Phase 4 cleanup (chgrp the hwmon PWM node at boot via udev, or remove fan control until Phase 4 owns it). The voice service still starts; only the fan-control codepath errors. |
+| **`SystemCallFilter=~@privileged` may block Python's `subprocess`** | router.py runs `claude -p` as a subprocess (cloud LLM path) | `~@privileged` blocks privileged syscalls, not exec/fork. Test in Docker before shipping. If it does block, drop `~@privileged` from the voice unit and rely on the broader filter. |
+| **Dashboard cache `NEXT_PRIVATE_CACHE_DIR` is unstable Next.js API** | Could break in future Next.js versions | Document; pin Next.js to 16.x in package.json (already pinned to 16.1.6); revisit on major upgrade. |
+
+### Nit-class
+
+| Issue | What goes wrong | How to avoid |
+|---|---|---|
+| **`dialout` group inclusion is speculative** | May not actually be needed by the WhisPlay driver | Test on arlowe-1; remove if not needed. |
+| **`video` group inclusion is speculative** | `/dev/fb0` may not be touched by WhisPlay driver (SPI display, not framebuffer) | Test on arlowe-1; remove if not needed. |
+| **Hardening directives' effect on `systemd-analyze security` score** | Score may vary between systemd 252 (Pi OS Bookworm) and 256 (Bookworm-backports) | Score is informational, not a CI gate. Set the threshold (≤ 4.0 for hardware units, ≤ 3.0 for others) and accept variance. |
+| **`/usr/sbin/nologin` vs `/sbin/nologin`** | Path differs on some distros; both exist on Debian Bookworm | Use `/usr/sbin/nologin` (Debian Bookworm canonical path); falls back to existence check in the install script. |
+
+---
+
+## 11. Validation strategy
+
+### Test harness layout
+
+```
+tests/phase-3/
+├── docker/
+│   ├── Dockerfile                         # debian:bookworm-slim with systemd
+│   ├── docker-compose.yml                 # privileged mode for systemd
+│   └── run-tests.sh                       # runs the assertions below
+├── assertions/
+│   ├── 01-user-shape.sh                   # SC1
+│   ├── 02-fs-layout.sh                    # SC2
+│   ├── 03-unit-syntax.sh                  # SC3 (systemd-analyze verify + security)
+│   └── 04-sandbox-write-deny.sh           # SC4
+└── README.md                              # how to run + interpret
+```
+
+### SC1: user shape
+
+```bash
+# Run as part of the Docker test after install-arlowe-user.sh executes.
+test "$(id -u arlowe)" -lt 1000                                              || fail "arlowe is not a system user (uid >= 1000)"
+test "$(getent passwd arlowe | cut -d: -f6)" = "/var/lib/arlowe"             || fail "HOME wrong"
+test "$(getent passwd arlowe | cut -d: -f7)" = "/usr/sbin/nologin"           || fail "shell wrong"
+getent passwd focal55 && fail "founder user present"                         || true
+id -nG arlowe | grep -qw audio                                               || fail "missing audio group"
+id -nG arlowe | grep -qw gpio                                                || fail "missing gpio group"
+id -nG arlowe | grep -qw spi                                                 || fail "missing spi group"
+```
+
+### SC2: filesystem layout
+
+```bash
+# /opt/arlowe perms and ownership
+stat -c '%U:%G %a' /opt/arlowe                       | grep -q '^root:arlowe 750$'        || fail
+stat -c '%U:%G %a' /opt/arlowe/runtime               | grep -q '^root:arlowe 755$'        || fail
+stat -c '%U:%G %a' /opt/arlowe/venvs                 | grep -q '^root:arlowe 755$'        || fail
+stat -c '%U:%G %a' /opt/arlowe/config/defaults.yml   | grep -q '^root:arlowe 644$'        || fail  # populated by Phase 4; in Phase 3 just check the file exists with right perms even if empty
+
+# /var/lib/arlowe perms and ownership
+stat -c '%U:%G %a' /var/lib/arlowe                   | grep -q '^arlowe:arlowe 750$'      || fail
+stat -c '%U:%G %a' /var/lib/arlowe/logs              | grep -q '^arlowe:arlowe 750$'      || fail
+stat -c '%U:%G %a' /var/lib/arlowe/identity          | grep -q '^arlowe:arlowe 700$'      || fail
+stat -c '%U:%G %a' /var/lib/arlowe/conversations     | grep -q '^arlowe:arlowe 700$'      || fail
+
+# /etc/arlowe reserved
+test -d /etc/arlowe                                                                       || fail
+stat -c '%U:%G %a' /etc/arlowe                       | grep -q '^root:arlowe 755$'        || fail
+test ! -f /etc/arlowe/config.yml                                                          || fail "config.yml should NOT exist in Phase 3 (its absence is the pairing trigger)"
+```
+
+### SC3: unit hardening
+
+```bash
+# Syntax + warnings check
+for unit in arlowe-face arlowe-voice arlowe-dashboard qwen-tokenizer qwen-api whisper-stt; do
+    systemd-analyze verify /etc/systemd/system/$unit.service  || fail "$unit verify failed"
+done
+
+# Security score check
+declare -A MAX_SCORE
+MAX_SCORE[arlowe-face]=4.0
+MAX_SCORE[arlowe-voice]=4.0
+MAX_SCORE[qwen-api]=4.5      # axcl device access loosens score
+MAX_SCORE[arlowe-dashboard]=3.0
+MAX_SCORE[qwen-tokenizer]=3.0
+MAX_SCORE[whisper-stt]=3.0
+
+for unit in "${!MAX_SCORE[@]}"; do
+    score=$(systemd-analyze security $unit.service --no-pager | grep -oP 'Overall exposure level for .+: \K[0-9.]+')
+    awk -v s="$score" -v m="${MAX_SCORE[$unit]}" 'BEGIN { exit !(s+0 <= m+0) }' || \
+        fail "$unit score $score exceeds threshold ${MAX_SCORE[$unit]}"
+done
+
+# User=arlowe on every shipping unit
+for unit in arlowe-face arlowe-voice arlowe-dashboard qwen-tokenizer qwen-api whisper-stt; do
+    grep -q '^User=arlowe$' /etc/systemd/system/$unit.service || fail "$unit not running as arlowe"
+done
+
+# No --user units anywhere (USER-04)
+test ! -d /home/arlowe/.config/systemd/user                                                          || fail
+test ! -d /var/lib/arlowe/.config/systemd/user                                                       || fail
+```
+
+### SC4: sandbox write denial
+
+```bash
+# Positive test: arlowe can write to its declared writable paths
+systemd-run --uid=arlowe --gid=arlowe --pty --wait -p ProtectSystem=strict -p ReadWritePaths=/var/lib/arlowe/logs/voice \
+    /bin/sh -c 'touch /var/lib/arlowe/logs/voice/sandbox-positive-test && rm /var/lib/arlowe/logs/voice/sandbox-positive-test'
+
+# Negative test: arlowe cannot write to /opt/arlowe under the same sandbox
+! systemd-run --uid=arlowe --gid=arlowe --pty --wait -p ProtectSystem=strict -p ReadWritePaths=/var/lib/arlowe/logs/voice \
+    /bin/sh -c 'touch /opt/arlowe/runtime/voice/sandbox-negative-test' 2>&1 \
+    | grep -qE 'Read-only file system|Permission denied' \
+    || fail "negative write test allowed write to /opt/arlowe"
+
+# Negative test: arlowe cannot write outside /var/lib/arlowe/ at all
+! systemd-run --uid=arlowe --gid=arlowe --pty --wait -p ProtectSystem=strict -p ReadWritePaths=/var/lib/arlowe/logs/voice \
+    /bin/sh -c 'touch /etc/sandbox-test' 2>&1 \
+    | grep -qE 'Read-only file system|Permission denied' \
+    || fail
+```
+
+### Test runner
+
+```bash
+# tests/phase-3/docker/run-tests.sh
+#!/bin/bash
+set -euo pipefail
+
+docker run --rm -it --privileged \
+    --tmpfs /run --tmpfs /tmp \
+    -v $(pwd)/..:/arlowe-firmware:ro \
+    debian:bookworm-slim \
+    /bin/bash -c '
+        apt-get update && apt-get install -y systemd python3 python3-venv nodejs
+        # Run install scripts
+        bash /arlowe-firmware/scripts/provision/install-arlowe-user.sh
+        bash /arlowe-firmware/scripts/provision/install-arlowe-fs.sh
+        bash /arlowe-firmware/units/install-units.sh
+        # Run assertions
+        for a in /arlowe-firmware/tests/phase-3/assertions/*.sh; do
+            bash "$a"
+        done
+    '
+```
+
+### Arlowe-1 staging-user side-by-side script
+
+`scripts/provision/install-arlowe-on-arlowe1-staging.sh` — same as the production script but installs as user `arlowe-staging` (uid in 100..999 but distinct from `arlowe`), with units named `arlowe-staging-*.service`, layout under `/opt/arlowe-staging/` and `/var/lib/arlowe-staging/`. Lets Joe run the assertions against real hardware without touching the live `focal55`-owned `arlowe-*.service` units. Tear down with a paired `uninstall-arlowe-on-arlowe1-staging.sh`.
+
+This is the "arlowe-1 doesn't pollute" answer to the context's question.
+
+---
+
+## 12. Open questions for the planner
+
+These could not be resolved by research alone and need either a checkpoint with Joe or explicit deferral.
+
+1. **OTA-01 amendment.** OTA-01 says "OTA agent runs as a systemd service under the `arlowe` user." This conflicts with the read-only `/opt/arlowe/` decision in Phase 3. **Recommendation: amend OTA-01 to "OTA agent runs as a system-level systemd service with strictly sandboxed root, writing only to /opt/arlowe and /var/lib/arlowe/logs/ota.log."** Flag to Joe; if rejected, fall back to polkit-grant-arlowe-write-to-/opt, which is more complex.
+
+2. **Pairing daemon (Phase 8) user.** Same question as OTA: does the Phase 8 pairing daemon run as `arlowe` (can't write `/etc/arlowe/config.yml` under sandbox) or as root (one-shot at first boot, tears down after pairing complete)? **Recommendation: root one-shot, tighter sandbox; Phase 3 doesn't author the unit but documents the recommendation for Phase 8.**
+
+3. **`dialout` and `video` group membership for `arlowe`.** Both are speculative based on Pi 5 audio HAT and framebuffer access patterns. **Action: Phase 3 plan should include "validate on arlowe-1 staging; remove if not needed" as an explicit task with a verification step.**
+
+4. **Pi 5 GPIO chip enumeration on Pi OS 12.4+.** Pi 5's RP1 chip exposes GPIO via `/dev/gpiochip4` (main user-controllable bank) while `/dev/gpiochip0` is internal. The WhisPlay driver may use either or both. **Action: Phase 3 plan should include a hardware-loop verification of which gpiochip nodes the WhisPlay driver actually opens, and `DeviceAllow=` should match.**
+
+5. **Axera device permissions.** `/dev/axcl_host` and `/dev/ax_mmb_dev` ownership is set by the `axcl_host_aarch64_V3.10.2.deb` install scripts. Phase 3 ships a udev rule to chown them to `root:arlowe 0660`, but the exact device names and the deb's behavior need verification. **Action: Phase 3 plan includes a task to inspect the axcl_host.deb postinst (third_party/axcl) and write a matching udev rule.**
+
+6. **Service-restart capability for the dashboard.** Dashboard's `POST /api/voice` issues `systemctl restart arlowe-voice`. The dashboard runs as `arlowe`; systemctl restart of another arlowe unit requires explicit polkit grant (or the dashboard runs as root, which is bad). **Recommendation: Phase 3 ships a polkit rule allowing `arlowe` group members to restart `arlowe-*` units. File: `/etc/polkit-1/rules.d/50-arlowe-systemctl.rules`.** Sample rule:
+
+   ```javascript
+   polkit.addRule(function(action, subject) {
+       if (action.id == "org.freedesktop.systemd1.manage-units" &&
+           subject.user == "arlowe" &&
+           action.lookup("unit").startsWith("arlowe-")) {
+           return polkit.Result.YES;
+       }
+   });
+   ```
+
+   Flag to Joe — this is a reasonable Phase 3 scope expansion, OR push to Phase 4. Recommend Phase 3 since the dashboard fails open today (Phase 1 used `--user` systemctl which doesn't need this).
+
+7. **Should we set `RemoveIPC=yes` on every unit?** It cleans up POSIX shmem and message queues when the service exits. Voice service uses pyaudio which may or may not allocate POSIX shmem. Default-on is the safer answer but may break audio. **Recommendation: ship without it in Phase 3; revisit if leakage is observed.**
+
+8. **`/var/lib/arlowe/.ssh/authorized_keys` baseline.** Phase 10 specifically asserts this file is absent or has no founder key. **Action: Phase 3 explicitly does NOT create `/var/lib/arlowe/.ssh/`. Document that Phase 10 creates it.** No work item; just an explicit non-action.
+
+---
+
+## Sources
+
+### Primary (HIGH confidence)
+
+- [systemd.exec(5) — Arch manual pages](https://man.archlinux.org/man/systemd.exec.5.en) — sandboxing directive semantics, PrivateDevices/DeviceAllow/SupplementaryGroups behavior
+- [Next.js output configuration](https://nextjs.org/docs/pages/api-reference/config/next-config-js/output) — `output: 'standalone'` mechanics, `server.js` runtime
+- [Next.js cache directory discussion #67031](https://github.com/vercel/next.js/discussions/67031) — `NEXT_PRIVATE_CACHE_DIR` for read-only-rootfs deployments
+- [arlowe-firmware repo: runtime/, .dev-stash/arlowe-1/systemd-*, scripts/sanitize/](.) — internal source-of-truth for what runs today, what the unit-name banlist allows, and what env vars and paths the runtime expects
+
+### Secondary (MEDIUM confidence)
+
+- [systemd ProtectSystem/ProtectHome on Ubuntu](https://oneuptime.com/blog/post/2026-03-02-use-systemd-protectsystem-protecthome-directives-ubuntu/view) — practical strict-mode patterns
+- [systemd Service Hardening (Rocky Linux)](https://docs.rockylinux.org/9/guides/security/systemd_hardening/) — systemd-analyze security workflow
+- [Hardening with systemd-analyze security](https://dev.to/lyraalishaikh/harden-linux-services-with-systemd-analyze-security-from-score-to-enforceable-policy-3045) — score interpretation guidance
+- [pi-gen Customization Guide](https://deepwiki.com/RPi-Distro/pi-gen/5-customization-guide) — custom stage structure for the Phase 6 hand-off
+- [Pi udev rules for GPIO/SPI access](https://forums.raspberrypi.com/viewtopic.php?t=9667) — Pi OS's 99-com.rules group assignments
+
+### Tertiary (LOW confidence — verify in Docker testbed or on arlowe-1)
+
+- [Quora: systemd-nspawn vs Docker for testing](https://www.quora.com/What-are-the-merits-of-using-systemd-nspawn-over-Docker) — informed the testbed-choice recommendation
+- [Ctrl Blog: systemd hardening 101](https://www.ctrl.blog/entry/systemd-service-hardening.html) — order-of-tightening heuristics
+- [No Audio with Systemd Command Service on Raspberry Pi](https://www.blog.neudeep.com/raspberry/no-audio-with-systemd-command-service-on-raspberry-pi/1138/) — Group=audio + sound.target dependency pattern
+
+---
+
+## Metadata
+
+**Confidence breakdown:**
+
+- Standard stack (systemd, useradd, ext4, polkit): HIGH — well-documented, stable APIs
+- Architecture (read-only /opt + writable /var/lib + system user + system units): HIGH — Debian/FHS standard
+- Per-unit hardening directives: MEDIUM — directives are HIGH confidence; their *interaction with arlowe-specific code paths* needs the Docker testbed and arlowe-1 verification to confirm
+- Testbed (Docker primary, arlowe-1 secondary): MEDIUM — recommendation is sound but depends on Joe's appetite for Docker-systemd dance vs. systemd-nspawn fallback
+- Next.js read-only deployment: MEDIUM — `NEXT_PRIVATE_CACHE_DIR` is a documented-but-private API
+- OTA-01 amendment: LOW until Joe weighs in
+
+**Research date:** 2026-05-26
+**Valid until:** ~2026-06-26 (Next.js 16.x cache API stability is the soonest-likely-to-rot item; systemd directives are stable for years)


### PR DESCRIPTION
## Summary

- Closes Phase 2 (sanitization gate) in ROADMAP and STATE — all four PRs (#58-#61) merged.
- Lands Phase 3 (service user + filesystem layout) planning artifacts: 1 RESEARCH + 5 PLAN files.
- Rescues an orphaned research commit (`4381ab2` → cherry-picked as `c08ce62`) that lived only on the now-deleted `feat/sanitize-02-04-runtime-cleanup` branch.
- STATE.md rewritten to position Phase 2 complete; next step is `/issue-from-plan 3` to seed the board for workforce-tick.

## Why this PR exists

When PR #61 squash-merged on 2026-05-27, the SC4 cleanup work landed on main but two local-only artifacts were orphaned on the feature branch: the Phase 3 research commit and a tree full of uncommitted Phase 3 plans. Without this PR, those artifacts would have been lost when the branch is deleted.

## Test plan

- [x] No code changes — planning docs only.
- [x] `.planning/**` is allow-listed in `.sanitize-allowlist`, so sanitize CI jobs are no-ops for these files.
- [x] Confirm sanitize jobs still pass on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)