### PR TITLE
feat(provision): plan 03-05 — arlowe-1 staging harness + SC4 real-hardware verification

### DIFF
--- a/.planning/phases/03-service-user-and-filesystem-layout/03-05-SUMMARY.md
+++ b/.planning/phases/03-service-user-and-filesystem-layout/03-05-SUMMARY.md
@@ -1,0 +1,74 @@
+---
+phase: 03-service-user-and-filesystem-layout
+plan: 05
+status: complete
+closure: passed-with-notes
+provides:
+  - Phase 3 SC4 closure — real-hardware sandbox write-deny verified on arlowe-1 against arlowe-staging under real systemd 257 (positive RW + 4 negative denials incl. founder home). Observed run 2026-06-06; see docs/operations/phase-3-staging.md.
+  - Resolution of speculative groups — video and dialout confirmed UNUSED on real hardware (no /dev/fb0; WM8960 codec is I2C/in-kernel, only serial node is the agetty console). Granted set should tighten to {audio, gpio, spi} in Phase 4.
+  - gpiochip enumeration resolved — /dev/gpiochip4 is a symlink to gpiochip0, /dev/gpiomem absent on the 6.12 rpt kernel; WhisPlay opens gpiochip0. DeviceAllow can narrow to gpiochip0.
+  - Axera udev rule conflict CONFIRMED — the axcl deb ships /etc/udev/rules.d/axcl_host.rules (0666 root:root) that sorts after and overrides our 90-arlowe-axera.rules; ours is inert on real hardware.
+  - arlowe-1 staging harness — install/uninstall scripts + 06 (SC4) + 07 (hardware) assertion scripts; reusable for re-verification after Phase 4-6 changes touching user/layout/units.
+  - Env-var contract on plan 01/02 assertions verified in a production-like setting — 02-fs-layout.sh re-targets cleanly via ARLOWE_USER override (zero edits); 01-user-shape.sh's bundled founder-absence check is image-only and cannot pass on the dev Pi.
+affects:
+  - Phase 4 (config overlay) — pick up cleanups: drop video+dialout groups, narrow gpiochip DeviceAllow, split founder-absence out of 01-user-shape.sh, rename 90-arlowe-axera.rules to sort after the axcl deb.
+  - Phase 6 (image build) — consumes plans 01-04 install scripts as a pi-gen stage; consumes the group-narrowing + axcl-rule-ordering decisions recorded here.
+  - Phase 12 (first-flash integration) — inherits the SC1-4 assertion suite for the real-hardware closure gate.
+files_written:
+  - scripts/provision/install-arlowe-on-arlowe1-staging.sh
+  - scripts/provision/uninstall-arlowe-on-arlowe1-staging.sh
+  - tests/phase-3/staging/run-staging.sh
+  - tests/phase-3/staging/06-sandbox-write-deny.sh
+  - tests/phase-3/staging/07-hardware-speculative.sh
+  - tests/phase-3/staging/README.md
+  - docs/operations/phase-3-staging.md
+  - .sanitize-allowlist
+---
+
+## What landed
+
+A staging harness that runs the production Phase 3 provisioning under a parallel
+`arlowe-staging` user on the real dev Pi, side-by-side with the `focal55`
+daily-driver (never touched), then tears it down. It closes **SC4 on real
+hardware** — the one Phase 3 success criterion the Docker testbed could only prove
+synthetically.
+
+**`install/uninstall-arlowe-on-arlowe1-staging.sh`** — the install sed-transforms
+copies of the production user/fs/cli scripts (no edits to committed plans 01/02/04)
+and transforms+renames the plan-03 udev/polkit rule files directly. Units are
+prefix-renamed (`arlowe-face` → `arlowe-staging-face`, `qwen-api` →
+`qwen-staging-api`, `whisper-stt` → `whisper-stt-staging`) so the polkit
+`indexOf("arlowe-staging-")` grant matches. Hostname-scoped, refuses to coexist
+with a production `arlowe` user. Uninstall is idempotent and restores the Pi.
+
+**`tests/phase-3/staging/{run-staging,06-sandbox-write-deny,07-hardware-speculative}.sh`
++ README** — Mac-side runner (env-overrides plan 01/02 assertions onto the staging
+tree), SC4 verifier via `systemd-run`, and the hardware/group probe.
+
+## Verification — observed run 2026-06-06 (Pi 5, Debian 13, systemd 257)
+
+- **SC4: PASS** against real systemd. Declared RW path writable; `/opt`, `/etc`,
+  `/root`, `/home/focal55` all denied. Founder home unreachable from the sandbox.
+- **SC2: PASS** via env override, zero assertion edits.
+- **SC1:** user-shape sub-checks pass; the bundled founder-absence check fails on
+  the dev Pi by design (focal55 is the login) — image-only, see follow-up.
+- Tear-down verified clean: `arlowe-staging` gone, all staging units/trees/rules/
+  symlinks removed, `focal55` + all 6 daily-driver services intact.
+
+## Notes carried to Phase 4 (why this is passed-with-notes, not pass)
+
+1. Drop `video` + `dialout` groups (both confirmed unused) → tighten to
+   `{audio, gpio, spi}`; update 01's group checks.
+2. Narrow gpiochip `DeviceAllow` to `/dev/gpiochip0`; drop the dead `/dev/gpiomem`
+   udev line.
+3. Split the founder-absence check out of `01-user-shape.sh` into an image-only
+   assertion so 01 is reusable in staging without spurious failure.
+4. Reorder `90-arlowe-axera.rules` after the axcl deb's `axcl_host.rules` (or
+   reconcile) and decide whether `0666 root:root` on the NPU node is acceptable.
+
+## Incidental fix
+
+Added `tests/phase-3/assertions/05-cli-symlinks.sh` to `.sanitize-allowlist` — it
+carries banned literals in a negative grep check (same rationale as `04-...`) but
+shipped in plan 03-04 without the entry, leaving the sanitize gate red on main.
+Worth checking why CI didn't block #71.

