### PR TITLE
fix(provision): tighten Axera NPU nodes to 0660 root:arlowe; correct gpiochip comment (#74, #75)

### DIFF
--- a/docs/operations/phase-3-staging.md
+++ b/docs/operations/phase-3-staging.md
@@ -72,17 +72,39 @@ cannot pass on the founder's own dev Pi. See follow-ups.
 | gpiochip0 vs gpiochip4? | `/dev/gpiochip4` is a symlink → `gpiochip0`; `/dev/gpiomem` absent on this kernel; WhisPlay opens `gpiochip0` | narrow DeviceAllow to `gpiochip0`; the gpiomem udev line is a no-op here |
 | axcl deb conflict? | deb ships `/etc/udev/rules.d/axcl_host.rules` setting `axcl_host`/`ax_mmb_dev` to `0666 root:root`; it sorts **after** our `90-arlowe-axera.rules`, so the deb wins — our rule is inert on real hw, and `0666` is looser than our intended `0660 root:arlowe` | rename ours to sort last (`95-`/`99-`) or reconcile |
 
-## Decisions for follow-up (Phase 4 cleanup)
+## Decisions for follow-up (Phase 4 cleanup) — resolved 2026-06-07 (issues #73–#75)
 
-1. Drop `video` and `dialout` from `install-arlowe-user.sh`; tighten the granted
-   set to `{audio, gpio, spi}`. Update `01-user-shape.sh` group checks to match.
-2. Narrow the gpiochip `DeviceAllow` in `units/arlowe-face.service` to
-   `/dev/gpiochip0`; drop the dead `/dev/gpiomem` udev line.
-3. Split the founder-absence check out of `01-user-shape.sh` into an image-only
-   assertion so 01 is cleanly reusable by the staging harness.
-4. Rename `90-arlowe-axera.rules` to sort after the axcl deb's `axcl_host.rules`
-   (or reconcile the two), and decide whether `0666 root:root` on the NPU node is
-   acceptable or should be tightened to `0660 root:arlowe`.
+1. **Done (#73, PR #76):** dropped `video` + `dialout` from `install-arlowe-user.sh`
+   (granted set now `{audio, gpio, spi}`); `01-user-shape.sh` group checks updated.
+2. **Won't-fix (#74):** the gpiochip `DeviceAllow` is intentionally NOT narrowed and
+   the `gpiomem` line is kept. Narrowing removes no real privilege — a `DeviceAllow`
+   for a symlinked/absent node grants access to nothing — and risks breaking face on
+   a kernel that enumerates the RP1 bank differently (gpiochip4 was a symlink to
+   gpiochip0 on one boot and absent on another). The misleading "primary GPIO bank"
+   comment in `91-arlowe-gpio-spi.rules` was corrected instead.
+3. **Done (#73, PR #76):** founder-absence check split into image-only
+   `06-image-sanitization.sh`; `01` is now dev-Pi-reusable.
+4. **Done (#75):** NPU nodes tightened to **`0660 root:arlowe`** on the image. The
+   deb's `axcl_host.rules` turned out to be a packaging bug — an unsubstituted
+   `GROUP="<users>"` placeholder + `0666`, which is the actual cause of the
+   `root:root 0666` nodes. Rather than out-sort a broken rule by filename (which
+   would also break the staging harness's `9X-` naming), `install-arlowe-udev-polkit.sh`
+   removes the broken deb rule so `90-arlowe-axera.rules` governs; the rule now
+   covers all four exposed nodes (`axcl_host`, `ax_mmb_dev`, `msg_userdev`, `p2p`).
+
+   **Decision / risk-acceptance (Joe, 2026-06-07):** tighten to `0660 root:arlowe`
+   on the production image. Residual accepted: (a) `root` and the `arlowe` service
+   keep NPU access — required for the LLM; (b) the dev Pi keeps the deb's
+   `0666 root:root` (the production installer is not run there, so the daily-driver
+   LLM running as `focal55` is unaffected). Tightening costs no firmware
+   functionality — the NPU consumer runs as `arlowe` — and removes the NPU driver's
+   ioctl/DMA surface from non-`arlowe` local UIDs (defense-in-depth on a device
+   running network-facing services).
+
+   **Runtime verification deferred to Phase 6:** applying the winning rule on the dev
+   Pi would re-own the NPU away from `focal55` and break the daily-driver LLM, so it
+   can only be verified on a clean image (arlowe user, no daily-driver). This change
+   is verified syntactically + by `04-udev-polkit-shape.sh` shape assertions.
 
 ## Limits
 

--- a/provision/udev/90-arlowe-axera.rules
+++ b/provision/udev/90-arlowe-axera.rules
@@ -1,23 +1,25 @@
-# Arlowe Phase 3: Axera device permissions
-# Grants the `arlowe` group read/write to the AXCL device nodes installed by
-# axcl_host_aarch64_V3.10.2.deb. The deb itself may or may not ship udev rules
-# (see scripts/provision/extract-axcl-udev-from-deb.sh). If the deb ships
-# conflicting rules, this file's higher number (90 vs typical 60s) wins on
-# last-rule-applied semantics for matching attributes.
+# Arlowe Phase 3/4: Axera NPU device permissions — root:arlowe 0660.
 #
-# Device nodes:
-#   /dev/axcl_host  — the main AXCL host control interface (NPU access)
-#   /dev/ax_mmb_dev — the multimedia buffer interface (shared memory)
+# The axcl deb (axcl_host_aarch64_*.deb) ships its own
+# /etc/udev/rules.d/axcl_host.rules, but with an unsubstituted GROUP="<users>"
+# placeholder and MODE=0666 — a packaging bug. udev can't resolve a group named
+# "<users>", so the group assignment silently fails and the nodes end up
+# world-writable (root:root 0666). Confirmed on hardware in plan 03-05.
+# install-arlowe-udev-polkit.sh removes that broken rule so this file governs the
+# nodes. Rationale for 0660 (vs the deb's 0666) is in
+# docs/operations/phase-3-staging.md: it keeps the NPU reachable only by the
+# arlowe service + root, shrinking the local privilege-escalation surface on a
+# device that runs network-facing services.
 #
-# Required by:
-#   - arlowe-face.service (WhisPlay display driver uses NPU for face recognition)
-#   - arlowe-voice.service (uses NPU for wake-word and STT inference)
-#   - arlowe-llm.service (uses NPU for local LLM inference)
+# Covers all four nodes the deb exposes:
+#   /dev/axcl_host   — AXCL host control interface (NPU access)
+#   /dev/ax_mmb_dev  — multimedia buffer / shared NPU memory
+#   /dev/msg_userdev — AXCL message channel
+#   /dev/p2p         — AXCL peer-to-peer DMA channel
 #
-# Verified on real hardware: plan 03-05 / tests/phase-3/staging/.
-# DeviceAllow= in the unit files is necessary but not sufficient — the kernel
-# device-node permissions must also permit arlowe to open the node; this rule
-# closes that gap.
+# Required by qwen-api (LLM inference) and any arlowe service that uses the NPU.
 
-KERNEL=="axcl_host",  OWNER="root", GROUP="arlowe", MODE="0660"
-KERNEL=="ax_mmb_dev", OWNER="root", GROUP="arlowe", MODE="0660"
+KERNEL=="axcl_host",   OWNER="root", GROUP="arlowe", MODE="0660"
+KERNEL=="ax_mmb_dev",  OWNER="root", GROUP="arlowe", MODE="0660"
+KERNEL=="msg_userdev", OWNER="root", GROUP="arlowe", MODE="0660"
+KERNEL=="p2p",         OWNER="root", GROUP="arlowe", MODE="0660"

--- a/provision/udev/91-arlowe-gpio-spi.rules
+++ b/provision/udev/91-arlowe-gpio-spi.rules
@@ -6,18 +6,17 @@
 # Lite image omits 99-com.rules. Both rules produce identical permissions so
 # there is no conflict, only redundancy.
 #
-# Covers both gpiochip0 (main bank, legacy) and gpiochip4 (RP1 chip on Pi 5).
-# Research §12.4 documents the Pi 5 RP1 chip enumeration; the KERNEL wildcard
-# matches both. Plan 05 confirms which chip the WhisPlay driver actually opens.
+# The gpiochip[0-9]* wildcard intentionally matches whichever chips the kernel
+# presents. Plan 05 found this enumeration is NOT stable on the Pi 5 dev kernel
+# (6.12 rpt / trixie): the WhisPlay driver opens gpiochip0, and gpiochip4
+# is sometimes a symlink to gpiochip0 and sometimes absent across boots. The
+# broad wildcard is therefore the robust choice — do NOT narrow it to a specific
+# chip, or face breaks on a kernel that enumerates the RP1 bank differently.
 #
 # Required by:
 #   - arlowe-face.service (WhisPlay SPI LCD panel needs /dev/spidev* and gpiochip)
-#
-# Note: gpiochip0 and gpiochip4 are matched by the gpiochip[0-9]* wildcard below;
-# the individual names are listed explicitly in comments for plan 05 auditing.
 
-# gpiochip0 (main GPIO bank on Pi 4 and earlier; also present on Pi 5 as alias)
-# gpiochip4 (RP1 chip GPIO controller on Pi 5 — the primary GPIO bank on Pi 5)
+# Matches gpiochip0 (and gpiochip4 when present — symlink/alias on this kernel).
 KERNEL=="gpiochip[0-9]*", OWNER="root", GROUP="gpio", MODE="0660"
 KERNEL=="gpiomem",         OWNER="root", GROUP="gpio", MODE="0660"
 KERNEL=="spidev*",         OWNER="root", GROUP="spi",  MODE="0660"

--- a/scripts/provision/install-arlowe-udev-polkit.sh
+++ b/scripts/provision/install-arlowe-udev-polkit.sh
@@ -44,6 +44,17 @@ install -m 0644 -o root -g root "${UDEV_SRC}"/*.rules /etc/udev/rules.d/
 # Install polkit rules (mode 0644, root:root — standard for polkit rules.d).
 install -m 0644 -o root -g root "${POLKIT_SRC}"/*.rules /etc/polkit-1/rules.d/
 
+# The axcl deb ships /etc/udev/rules.d/axcl_host.rules with an unsubstituted
+# GROUP="<users>" placeholder + MODE=0666, leaving the NPU nodes world-writable
+# (root:root 0666; the bogus group silently fails). Remove that broken rule so
+# 90-arlowe-axera.rules governs the nodes (root:arlowe 0660). Guarded on the
+# placeholder so we only touch the known-broken version. See plan 03-05.
+_axcl_deb_rule=/etc/udev/rules.d/axcl_host.rules
+if [[ -f "${_axcl_deb_rule}" ]] && grep -q 'GROUP="<users>"' "${_axcl_deb_rule}"; then
+    rm -f "${_axcl_deb_rule}"
+    echo "[install-udev-polkit] removed axcl deb's broken udev rule (GROUP=\"<users>\" placeholder)"
+fi
+
 # Reload udev. In Docker containers without a running udev daemon this is a
 # no-op; the error is suppressed with a diagnostic message so CI doesn't fail.
 if command -v udevadm >/dev/null 2>&1; then

--- a/tests/phase-3/assertions/04-udev-polkit-shape.sh
+++ b/tests/phase-3/assertions/04-udev-polkit-shape.sh
@@ -75,4 +75,15 @@ grep -q 'axcl_host' /etc/udev/rules.d/90-arlowe-axera.rules \
 grep -q 'ax_mmb_dev' /etc/udev/rules.d/90-arlowe-axera.rules \
     || fail "90-arlowe-axera.rules does not cover ax_mmb_dev"
 
+# plan 03-05 found the axcl deb also exposes msg_userdev + p2p; cover all four.
+grep -q 'msg_userdev' /etc/udev/rules.d/90-arlowe-axera.rules \
+    || fail "90-arlowe-axera.rules does not cover msg_userdev"
+
+grep -q 'p2p' /etc/udev/rules.d/90-arlowe-axera.rules \
+    || fail "90-arlowe-axera.rules does not cover p2p"
+
+# all four nodes must be root:arlowe 0660 (not the deb's world-writable 0666)
+grep -qE 'GROUP="arlowe", *MODE="0660"' /etc/udev/rules.d/90-arlowe-axera.rules \
+    || fail "90-arlowe-axera.rules does not set GROUP=arlowe MODE=0660"
+
 echo "[04-udev-polkit-shape] PASS (file shape only; runtime application verified in plan 05)"


### PR DESCRIPTION
Closes #75 and #74. Phase 4 udev cleanup from the 03-05 hardware run.

## #75 — NPU node permissions
The axcl deb's `/etc/udev/rules.d/axcl_host.rules` is **broken**: an unsubstituted `GROUP="<users>"` placeholder + `MODE=0666`. udev can't resolve `<users>`, so the group silently falls back to root → the NPU nodes are world-writable `root:root 0666`. That's the real cause, not just a permissive default.

**Fix:** `install-arlowe-udev-polkit.sh` removes the broken deb rule (guarded on the `<users>` placeholder) so `90-arlowe-axera.rules` governs. Our rule is expanded to **all four** exposed nodes — `axcl_host`, `ax_mmb_dev`, `msg_userdev`, `p2p` — at **`0660 root:arlowe`**.

Why remove-the-deb-rule instead of rename-to-out-sort-it: a filename rename to beat `axcl_host.rules` lexically would also break the staging harness's `9X-arlowe-*` naming assumptions (install sed + uninstall glob). Removing the broken rule fixes the root cause without that ripple.

**Decision / risk-acceptance** (recorded in `docs/operations/phase-3-staging.md`): tighten on the production image — zero functionality cost (the LLM runs as `arlowe`), removes the NPU driver's ioctl/DMA surface from non-`arlowe` local UIDs. Residual accepted: root + arlowe keep access (required); the dev Pi keeps the deb's `0666` (production installer isn't run there, so the `focal55` daily-driver LLM is unaffected).

## #74 — gpiochip (won't narrow)
Closing the narrowing part as won't-fix: a `DeviceAllow` for a symlinked/absent node grants access to nothing, so narrowing removes no privilege — and dropping `gpiochip4`/`gpiomem` risks breaking face on a kernel that enumerates the RP1 bank differently (gpiochip4 was a symlink to gpiochip0 on one boot and absent on another). Corrected the misleading "primary GPIO bank on Pi 5" comment in `91-arlowe-gpio-spi.rules` instead; kept the robust `gpiochip[0-9]*` wildcard.

## Verification
`bash -n` clean; sanitize gate green; `04-udev-polkit-shape.sh` extended to assert all four nodes + `0660 root:arlowe`. **Runtime perms verification is deferred to Phase 6** — applying the winning rule on the dev Pi would re-own the NPU away from `focal55` and break the daily-driver LLM, so it's only safely verifiable on a clean image. Docker testbed not run locally (no Docker here); CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)