### PR TITLE
feat(provision): 03-04 — CLI symlinks installer + boot-check system flag flip

### DIFF
--- a/.planning/phases/03-service-user-and-filesystem-layout/03-04-SUMMARY.md
+++ b/.planning/phases/03-service-user-and-filesystem-layout/03-04-SUMMARY.md
@@ -1,0 +1,41 @@
+---
+phase: 03-service-user-and-filesystem-layout
+plan: 04
+status: complete
+provides:
+  - /usr/local/sbin/arlowe-{face,speak,stt,record,boot-check,purge-logs,run-logrotate,wake-train} symlinks (Phase 10 support-mode invocation pattern depends on these)
+  - boot-check ARLOWE_SYSTEMCTL_FLAGS default flipped from '--user' to '' (Phase 11 boot-health depends on this; Phase 5 audio auto-detect calls boot-check)
+  - No Phase 1 runtime/cli/* file behavior changed except boot-check's default; other CLI scripts ride the symlinks without modification
+files_written:
+  - scripts/provision/install-arlowe-cli.sh
+  - runtime/cli/boot-check  (one-line default flip)
+  - tests/phase-3/assertions/05-cli-symlinks.sh
+---
+
+## What landed
+
+**`scripts/provision/install-arlowe-cli.sh`** — idempotent installer that creates 8
+root-owned symlinks in `/usr/local/sbin/arlowe-*` pointing into
+`/opt/arlowe/runtime/cli/<name>`. Uses `ln -sf` for idempotency. Picked up
+automatically by the Phase 3 Docker harness auto-discovery loop (run-tests.sh
+already contains the CLI pre-stage step gated on this file's existence).
+
+**`runtime/cli/boot-check`** — single-line edit: `ARLOWE_SYSTEMCTL_FLAGS` default
+changed from `--user` (Phase 1 legacy) to `""` (system-level, Phase 3+ image).
+Backward-compat preserved — `ARLOWE_SYSTEMCTL_FLAGS=--user` env override still
+works for ad-hoc invocations against dev-stash `--user` units.
+
+**`tests/phase-3/assertions/05-cli-symlinks.sh`** — validates all 8 symlinks exist,
+each points to the correct target and resolves to an existing file, each is
+root-owned, and the boot-check default-flip is in place.
+
+## Verification
+
+Docker testbed (`bash tests/phase-3/docker/run-tests.sh`): all 5 assertions pass,
+including 05-cli-symlinks.sh. Sanitization gate clean (139 files, 9 units).
+
+## Cross-phase dependencies satisfied
+
+- Phase 5 audio auto-detect calls `arlowe-boot-check`; symlink now in PATH.
+- Phase 10 support-mode SSH invokes all 8 `arlowe-*` helpers; discoverable via `/usr/local/sbin`.
+- Phase 11 boot-health reads service status via system-level `systemctl` (no `--user`); boot-check default now matches.

--- a/runtime/cli/boot-check
+++ b/runtime/cli/boot-check
@@ -3,11 +3,14 @@
 # Run after reboot to verify all services are operational
 #
 # Env overrides:
-#   ARLOWE_SYSTEMCTL_FLAGS  Flags passed to systemctl (default: --user)
-#                           Set to empty string for system-level units (Phase 11+)
+#   ARLOWE_SYSTEMCTL_FLAGS  Flags passed to systemctl
+#                           Default: '' (system-level units, Phase 3+ image)
+#                           Set to '--user' for ad-hoc test invocations
+#                           against legacy --user units in dev-stash/.
 
-# TODO(phase-11): --user mode flips to system-level when image build lands.
-SYSTEMCTL_FLAGS="${ARLOWE_SYSTEMCTL_FLAGS:---user}"
+# Phase 3 plan 04: default flipped from '--user' to '' to align with
+# the system-level unit files shipped in plan 03-02.
+SYSTEMCTL_FLAGS="${ARLOWE_SYSTEMCTL_FLAGS:-}"
 
 echo "============================================================"
 echo "           ARLOWE BOOT VERIFICATION"

--- a/scripts/provision/install-arlowe-cli.sh
+++ b/scripts/provision/install-arlowe-cli.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Installs arlowe CLI symlinks at /usr/local/sbin/arlowe-* pointing into
+# /opt/arlowe/runtime/cli/. Idempotent. Invoked by pi-gen and the Docker testbed.
+#
+# Purpose:
+#   The CLI helpers are how support-mode SSH (Phase 10) and ad-hoc debugging
+#   invoke arlowe internals. They must be discoverable in PATH and prefixed
+#   arlowe-* to avoid namespace pollution.
+#
+# Idempotency contract:
+#   ln -sf replaces an existing symlink without error. Re-running this script
+#   produces no state change.
+#
+# Target population:
+#   This script creates symlinks only; it does NOT copy files into
+#   /opt/arlowe/runtime/cli/. Phase 6 populates the targets during image build.
+#   Symlinks may dangle briefly in the provision ordering; that is expected.
+#
+# Must be run as root (or via sudo).
+set -euo pipefail
+
+CLIS=(face speak stt record boot-check purge-logs run-logrotate wake-train)
+TARGET_DIR=/opt/arlowe/runtime/cli
+LINK_DIR=/usr/local/sbin
+
+install -d -m 0755 "${LINK_DIR}"
+
+for cli in "${CLIS[@]}"; do
+    link="${LINK_DIR}/arlowe-${cli}"
+    target="${TARGET_DIR}/${cli}"
+    ln -sf "${target}" "${link}"
+done
+
+echo "[install-arlowe-cli] installed ${#CLIS[@]} symlinks in ${LINK_DIR}"

--- a/tests/phase-3/assertions/05-cli-symlinks.sh
+++ b/tests/phase-3/assertions/05-cli-symlinks.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Phase 3 SC5 assertion: CLI symlinks + boot-check default flip.
+#
+# Validates:
+#   1. Each of the 8 /usr/local/sbin/arlowe-* symlinks exists.
+#   2. Each symlink points to /opt/arlowe/runtime/cli/<unprefixed-name>.
+#   3. Each symlink target exists (Docker testbed pre-stages marker files;
+#      Phase 6 populates with real CLI scripts).
+#   4. Each symlink is owned by root.
+#   5. boot-check's ARLOWE_SYSTEMCTL_FLAGS default is '' (system-level),
+#      not '--user' (Phase 1 legacy).
+#   6. boot-check still honors the ARLOWE_SYSTEMCTL_FLAGS env override
+#      for backward compatibility with ad-hoc --user invocations.
+set -euo pipefail
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+CLIS=(face speak stt record boot-check purge-logs run-logrotate wake-train)
+
+for cli in "${CLIS[@]}"; do
+    link="/usr/local/sbin/arlowe-${cli}"
+    target="/opt/arlowe/runtime/cli/${cli}"
+
+    test -L "${link}"                     || fail "${link} is not a symlink"
+    actual=$(readlink "${link}")
+    test "${actual}" = "${target}"        || fail "${link} points to ${actual}, expected ${target}"
+
+    # Target must exist — Docker testbed pre-stages empty marker files;
+    # in production Phase 6 populates with real CLI scripts.
+    test -e "${target}"                   || fail "${link} target ${target} does not exist"
+
+    sym_owner=$(stat -c %U "${link}")
+    test "${sym_owner}" = "root"          || fail "${link} owned by ${sym_owner}, expected root"
+done
+
+# Boot-check default-flip: ARLOWE_SYSTEMCTL_FLAGS default must be '' not '--user'.
+grep -E '^\s*SYSTEMCTL_FLAGS="\$\{ARLOWE_SYSTEMCTL_FLAGS:-\}"' /opt/arlowe/runtime/cli/boot-check \
+    || fail "boot-check did not flip default from --user to '' (system-level)"
+
+# Backward-compat: --user mode is still supported by env override.
+grep -q 'ARLOWE_SYSTEMCTL_FLAGS:-' /opt/arlowe/runtime/cli/boot-check \
+    || fail "boot-check no longer honors ARLOWE_SYSTEMCTL_FLAGS override"
+
+# Sanitization spot-check.
+if grep -E 'focal55|/home/focal55|joe@focal55|iol-monorepo' /opt/arlowe/runtime/cli/boot-check; then
+    fail "boot-check contains a banned literal"
+fi
+
+echo "[05-cli-symlinks] PASS"


### PR DESCRIPTION
## Summary

- Adds `scripts/provision/install-arlowe-cli.sh` — idempotent installer that creates 8 root-owned symlinks at `/usr/local/sbin/arlowe-{face,speak,stt,record,boot-check,purge-logs,run-logrotate,wake-train}` pointing into `/opt/arlowe/runtime/cli/`
- Flips `runtime/cli/boot-check` `ARLOWE_SYSTEMCTL_FLAGS` default from `--user` (Phase 1 legacy) to `""` (system-level, Phase 3+ image); backward-compat env override preserved
- Adds `tests/phase-3/assertions/05-cli-symlinks.sh` validating all 8 symlinks, target resolution, root ownership, and the boot-check default flip

## Test plan

- [x] `bash -n` syntax check on all three files: clean
- [x] `bash scripts/sanitize/check.sh`: clean (139 files, 9 units)
- [x] Full Docker harness `bash tests/phase-3/docker/run-tests.sh`: all 5 assertions pass (01-user-shape, 02-fs-layout, 03-unit-syntax, 04-udev-polkit-shape, 05-cli-symlinks)
- [x] Idempotency confirmed via `ln -sf` semantics
- [x] PR ~100 net LOC (131 insertions, 4 deletions)

Closes #66