--- a/.sanitize-allowlist
+++ b/.sanitize-allowlist
@@ -60,3 +60,24 @@ runtime/tts/manifest.yml
 # from the polkit rule. Both files never ship in the firmware image (tests/ is not a pi-gen stage).
 tests/phase-3/assertions/01-user-shape.sh
 tests/phase-3/assertions/04-udev-polkit-shape.sh
+# 05-cli-symlinks.sh: `grep -E 'focal55|/home/focal55|...' boot-check` is a negative
+# check verifying boot-check carries no banned literals — same rationale as 04.
+# (Shipped in plan 03-04 without this entry; gate was red on main until now.)
+tests/phase-3/assertions/05-cli-symlinks.sh
+
+# --- Phase 3 plan 05 staging harness allow-list ---
+# These are dev-host tooling and never ship in the firmware image (tests/ and
+# docs/operations are not pi-gen stages). Precedent: scripts/dev-pull-from-pi.sh
+# (arlowe-1) and docs/operations/phase-1-smoke-test.md.
+#
+# 06-sandbox-write-deny.sh MUST contain /home/focal55 — it is the SC4 negative
+# test proving the sandbox denies writes to the founder home; removing the literal
+# defeats the test.
+tests/phase-3/staging/06-sandbox-write-deny.sh
+# run-staging.sh defaults the SSH target to the dev host (arlowe-1).
+tests/phase-3/staging/run-staging.sh
+# README documents the dev-host ssh invocations and the daily-driver stop prereq.
+tests/phase-3/staging/README.md
+# phase-3-staging.md is the dev-unit ops record; it references the daily-driver
+# user (focal55) and dev host (arlowe-1) because hardware contention is a real prereq.
+docs/operations/phase-3-staging.md

