### PR TITLE
feat(provision): drop unused video+dialout groups; split founder-absence into image-only assertion

### DIFF
--- a/.sanitize-allowlist
+++ b/.sanitize-allowlist
@@ -54,12 +54,12 @@ runtime/wake-word/requirements.txt
 runtime/tts/manifest.yml
 
 # Phase 3 assertion scripts: contain founder identity literals in negative checks by design.
-# 01-user-shape.sh: `getent passwd focal55 && fail "..."` verifies the founder user was
-# not provisioned on the device.
+# 06-image-sanitization.sh: `getent passwd focal55 && fail` verifies the founder user is
+# absent from a shipped image (moved out of 01 in plan 03-05 so 01 is dev-Pi-reusable).
 # 04-udev-polkit-shape.sh: `grep -qE 'focal55|...'` verifies banned literals are absent
-# from the polkit rule. Both files never ship in the firmware image (tests/ is not a pi-gen stage).
-tests/phase-3/assertions/01-user-shape.sh
+# from the polkit rule. Neither file ships in the firmware image (tests/ is not a pi-gen stage).
 tests/phase-3/assertions/04-udev-polkit-shape.sh
+tests/phase-3/assertions/06-image-sanitization.sh
 # 05-cli-symlinks.sh: `grep -E 'focal55|/home/focal55|...' boot-check` is a negative
 # check verifying boot-check carries no banned literals — same rationale as 04.
 # (Shipped in plan 03-04 without this entry; gate was red on main until now.)

--- a/scripts/provision/install-arlowe-user.sh
+++ b/scripts/provision/install-arlowe-user.sh
@@ -48,9 +48,10 @@ fi
 #   audio   — ALSA /dev/snd/* for arlowe-voice + arlowe-wake-word (pyaudio)
 #   gpio    — /dev/gpiomem + /dev/gpiochip* for arlowe-face (WhisPlay SPI chip-select)
 #   spi     — /dev/spidev* for arlowe-face (WhisPlay LCD panel)
-#   dialout — possibly arlowe-voice (codec control via UART/I2C on some HATs); cheap to grant
-#   video   — /dev/fb0 framebuffer for arlowe-face; speculative (plan 05 confirms on hardware)
-for grp in audio gpio spi dialout video; do
+# dialout + video were dropped after plan 03-05 hardware verification: no /dev/fb0
+# (WhisPlay is SPI, not framebuffer) and the WM8960 codec is I2C/in-kernel, so the
+# voice service opens no serial device. See 03-05-SUMMARY.md.
+for grp in audio gpio spi; do
     if getent group "${grp}" >/dev/null 2>&1; then
         usermod -aG "${grp}" arlowe
     fi

--- a/tests/phase-3/assertions/01-user-shape.sh
+++ b/tests/phase-3/assertions/01-user-shape.sh
@@ -24,17 +24,11 @@ test "${actual_home}" = "${ARLOWE_HOME}" || fail "HOME wrong: expected ${ARLOWE_
 actual_shell="$(getent passwd "${ARLOWE_USER}" | cut -d: -f7)"
 test "${actual_shell}" = "/usr/sbin/nologin" || fail "shell wrong: expected /usr/sbin/nologin, got ${actual_shell}"
 
-# founder identity must not exist — this assertion is about a specific banned identity,
-# not the runtime user, so it stays a literal check
-getent passwd focal55 >/dev/null 2>&1 && fail "founder user 'focal55' present in passwd" || true
-
-# required supplementary groups
+# required supplementary groups (dialout + video dropped per plan 03-05 — confirmed
+# unused on hardware; founder-absence moved to 06-image-sanitization.sh so this
+# script is reusable against a dev Pi via ARLOWE_USER override)
 id -nG "${ARLOWE_USER}" | grep -qw audio || fail "${ARLOWE_USER} missing audio group"
 id -nG "${ARLOWE_USER}" | grep -qw gpio  || fail "${ARLOWE_USER} missing gpio group"
 id -nG "${ARLOWE_USER}" | grep -qw spi   || fail "${ARLOWE_USER} missing spi group"
-
-# Speculative; plan 05 confirms on hardware. Remove if plan 05 finds unnecessary.
-id -nG "${ARLOWE_USER}" | grep -qw dialout || fail "${ARLOWE_USER} missing dialout group"
-id -nG "${ARLOWE_USER}" | grep -qw video   || fail "${ARLOWE_USER} missing video group"
 
 echo "SC1: PASS"

--- a/tests/phase-3/assertions/06-image-sanitization.sh
+++ b/tests/phase-3/assertions/06-image-sanitization.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Image-only sanitization assertion: the founder identity must NOT be present on a
+# shipped image. Split out of 01-user-shape.sh (plan 03-05) because that check is
+# inherently false on the founder's own dev Pi, which broke 01's reuse by the
+# staging harness. This assertion runs in the Docker testbed and the Phase 6 image
+# build — NOT against a dev Pi (where focal55 legitimately exists).
+set -euo pipefail
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+echo "SC-image: checking founder identity is absent"
+
+getent passwd focal55 >/dev/null 2>&1 \
+    && fail "founder user 'focal55' present in passwd — image not sanitized"
+[ ! -d /home/focal55 ] \
+    || fail "founder home /home/focal55 present — image not sanitized"
+
+echo "SC-image: PASS"


### PR DESCRIPTION
Closes #73. Phase 4 least-privilege cleanup from the 03-05 hardware run.

## Changes
- `install-arlowe-user.sh`: granted groups `{audio, gpio, spi, dialout, video}` → `{audio, gpio, spi}`.
- `01-user-shape.sh`: drops the `dialout`/`video` group assertions and the bundled founder-absence check.
- **new** `06-image-sanitization.sh`: the founder-absence check, as an image-only assertion (runs in Docker/image, excluded from the dev-Pi staging harness).
- `.sanitize-allowlist`: drop `01` (no longer carries `focal55`), add `06`.

## Why
03-05 hardware verification: `/dev/fb0` absent (WhisPlay is SPI, not framebuffer) and the WM8960 codec is I2C/in-kernel (voice holds no serial fd) → `video` + `dialout` are dead grants. And `01`'s founder-absence check can't pass on the founder's own dev Pi, which broke its reuse by the staging harness.

## Verification
Re-ran the staging harness on `arlowe-1`: **SC1 now PASS** (previously aborted on the founder check), `arlowe-staging` granted only `{audio,gpio,spi}`, SC2 + SC4 still green. Docker testbed not run locally (no Docker on this host) — CI covers it; `06` is auto-discovered by `run-tests.sh`'s `assertions/*.sh` glob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)