--- a/docs/operations/phase-3-staging.md
+++ b/docs/operations/phase-3-staging.md
@@ -1,0 +1,95 @@
+# Phase 3 staging harness — operations record
+
+## Overview
+
+Phase 3's SC4 requirement reads: *"a test on the dev image verifies that the
+runtime cannot write outside `/var/lib/arlowe/`."* The Docker testbed validated
+SC1–SC4 synthetically; this harness closes the **real-hardware** gap without a
+full Phase 6 image build, by installing the production Phase 3 provisioning under
+a parallel `arlowe-staging` user on the dev Pi — side-by-side with the live
+daily-driver (`focal55`) setup, which it never touches — exercising SC4 against
+real systemd, then tearing the staging user down.
+
+It relates forward to Phase 6 (image build consumes plans 01–04 as a pi-gen
+stage) and Phase 12 (first-flash integration inherits the SC1–SC4 suite).
+
+## Procedure
+
+1. **SSH prereq:** alias `arlowe-1` with key auth (override host via
+   `ARLOWE_STAGING_HOST`).
+2. **Daily-driver face service:** the harness does **not** require stopping it.
+   The plan/README list a `systemctl --user stop arlowe-face` prereq so that
+   `07-hardware-speculative.sh` can start the staging face service and `lsof` its
+   gpiochip fds. On a pre-Phase-6 Pi the staging face service can't start anyway
+   (no populated venv), so stopping the daily-driver buys nothing — and the
+   gpiochip question is answerable directly from the running daily-driver face
+   (it holds `/dev/gpiochip0`). The stop-prereq only becomes meaningful once a
+   real runtime is populated (Phase 6+).
+3. **Run:** from the repo root on the Mac, `bash tests/phase-3/staging/run-staging.sh`.
+   Each phase's exit code is captured (not aborted on) so the full run is visible.
+4. **Tear down:** `ssh arlowe-1 'sudo bash /tmp/arlowe-firmware/scripts/provision/uninstall-arlowe-on-arlowe1-staging.sh'`.
+
+## Observed run — 2026-06-06
+
+- Host: `arlowe-1` — Pi 5, Debian 13 (trixie), kernel `6.12.47+rpt-rpi-2712`,
+  **systemd 257** (not Bookworm/systemd 252 — the plan assumed Bookworm; SC1–SC4
+  behaviour was identical on trixie).
+- Staging install: `arlowe-staging` uid=999, layout under `/opt/arlowe-staging`
+  + `/var/lib/arlowe-staging`, six `*-staging.service` units, CLI symlinks, udev +
+  polkit `-staging` rules. Clean.
+
+**SC4 — sandbox write-deny (PASS, against real systemd):**
+
+| Target | Result |
+|---|---|
+| `/var/lib/arlowe-staging/logs/face` (declared RW) | write OK |
+| `/opt/arlowe-staging` | denied — Read-only file system |
+| `/etc` | denied — Read-only file system |
+| `/root` | denied — Permission denied |
+| `/home/focal55` (founder home) | denied — Permission denied |
+
+The founder home is unreachable from a service account under the production
+sandbox directives. **SC4 is closed on real hardware.**
+
+**SC2 — filesystem layout:** PASS, re-run via `ARLOWE_USER=arlowe-staging`
+override with zero edits to the assertion. Confirms the env-var contract works
+and Docker↔trixie layout parity holds.
+
+**SC1 — user shape:** the user-shape sub-checks pass (uid=999 < 1000, HOME
+`/var/lib/arlowe-staging`, shell `/usr/sbin/nologin`, groups present), but the
+script exits non-zero on its bundled founder-absence check (`getent passwd
+focal55 && fail`). That check is an **image-only sanitization assertion** and
+cannot pass on the founder's own dev Pi. See follow-ups.
+
+**Speculative groups / devices (research §12):**
+
+| Question | Finding | Decision |
+|---|---|---|
+| `video` group needed? | `/dev/fb0` absent; WhisPlay is an SPI LCD (face holds `/dev/spidev0.0` + `/dev/gpiochip0`), not a framebuffer | **drop** |
+| `audio` group needed? | `/dev/snd` present (`wm8960-soundcard` + 2× vc4-hdmi); voice uses ALSA | keep |
+| `gpio` / `spi` needed? | face holds `/dev/gpiochip0` and `/dev/spidev0.0` | keep |
+| `dialout` group needed? | only serial node is `/dev/ttyAMA10` (held by `agetty` console); WM8960 codec is I2C + in-kernel; voice holds no serial/tty/i2c fd | **drop** |
+| gpiochip0 vs gpiochip4? | `/dev/gpiochip4` is a symlink → `gpiochip0`; `/dev/gpiomem` absent on this kernel; WhisPlay opens `gpiochip0` | narrow DeviceAllow to `gpiochip0`; the gpiomem udev line is a no-op here |
+| axcl deb conflict? | deb ships `/etc/udev/rules.d/axcl_host.rules` setting `axcl_host`/`ax_mmb_dev` to `0666 root:root`; it sorts **after** our `90-arlowe-axera.rules`, so the deb wins — our rule is inert on real hw, and `0666` is looser than our intended `0660 root:arlowe` | rename ours to sort last (`95-`/`99-`) or reconcile |
+
+## Decisions for follow-up (Phase 4 cleanup)
+
+1. Drop `video` and `dialout` from `install-arlowe-user.sh`; tighten the granted
+   set to `{audio, gpio, spi}`. Update `01-user-shape.sh` group checks to match.
+2. Narrow the gpiochip `DeviceAllow` in `units/arlowe-face.service` to
+   `/dev/gpiochip0`; drop the dead `/dev/gpiomem` udev line.
+3. Split the founder-absence check out of `01-user-shape.sh` into an image-only
+   assertion so 01 is cleanly reusable by the staging harness.
+4. Rename `90-arlowe-axera.rules` to sort after the axcl deb's `axcl_host.rules`
+   (or reconcile the two), and decide whether `0666 root:root` on the NPU node is
+   acceptable or should be tightened to `0660 root:arlowe`.
+
+## Limits
+
+- Staging shares hardware with the daily-driver, so the staging face service can't
+  acquire the SPI/GPIO devices while the daily-driver face runs — and can't start
+  at all pre-Phase-6 (no venv). The gpiochip-open question was answered from the
+  daily-driver's live state, not the staging service.
+- Staging units use remapped ports/names and are installed but not started (except
+  the best-effort face probe), so production ports (3000/8080/…) are not exercised
+  here — Phase 12 owns end-to-end port verification.

--- a/scripts/provision/install-arlowe-on-arlowe1-staging.sh
+++ b/scripts/provision/install-arlowe-on-arlowe1-staging.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# Phase 3 plan 05: install a parallel `arlowe-staging` user + layout + units +
+# rules on the dev Pi, side-by-side with the existing daily-driver setup
+# (which it never touches), to verify SC4 sandbox write-deny against REAL systemd
+# and resolve the speculative group / device questions from research §12.
+#
+# Reuse strategy: the production install scripts (plans 01/02/04) hardcode the
+# literal `arlowe`; this script sed-transforms copies of them into a temp dir and
+# runs those, so plans 01-04's committed scripts are never edited. The udev/polkit
+# RULE FILES (plan 03) are transformed + renamed directly here, because the
+# production udev/polkit installer resolves repo paths relative to its own location
+# and so cannot be run from a temp copy.
+#
+# Staging naming:
+#   user/group   arlowe          -> arlowe-staging
+#   paths        /opt|/var/lib|/etc/arlowe -> .../arlowe-staging
+#   units        arlowe-face     -> arlowe-staging-face   (prefix; required by the
+#                qwen-api        -> qwen-staging-api        polkit prefix-match rule)
+#                whisper-stt     -> whisper-stt-staging
+#   rules        90-arlowe-axera -> 90-arlowe-staging-axera
+#
+# Run on the dev Pi as root: sudo bash install-arlowe-on-arlowe1-staging.sh
+# Tear down with uninstall-arlowe-on-arlowe1-staging.sh.
+set -euo pipefail
+
+# Hard-scope to the dev Pi: refuse anywhere the hostname doesn't start with "arlowe".
+if [[ ! -r /etc/hostname ]] || ! grep -qE '^arlowe' /etc/hostname; then
+    echo "Refusing: hostname does not start with 'arlowe'. This script is scoped to the dev Pi." >&2
+    exit 1
+fi
+
+# Refuse to coexist with a production install — that path belongs to the Phase 6 image.
+if id arlowe >/dev/null 2>&1; then
+    echo "Production 'arlowe' user exists; this looks like a Phase 6 image, not the dev Pi." >&2
+    echo "Refusing to run the staging install side-by-side with production." >&2
+    exit 1
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# --- user / fs / cli: sed-transform the production scripts, then run the copies.
+# These three have no repo-relative file lookups, so running them from /tmp is safe.
+for script in install-arlowe-user install-arlowe-fs install-arlowe-cli; do
+    sed 's|arlowe|arlowe-staging|g' "$REPO_ROOT/scripts/provision/$script.sh" \
+        > "$TMP/$script-staging.sh"
+done
+bash "$TMP/install-arlowe-user-staging.sh"
+bash "$TMP/install-arlowe-fs-staging.sh"
+
+# --- udev + polkit: transform + rename the rule files, install directly.
+install -d -m 0755 /etc/udev/rules.d /etc/polkit-1/rules.d
+for rule in "$REPO_ROOT"/provision/udev/*.rules; do
+    dest="9$(basename "$rule" | sed 's|^9||; s|arlowe|arlowe-staging|')"
+    sed 's|arlowe|arlowe-staging|g' "$rule" > "$TMP/$dest"
+    install -m 0644 -o root -g root "$TMP/$dest" "/etc/udev/rules.d/$dest"
+done
+for rule in "$REPO_ROOT"/provision/polkit/*.rules; do
+    dest="$(basename "$rule" | sed 's|arlowe|arlowe-staging|')"
+    # Broad arlowe sub handles user + arlowe-/qwen- prefixes; whisper-stt has no
+    # "arlowe" so its exact-match unit name needs its own substitution.
+    sed -e 's|arlowe|arlowe-staging|g' \
+        -e 's|whisper-stt\.service|whisper-stt-staging.service|g' \
+        "$rule" > "$TMP/$dest"
+    install -m 0644 -o root -g root "$TMP/$dest" "/etc/polkit-1/rules.d/$dest"
+done
+if command -v udevadm >/dev/null 2>&1; then
+    udevadm control --reload 2>/dev/null || true
+    udevadm trigger 2>/dev/null || true
+fi
+
+# --- units: prefix-rename + content transform + port remap (only ports that the
+# unit files actually declare; face/stt/qwen ports are code/config-driven).
+for unit in "$REPO_ROOT"/units/*.service; do
+    name="$(basename "$unit" .service)"
+    staging_name="$(echo "$name" | sed -e 's|^arlowe-|arlowe-staging-|' \
+                                       -e 's|^qwen-|qwen-staging-|' \
+                                       -e 's|^whisper-stt$|whisper-stt-staging|').service"
+    sed -e 's|arlowe|arlowe-staging|g' \
+        -e 's|qwen-|qwen-staging-|g' \
+        -e 's|whisper-stt|whisper-stt-staging|g' \
+        -e 's|PORT=3000|PORT=3001|g' \
+        -e 's|localhost:8080|localhost:8081|g' \
+        -e 's|localhost:8082|localhost:8083|g' \
+        "$unit" > "$TMP/$staging_name"
+    install -m 0644 -o root -g root "$TMP/$staging_name" "/etc/systemd/system/$staging_name"
+done
+systemctl daemon-reload
+
+# --- CLI symlinks: sed the production installer (creates arlowe-staging-* links
+# into /opt/arlowe-staging/runtime/cli), then populate the targets from the repo
+# so the links resolve (Phase 6 populates these on a real image).
+sed 's|arlowe|arlowe-staging|g' "$REPO_ROOT/scripts/provision/install-arlowe-cli.sh" \
+    > "$TMP/install-arlowe-cli-staging.sh"
+bash "$TMP/install-arlowe-cli-staging.sh"
+for cli in face speak stt record boot-check purge-logs run-logrotate wake-train; do
+    [[ -f "$REPO_ROOT/runtime/cli/$cli" ]] \
+        && install -m 0755 -o root -g arlowe-staging "$REPO_ROOT/runtime/cli/$cli" \
+           "/opt/arlowe-staging/runtime/cli/$cli"
+done
+
+echo "[install-arlowe-on-arlowe1-staging] staging environment provisioned."
+echo "  Next: tests/phase-3/staging/06-sandbox-write-deny.sh + 07-hardware-speculative.sh"
+echo "  Tear down: uninstall-arlowe-on-arlowe1-staging.sh"

--- a/scripts/provision/uninstall-arlowe-on-arlowe1-staging.sh
+++ b/scripts/provision/uninstall-arlowe-on-arlowe1-staging.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Paired tear-down for install-arlowe-on-arlowe1-staging.sh. Restores the dev Pi to
+# its pre-staging state: stops/removes staging units, rules, symlinks, trees, and
+# the arlowe-staging user. Idempotent — a no-op when no staging user is present.
+#
+# Run on the dev Pi as root: sudo bash uninstall-arlowe-on-arlowe1-staging.sh
+set -euo pipefail
+
+if ! id arlowe-staging >/dev/null 2>&1; then
+    echo "[uninstall] no arlowe-staging user; nothing to tear down."
+    exit 0
+fi
+
+# Stop + disable + remove all staging unit files. Staging units are the only
+# ones matching *-staging.service (prefix-renamed from arlowe-/qwen-/whisper-stt).
+shopt -s nullglob
+for unit in /etc/systemd/system/*-staging.service; do
+    name="$(basename "$unit")"
+    systemctl stop "$name" 2>/dev/null || true
+    systemctl disable "$name" 2>/dev/null || true
+    rm -f "$unit"
+done
+systemctl daemon-reload
+
+for cli in face speak stt record boot-check purge-logs run-logrotate wake-train; do
+    rm -f "/usr/local/sbin/arlowe-staging-$cli"
+done
+
+rm -f /etc/udev/rules.d/9?-arlowe-staging-*.rules
+rm -f /etc/polkit-1/rules.d/5?-arlowe-staging-*.rules
+command -v udevadm >/dev/null 2>&1 && { udevadm control --reload 2>/dev/null || true; }
+
+rm -rf /opt/arlowe-staging /var/lib/arlowe-staging /etc/arlowe-staging
+
+deluser --remove-home arlowe-staging >/dev/null 2>&1 \
+    || userdel -r arlowe-staging >/dev/null 2>&1 || true
+
+echo "[uninstall] arlowe-staging tear-down complete. Verify: id arlowe-staging (should fail)."

--- a/tests/phase-3/staging/06-sandbox-write-deny.sh
+++ b/tests/phase-3/staging/06-sandbox-write-deny.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# SC4 (real-hardware): under the production sandbox directives, arlowe-staging
+# cannot write outside its own /var/lib/arlowe-staging/ tree. Verified against the
+# actual systemd on the dev Pi via systemd-run (the Docker testbed could only
+# validate this synthetically).
+#
+# Run on the dev Pi as root, after the staging install has run.
+set -uo pipefail
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+SVC_USER=arlowe-staging
+RWPATH=/var/lib/arlowe-staging/logs/face
+
+id "$SVC_USER" >/dev/null 2>&1 || fail "$SVC_USER not present — run the staging install first"
+[[ -d "$RWPATH" ]] || fail "$RWPATH missing — staging fs layout not provisioned"
+
+# Production sandbox directives mirrored from the shipping units.
+SANDBOX=(-p ProtectSystem=strict -p ProtectHome=yes -p NoNewPrivileges=yes
+         -p PrivateTmp=yes -p "ReadWritePaths=$RWPATH")
+
+attempt() { # attempt <path> -> prints command output, exits with touch's status
+    systemd-run --uid="$SVC_USER" --gid="$SVC_USER" --pipe --wait -q \
+        "${SANDBOX[@]}" /bin/sh -c "touch '$1'" 2>&1
+}
+
+# Positive: the declared ReadWritePaths target must be writable.
+if out=$(attempt "$RWPATH/positive-test"); then
+    rm -f "$RWPATH/positive-test"
+    echo "  positive: write to $RWPATH OK"
+else
+    fail "positive write to declared RW path denied: ${out:-<no output>}"
+fi
+
+# Negative: every path outside the sandbox must be denied. A successful write here
+# is a catastrophic sandbox failure; /home/focal55 is the founder home and must
+# NEVER be reachable from a service account.
+for target in /opt/arlowe-staging/runtime/voice/neg /etc/neg /root/neg /home/focal55/neg; do
+    if out=$(attempt "$target"); then
+        fail "sandbox ALLOWED write to $target — SC4 enforcement broken"
+    fi
+    echo "  negative: $target denied (${out##*: })"
+done
+
+echo "[06-sandbox-write-deny] PASS (1 positive + 4 negative against real systemd)"

--- a/tests/phase-3/staging/07-hardware-speculative.sh
+++ b/tests/phase-3/staging/07-hardware-speculative.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Phase 3 speculative-hardware resolution (research §12). Answers, on real hardware:
+#   - Does arlowe-staging actually need the dialout / video groups?
+#   - Can arlowe-staging open each hardware device per its udev rule + groups?
+#   - Which gpiochip does the WhisPlay face driver open (0, 4, or both)?
+#
+# -e is intentionally omitted: this script probes optional hardware and individual
+# checks are expected to fail on a board lacking a given device. We want the full
+# report regardless, not an abort on the first miss.
+#
+# PREREQUISITE (see README): stop the daily-driver face service first — it holds
+# the SPI/GPIO hardware exclusively, so the staging face service can't acquire it
+# while it runs.
+#
+# Run on the dev Pi as root, after the staging install has run.
+set -uo pipefail
+
+SVC_USER=arlowe-staging
+
+echo "=== group membership for $SVC_USER ==="
+for grp in audio gpio spi dialout video; do
+    if id -nG "$SVC_USER" 2>/dev/null | grep -qw "$grp"; then
+        echo "  $grp: granted"
+    else
+        echo "  $grp: NOT granted"
+    fi
+done
+
+echo ""
+echo "=== device-node enumeration ==="
+for dev in /dev/snd /dev/gpiochip0 /dev/gpiochip4 /dev/gpiomem \
+           /dev/spidev0.0 /dev/spidev0.1 /dev/axcl_host /dev/ax_mmb_dev /dev/fb0; do
+    if [[ -e "$dev" ]]; then ls -ld "$dev"; else echo "  $dev: absent"; fi
+done
+
+echo ""
+echo "=== can $SVC_USER read+write each present device? ==="
+for dev in /dev/gpiochip0 /dev/gpiochip4 /dev/gpiomem /dev/spidev0.0 \
+           /dev/axcl_host /dev/ax_mmb_dev /dev/fb0; do
+    [[ -e "$dev" ]] || continue
+    if sudo -u "$SVC_USER" -- bash -c "test -r '$dev' && test -w '$dev'"; then
+        echo "  $dev: read+write OK"
+    else
+        echo "  $dev: NOT accessible (group/udev gap?)"
+    fi
+done
+
+echo ""
+echo "=== WhisPlay: which gpiochip does the face driver open? ==="
+if sudo systemctl start arlowe-staging-face.service 2>/dev/null; then
+    sleep 5
+    pid=$(pgrep -u "$SVC_USER" -f 'face' | head -1 || true)
+    if [[ -n "$pid" ]]; then
+        echo "  arlowe-staging-face running (pid $pid); open hardware fds:"
+        sudo lsof -p "$pid" 2>/dev/null | grep -E '/dev/(gpiochip|spidev|snd|fb)' \
+            || echo "    (no hardware fds — driver may not have initialized)"
+    else
+        echo "  started but no process found (likely missing venv/deps on a non-image Pi)"
+    fi
+    sudo systemctl stop arlowe-staging-face.service 2>/dev/null || true
+else
+    echo "  arlowe-staging-face did not start — expected on a non-image Pi (no venv)."
+    echo "  Inspect: journalctl -u arlowe-staging-face.service -n 30 --no-pager"
+fi
+
+echo ""
+echo "[07-hardware-speculative] report complete — fold findings into docs/operations/phase-3-staging.md"

--- a/tests/phase-3/staging/README.md
+++ b/tests/phase-3/staging/README.md
@@ -1,0 +1,53 @@
+# Phase 3 staging harness
+
+Runs the production Phase 3 install on the real dev Pi under a parallel
+`arlowe-staging` user — side-by-side with the daily-driver setup, which it never
+touches — to verify **SC4 sandbox write-deny against real systemd** and resolve
+the speculative group / device questions from research §12. The Docker testbed
+validated SC1–SC3 synthetically; this closes the real-hardware gap without a full
+Phase 6 image build.
+
+## Prerequisites
+
+1. **SSH alias `arlowe-1`** with key-based auth (override with `ARLOWE_STAGING_HOST`).
+2. **Stop the daily-driver face service first.** It holds the WhisPlay SPI/GPIO
+   devices exclusively; if it's running, `07-hardware-speculative.sh` can't acquire
+   the hardware and its gpiochip probe is inconclusive:
+
+   ```bash
+   ssh arlowe-1 "systemctl --user stop arlowe-face"
+   ```
+
+   Restart it after tear-down:
+
+   ```bash
+   ssh arlowe-1 "systemctl --user start arlowe-face"
+   ```
+
+## Run
+
+From the repo root on the Mac:
+
+```bash
+bash tests/phase-3/staging/run-staging.sh
+```
+
+This syncs the repo to the Pi, installs the staging environment, runs SC1/SC2
+(env-overridden), SC4, and the hardware probe, and captures output to
+`.planning/phases/03-service-user-and-filesystem-layout/staging-observed-run.txt`.
+
+## Tear down
+
+Always tear down after reviewing — the harness does **not** auto-remove the
+staging user:
+
+```bash
+ssh arlowe-1 'sudo bash /tmp/arlowe-firmware/scripts/provision/uninstall-arlowe-on-arlowe1-staging.sh'
+ssh arlowe-1 'id arlowe-staging 2>&1'   # expect: no such user
+```
+
+## Output
+
+Fold the observed-run results and the dialout/video/gpiochip decisions into
+`docs/operations/phase-3-staging.md` (the permanent ops record) and the
+`03-05-SUMMARY.md` Phase 3 closure document.

--- a/tests/phase-3/staging/run-staging.sh
+++ b/tests/phase-3/staging/run-staging.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Phase 3 plan 05 staging harness. Runs on the Mac; drives the dev Pi over SSH.
+# Installs the arlowe-staging environment, re-runs the SC1/SC2 assertions against
+# it (via env override — no edits to those scripts), runs SC4 + the speculative
+# hardware probe, and captures the observed run. Tear-down is a separate explicit
+# step (printed at the end) so you can inspect the live system first.
+#
+# Each phase's exit code is captured and reported but does NOT abort the run: this
+# is a human-verified harness, so it surfaces every result rather than stopping at
+# the first expected divergence (e.g. SC1's founder-absence check, which is image-
+# only and cannot pass on the founder's own dev Pi — see docs/operations).
+#
+# Prereq: SSH alias 'arlowe-1' with key auth.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SSH_HOST="${ARLOWE_STAGING_HOST:-arlowe-1}"
+REMOTE=/tmp/arlowe-firmware
+OBSERVED="$REPO_ROOT/.planning/phases/03-service-user-and-filesystem-layout/staging-observed-run.txt"
+
+echo "=== Phase 3 plan 05 staging harness -> $SSH_HOST ==="
+ssh -o ConnectTimeout=5 -o BatchMode=yes "$SSH_HOST" 'hostname && uname -m && systemctl --version | head -1' \
+    || { echo "Cannot reach $SSH_HOST over SSH. Check your SSH config." >&2; exit 1; }
+
+echo "=== syncing repo to $SSH_HOST:$REMOTE ==="
+rsync -az --delete \
+    --exclude '.git' --exclude 'node_modules' --exclude '__pycache__' \
+    --exclude 'runtime/dashboard/.next' \
+    "$REPO_ROOT/" "$SSH_HOST:$REMOTE/" \
+    || { echo "rsync to $SSH_HOST failed." >&2; exit 1; }
+
+phase() { echo ""; echo "=== $1 ==="; }
+
+{
+    echo "### staging observed run ###"
+    echo "host: $SSH_HOST"
+
+    phase "install"
+    ssh "$SSH_HOST" "sudo bash $REMOTE/scripts/provision/install-arlowe-on-arlowe1-staging.sh"
+    echo "[install exit=$?]"
+
+    phase "SC1 + SC2 assertions (env-overridden to the staging tree)"
+    ssh "$SSH_HOST" "
+        export ARLOWE_USER=arlowe-staging ARLOWE_GROUP=arlowe-staging
+        export ARLOWE_HOME=/var/lib/arlowe-staging ARLOWE_OPT=/opt/arlowe-staging ARLOWE_ETC=/etc/arlowe-staging
+        for a in $REMOTE/tests/phase-3/assertions/01-user-shape.sh $REMOTE/tests/phase-3/assertions/02-fs-layout.sh; do
+            echo \"--- \$a ---\"; sudo -E bash \"\$a\"; echo \"[exit=\$?]\"
+        done
+    "
+
+    phase "SC4 sandbox write-deny"
+    ssh "$SSH_HOST" "sudo bash $REMOTE/tests/phase-3/staging/06-sandbox-write-deny.sh"
+    echo "[06 exit=$?]"
+
+    phase "speculative hardware probe"
+    ssh "$SSH_HOST" "sudo bash $REMOTE/tests/phase-3/staging/07-hardware-speculative.sh"
+    echo "[07 exit=$?]"
+} 2>&1 | tee "$OBSERVED"
+
+cat <<EOF
+
+=== staging run complete ===
+Observed run captured at: $OBSERVED
+
+Review it, then TEAR DOWN:
+  ssh $SSH_HOST 'sudo bash $REMOTE/scripts/provision/uninstall-arlowe-on-arlowe1-staging.sh'
+
+Verify clean:
+  ssh $SSH_HOST 'id arlowe-staging 2>&1; ls /etc/systemd/system/*-staging.service 2>&1 | head'
+
+Then fold findings into docs/operations/phase-3-staging.md + 03-05-SUMMARY.md.
+EOF


### PR DESCRIPTION
Closes #67. Phase 3 closure plan — verifies **SC4 (sandbox write-deny) on real hardware**, which the Docker testbed could only prove synthetically.

## What this does
Installs the production Phase 3 provisioning under a parallel `arlowe-staging` user on the dev Pi, side-by-side with the `focal55` daily-driver (never touched), exercises SC4 against real systemd, then tears it down.

- Reuses plans 01/02/04 install scripts via sed-to-temp (no edits to committed code); transforms + renames the plan-03 udev/polkit rule files directly (their installer is location-relative).
- Units prefix-renamed (`arlowe-face`→`arlowe-staging-face`, `qwen-api`→`qwen-staging-api`, `whisper-stt`→`whisper-stt-staging`) so the polkit `indexOf("arlowe-staging-")` grant matches. **This corrects an internal naming contradiction in the plan** (its Task-1 code used a suffix; the must-haves/tests/polkit require a prefix).
- Hostname-scoped; refuses to coexist with a production `arlowe` user. Uninstall idempotent and verified to restore the Pi.

## Observed run — 2026-06-06 (Pi 5, Debian 13/trixie, systemd 257)
| Check | Result |
|---|---|
| **SC4** sandbox write-deny | **PASS** — declared RW writable; `/opt`, `/etc`, `/root`, `/home/focal55` all denied |
| **SC2** fs layout (env override) | PASS, zero assertion edits |
| **SC1** user shape | shape sub-checks pass; bundled founder-absence check is image-only (can't pass on the dev Pi) |
| Tear-down | clean — staging fully removed, daily-driver + all 6 services intact |

Full record: `docs/operations/phase-3-staging.md`.

## Speculative questions resolved (research §12) → Phase 4 follow-ups
- **`video` + `dialout` groups: drop** — both confirmed unused (`/dev/fb0` absent; WM8960 codec is I2C/in-kernel; only serial node is the `agetty` console). Tighten to `{audio, gpio, spi}`.
- **gpiochip:** `gpiochip4`→symlink→`gpiochip0`, `/dev/gpiomem` absent → narrow DeviceAllow to `gpiochip0`.
- **axcl deb conflict CONFIRMED:** the deb's `axcl_host.rules` (`0666 root:root`) sorts after and overrides our `90-arlowe-axera.rules` → reorder/reconcile.
- Split the founder-absence check out of `01-user-shape.sh` into an image-only assertion.

**Phase 3 closes: passed-with-notes** (notes are Phase 4 cleanups, not re-opens).

## Incidental fix
Allowlists `tests/phase-3/assertions/05-cli-symlinks.sh` — it carries banned literals in a negative grep (same as `04-...`) but shipped in #71 without the entry, leaving the **sanitize gate red on main**. Worth checking why CI didn't block #71.

## Size
+563 LOC / 9 files — over the plan's 400 target (≈170 are the two closure docs), under the repo's 600 cap. Kept as one PR per owner decision; splitting a hands-on hardware-closure plan into 03-05a/b adds overhead without benefit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)