### PR TITLE
docs(04): Phase 4 (config overlay) — research + 4 plans + Phase 3 state sync

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -11,8 +11,8 @@ Twelve phases take the runtime from "lives on the founder's dev unit inside a pr
 - Decimal phases (e.g., 2.1): Reserved for urgent insertions during execution
 
 - [x] **Phase 1: Runtime extraction** - Carve `whisplay/` and `arlowe-dashboard/` out of `iol-monorepo` into `runtime/`; vendor `ax-llm`; pin Axera kernel module (complete 2026-05-17, qualified — SC4 hardware loop deferred per plan 13)
-- [ ] **Phase 2: Sanitization gate** - CI grep gate fails the build on any banned literal; founder-only services blocked at image-build time; UI snapshot test enforces no-founder copy
-- [ ] **Phase 3: Service user and filesystem layout** - Dedicated `arlowe` system user; code at `/opt/arlowe/`; state at `/var/lib/arlowe/`; system-level systemd units with sandboxing
+- [x] **Phase 2: Sanitization gate** - CI grep gate fails the build on any banned literal; founder-only services blocked at image-build time; UI snapshot test enforces no-founder copy (complete 2026-05-27)
+- [x] **Phase 3: Service user and filesystem layout** - Dedicated `arlowe` system user; code at `/opt/arlowe/`; state at `/var/lib/arlowe/`; system-level systemd units with sandboxing (complete 2026-06-07, passed-with-notes — SC4 verified on real hardware via plan 03-05 staging harness; Phase-4 cleanups #73–#75 already merged: groups tightened to {audio,gpio,spi}, NPU nodes 0660 root:arlowe)
 - [ ] **Phase 4: Config overlay** - Schema-validated `defaults.yml` + `/etc/arlowe/config.yml` overlay; every personal literal flows through config
 - [ ] **Phase 5: Audio device auto-detection** - USB audio enumerated at boot; owner override via dashboard; loopback verification in boot-check
 - [ ] **Phase 6: Image build with A/B partitions** - pi-gen pipeline produces a flashable `.img` with A/B system partitions and shared owner-state partition
@@ -97,11 +97,11 @@ Plans:
 **Plans**: 5 plans
 
 Plans:
-- [ ] 03-01-PLAN.md — Provisioning scripts (install-arlowe-user + install-arlowe-fs) + Docker testbed + SC1/SC2 assertions + layout-reference doc (Wave 1, foundational; OTA-01 amendment noted)
-- [ ] 03-02-PLAN.md — Six systemd unit files + install-units.sh + SC3 assertions (systemd-analyze verify + security) (Wave 2, depends on 03-01)
-- [ ] 03-03-PLAN.md — Udev rules (Axera + GPIO/SPI defense-in-depth) + polkit rule (arlowe→systemctl arlowe-*) + axcl-deb diagnostic (Wave 2, depends on 03-01; parallel with 03-02)
-- [ ] 03-04-PLAN.md — CLI symlinks installer + boot-check ARLOWE_SYSTEMCTL_FLAGS default flip to system-level (Wave 2, depends on 03-01; parallel with 03-02, 03-03)
-- [ ] 03-05-PLAN.md — arlowe-1 staging-user harness: install/uninstall, SC4 sandbox write-deny on real hardware, speculative-group + gpiochip resolution (Wave 3; non-autonomous, depends on 03-01..04)
+- [x] 03-01-PLAN.md — Provisioning scripts (install-arlowe-user + install-arlowe-fs) + Docker testbed + SC1/SC2 assertions + layout-reference doc (Wave 1, foundational; OTA-01 amendment noted)
+- [x] 03-02-PLAN.md — Six systemd unit files + install-units.sh + SC3 assertions (systemd-analyze verify + security) (Wave 2, depends on 03-01)
+- [x] 03-03-PLAN.md — Udev rules (Axera + GPIO/SPI defense-in-depth) + polkit rule (arlowe→systemctl arlowe-*) + axcl-deb diagnostic (Wave 2, depends on 03-01; parallel with 03-02)
+- [x] 03-04-PLAN.md — CLI symlinks installer + boot-check ARLOWE_SYSTEMCTL_FLAGS default flip to system-level (Wave 2, depends on 03-01; parallel with 03-02, 03-03)
+- [x] 03-05-PLAN.md — arlowe-1 staging-user harness: install/uninstall, SC4 sandbox write-deny on real hardware, speculative-group + gpiochip resolution (Wave 3; non-autonomous, depends on 03-01..04)
 
 ### Phase 4: Config overlay
 
@@ -117,7 +117,13 @@ Plans:
   3. Absent `/etc/arlowe/config.yml` is a recognized state that signals "not yet paired" (consumed in Phase 8); no service crashes or loops in this state.
   4. The dashboard writes the overlay atomically (temp file + rename), and at least one knob change end-to-end (e.g., persona) restarts the affected service and takes effect on the next interaction.
 
-**Plans**: TBD
+**Plans**: 4 plans
+
+Plans:
+- [ ] 04-01-PLAN.md — schema.yml + defaults.yml + shared Python loader/validator + tests + docs/04-scope.md (Wave 1, foundational)
+- [ ] 04-02-PLAN.md — ADR 0003 loosen-perms + /etc/arlowe 0770 + dashboard ReadWritePaths + install-arlowe-config.sh + install-shape assertion (Wave 2, package:security, depends on 04-01)
+- [ ] 04-03-PLAN.md — dashboard ajv validate-before-write + atomic write + knob->unit restart map/trigger + test (Wave 2, depends on 04-01; parallel with 04-02)
+- [ ] 04-04-PLAN.md — persona live slice: face consumes YAML overlay + ExecStartPre fail-fast validators + SC4 human-verify checkpoint (Wave 3; non-autonomous, depends on 04-01..03)
 
 ### Phase 5: Audio device auto-detection
 
@@ -263,8 +269,8 @@ Phases execute in numeric order: 1 -> 2 -> 3 -> 4 -> 5 -> 6 -> 7 -> 8 -> 9 -> 10
 |-------|----------------|--------|-----------|
 | 1. Runtime extraction | 15/15 | Complete (qualified — SC4 hardware loop deferred to Phase 12; see plan 13 SUMMARY F1-F4) | 2026-05-17 |
 | 2. Sanitization gate | 4/4 | Complete | 2026-05-27 |
-| 3. Service user and filesystem layout | 0/5 | Planned | - |
-| 4. Config overlay | 0/TBD | Not started | - |
+| 3. Service user and filesystem layout | 5/5 | Complete (passed-with-notes; #73–#75 cleanups merged) | 2026-06-07 |
+| 4. Config overlay | 0/4 | ◆ Planning | - |
 | 5. Audio device auto-detection | 0/TBD | Not started | - |
 | 6. Image build with A/B partitions | 0/TBD | Not started | - |
 | 7. Device identity and PKI | 0/TBD | Not started | - |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -5,16 +5,16 @@
 See: .planning/PROJECT.md (updated 2026-04-30)
 
 **Core value:** A factory-fresh Pi 5 + AX accelerator + Whisplay can flash this image, boot, pair to an owner, and run wake -> STT -> LLM -> TTS -> face entirely on-device, with no founder identity present anywhere in the image.
-**Current focus:** Phase 2 complete. Phase 3 (service user and filesystem layout) planned, ready to execute.
+**Current focus:** Phase 3 (service user and filesystem layout) complete, passed-with-notes (#73–#75 cleanups merged). Phase 4 (config overlay) is next — planning now.
 
 ## Current Position
 
-Phase: 2 of 12 (Sanitization gate) — COMPLETE
-Plan: 4 of 4 in Phase 2
-Status: Phase 2 closed 2026-05-27. All four SC criteria met (grep gate, units gate, dashboard Playwright gate, runtime/ zero banned literals). Phase 3 plans (5) and research committed in this PR.
-Last activity: 2026-05-27 -- Phase 2 PRs #58-#61 all merged; Phase 3 plans ready to seed as issues via /issue-from-plan 3
+Phase: 3 of 12 (Service user and filesystem layout) — COMPLETE (passed-with-notes)
+Plan: 5 of 5 in Phase 3
+Status: Phase 3 closed 2026-06-07. SC1–3 via Docker testbed; SC4 verified on REAL hardware via the arlowe-1 staging harness (plan 03-05). Phase-4 cleanups #73–#75 already merged: supplementary groups tightened to {audio,gpio,spi}; Axera NPU nodes → 0660 root:arlowe (broken axcl-deb rule removed by installer); founder-absence check split into image-only 06-image-sanitization.sh.
+Last activity: 2026-06-07 -- PRs #68–#72 (Phase 3) + #76–#77 (cleanups) merged; sanitize gate green on main; planning Phase 4.
 
-Progress: Phase 1 [██████████] 100% qualified; Phase 2 [██████████] 100% complete; Phase 3 [░░░░░░░░░░] 0/5 planned
+Progress: Phase 1 [██████████] 100% qualified; Phase 2 [██████████] 100%; Phase 3 [██████████] 100% complete; Phase 4 [░░░░░░░░░░] planning
 
 ## Performance Metrics
 
@@ -28,7 +28,8 @@ Progress: Phase 1 [██████████] 100% qualified; Phase 2 [█�
 |-------|-------|------|--------|
 | 1 | 15 | 15 | Complete (qualified) |
 | 2 | 4 | 4 | Complete |
-| 3 | 5 | 0 | Planned |
+| 3 | 5 | 5 | Complete (passed-with-notes) |
+| 4 | TBD | 0 | Planning |
 
 **Recent Trend (Phase 2):**
 - 02-01: grep gate runner, allow-list, CI workflow (#58)
@@ -49,6 +50,9 @@ Recent decisions affecting current work:
 - **WhisPlay driver**: PiSugar (Apache 2.0). Strategy A — vendor at image build (Phase 6).
 - **ax-llm submodule**: pinned at `df75c34c…` on `axcl-context` branch.
 - **axcl deb**: SHA-256 pinned in `third_party/axcl/manifest.yml`, never committed (Strategy C). `scripts/verify-third-party.sh` gates.
+- **Phase 3 layout** (resolved): `arlowe` system user (uid<1000, HOME=/var/lib/arlowe, nologin); code root-owned at `/opt/arlowe`, state at `/var/lib/arlowe`; six system-level units with PrivateTmp/ProtectSystem=strict/ReadWritePaths sandboxing; CLI symlinks at `/usr/local/sbin/arlowe-*`; udev (gpio/spi/axera) + polkit (arlowe→systemctl arlowe-*/qwen-*/whisper-stt) rules. SC4 (write-deny outside /var/lib/arlowe) verified on real hardware.
+- **Phase 3 group set** (resolved #73): the `arlowe` *user* is created with supplementary groups {audio, gpio, spi} only; `video`+`dialout` dropped (unused on hardware — no /dev/fb0, WM8960 codec is I2C/in-kernel). **Residual debt:** `units/arlowe-face.service` still declares `SupplementaryGroups=gpio spi video` + `DeviceAllow=/dev/fb0` — #73 fixed the user-creation + assertions but missed the unit, so the face *service process* still gets `video` at runtime. Tracked for cleanup (see todos / new issue); intentionally NOT touched by Phase 4.
+- **Axera NPU perms** (resolved #75): nodes 0660 root:arlowe; `install-arlowe-udev-polkit.sh` removes the axcl deb's broken `GROUP="<users>"` rule. Runtime verification deferred to Phase 6 image (can't verify on the focal55 dev Pi without breaking the daily-driver LLM).
 
 ### Pending Todos
 
@@ -72,6 +76,6 @@ Workforce-infra debt tracked in Claude's memory store:
 
 ## Session Continuity
 
-Last session: 2026-05-27
-Stopped at: Phase 2 closed. Phase 3 research + 5 plans drafted and committed. Branch `chore/phase-3-seed` opened to land planning artifacts. Next step: merge this PR, then run `/issue-from-plan 3` to populate board for workforce-tick dispatch.
-Resume file: branch `chore/phase-3-seed`, `.planning/phases/03-service-user-and-filesystem-layout/`
+Last session: 2026-06-07
+Stopped at: Phase 3 fully complete (5 plans merged via PRs #68–#72; SC4 hardware-verified). Phase-4 cleanups #73–#75 merged; sanitize gate green on main. Now planning Phase 4 (config overlay).
+Resume file: `.planning/phases/04-config-overlay/` (being created)

--- a/.planning/phases/04-config-overlay/04-01-PLAN.md
+++ b/.planning/phases/04-config-overlay/04-01-PLAN.md
@@ -1,0 +1,158 @@
+---
+phase: 04-config-overlay
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - config/schema.yml
+  - config/defaults.yml
+  - runtime/lib/arlowe_config.py
+  - runtime/lib/arlowe_config_validate.py
+  - runtime/lib/requirements.txt
+  - runtime/lib/tests/test_arlowe_config.py
+  - docs/04-scope.md
+autonomous: true
+requirements_covered: [CONFIG-01, CONFIG-02, CONFIG-04]
+must_haves:
+  truths:
+    - "config/schema.yml defines every CONFIG-06 knob with type, default, allowed values, and a description"
+    - "config/defaults.yml provides a value for every required knob and contains zero founder literals"
+    - "A merged defaults+overlay dict validates against the schema; a schema violation raises SystemExit(78) with a greppable stderr line"
+    - "Absent /etc/arlowe/config.yml is handled as a non-error state (returns defaults, no crash)"
+  artifacts:
+    - path: "config/schema.yml"
+      provides: "JSON-Schema-in-YAML defining all knobs (CONFIG-01)"
+      contains: "$schema"
+      min_lines: 60
+    - path: "config/defaults.yml"
+      provides: "Shipped defaults for every knob (CONFIG-02)"
+      min_lines: 20
+    - path: "runtime/lib/arlowe_config.py"
+      provides: "load() -> validated merged dict; SystemExit(78) on violation"
+      exports: ["load"]
+    - path: "runtime/lib/arlowe_config_validate.py"
+      provides: "python -m arlowe_config_validate standalone ExecStartPre validator"
+    - path: "runtime/lib/tests/test_arlowe_config.py"
+      provides: "Unit tests for merge, validation, absent-overlay, EX_CONFIG"
+  key_links:
+    - from: "runtime/lib/arlowe_config.py"
+      to: "config/schema.yml"
+      via: "Draft202012Validator reads ARLOWE_SCHEMA_PATH"
+      pattern: "Draft202012Validator"
+    - from: "runtime/lib/arlowe_config_validate.py"
+      to: "runtime/lib/arlowe_config.py"
+      via: "imports load()"
+      pattern: "from arlowe_config import|import arlowe_config"
+---
+
+<objective>
+Author the single source-of-truth config schema, the shipped defaults, and the shared Python loader/validator that every runtime service will use. This is the foundation Plans 04-02/03/04 build on.
+
+Purpose: Satisfies CONFIG-01 (schema defines every knob), CONFIG-02 (defaults ship for every knob), and CONFIG-04 (runtime loads + validates + fails fast). One schema file is consumed by both Python (jsonschema) and, later, the dashboard (ajv).
+Output: config/schema.yml, config/defaults.yml, runtime/lib/arlowe_config.py (+ standalone validator), tests, and docs/04-scope.md.
+</objective>
+
+<execution_context>
+@~/.claude/get-shit-done/workflows/execute-plan.md
+@~/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/phases/04-config-overlay/04-RESEARCH.md
+@.planning/REQUIREMENTS.md
+
+# Reference implementations and current literals (read these — the knobs map to existing env vars)
+@runtime/face/sentiment_classifier.py
+@runtime/voice/voice_client.py
+@.sanitize-allowlist
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Author schema.yml + defaults.yml from the CONFIG-06 knob inventory</name>
+  <files>config/schema.yml, config/defaults.yml, docs/04-scope.md</files>
+  <action>
+Create `config/schema.yml` as JSON-Schema-in-YAML (draft 2020-12). Use `$schema: "https://json-schema.org/draft/2020-12/schema"`, `type: object`, `additionalProperties: false`, a top-level `properties` map, and a `required` list. Each knob MUST carry `type`, `default`, `description`, and `enum` where a closed value set applies (CONFIG-01).
+
+Define exactly these top-level knobs (the CONFIG-06 inventory from 04-RESEARCH.md "Knob Inventory" table; group structured ones as nested objects):
+
+- `device`:
+  - `hostname` (string, default `"arlowe-${device_serial}"`, description: resolved at pairing in Phase 7/8). NOTE: keep the `${device_serial}` template literal exactly — it is NOT a founder literal and must never be a concrete hostname.
+- `audio` (Phase 5 owns detection; Phase 4 only defines the knobs):
+  - `capture_device` (string, default `"auto"`, description: ALSA capture device or "auto")
+  - `playback_device` (string, default `"auto"`, description: ALSA playback device or "auto")
+- `model`:
+  - `choice` (string, `enum: ["qwen2.5-7b-int4-ax650", "qwen2.5-1.5b-int4-ax650"]`, default `"qwen2.5-7b-int4-ax650"`, description: which Qwen model dir under /opt/arlowe/models)
+- `persona`:
+  - `sentiment_mapping` (object, default mirrors `DEFAULT_MAPPING` in sentiment_classifier.py: `{positive: ["happy","excited"], negative: ["concerned","sad"], neutral: ["idle","attentive"]}`, description: sentiment->expression mapping consumed by arlowe-face)
+- `ports`:
+  - `face` (integer, default `8080`, description: face service TCP port — resolves F1 todo's config knob)
+  - `stt` (integer, default `8082`)
+  - `dashboard` (integer, default `3000`)
+- `logs`:
+  - `transcript_retention_days` (integer, default `7`, description: voice transcript retention; consumed in Phase 11)
+  - `transcript_logging_enabled` (boolean, default `true`)
+- `support_mode` (defined-but-not-yet-consumed; Phase 10):
+  - `enabled` (boolean, default `false`)
+  - `window_hours` (integer, default `24`, description: 1..168)
+- `ota` (defined-but-not-yet-consumed; Phase 9):
+  - `channel` (string, `enum: ["stable","beta","off"]`, default `"stable"`)
+  - `channel_url` (string, default `""`, description: signed-manifest CDN base URL; empty until set at pairing)
+
+Add a top-of-file comment block documenting: (1) merge is SHALLOW at top-level, DEEP for nested objects like `persona.sentiment_mapping` (overlay sub-keys merge, siblings preserved) — Pitfall 5; (2) absent overlay returns defaults unchanged.
+
+Create `config/defaults.yml` with a value for EVERY knob above, matching each schema `default`. CRITICAL (Pitfall 3): zero founder literals — `device.hostname` MUST be the literal string `arlowe-${device_serial}`, never `arlowe-1`; no `focal55`, no `casa_ybarra_chelsea`, no `joe@focal55`, no ElevenLabs/API keys. These two files SHIP in the image and will be scanned by the Phase 2 sanitize gate — do NOT add them to `.sanitize-allowlist`.
+
+Create `docs/04-scope.md`: a short doc (resolves CONFIG-02's dangling reference). State that `config/schema.yml` is the canonical, authoritative list of config knobs and that this scope doc points to it rather than duplicating the inventory. Include the knob table (knob -> requirement -> consuming phase) so the cross-phase ownership is recorded. Note that `support_mode`, `ota`, and most of `device.hostname` are DEFINED here but CONSUMED in Phases 7-10. `docs/` is allow-listed for the sanitize gate, but still avoid concrete founder literals out of habit.
+  </action>
+  <verify>
+`python3 -c "import yaml,json; s=yaml.safe_load(open('config/schema.yml')); d=yaml.safe_load(open('config/defaults.yml')); from jsonschema import Draft202012Validator; Draft202012Validator.check_schema(s); errs=list(Draft202012Validator(s).iter_errors(d)); print('OK' if not errs else errs)"` prints `OK`.
+Run the repo sanitize gate against the two new files: `bash scripts/sanitize/*.sh` equivalent — confirm `git grep -nE 'focal55|arlowe-1|casa_ybarra_chelsea|/home/focal55|joe@focal55|iol-monorepo' config/` returns nothing (the only `arlowe-` token present must be `arlowe-${device_serial}`).
+  </verify>
+  <done>schema.yml is a valid draft-2020-12 schema; defaults.yml validates clean against it; every CONFIG-06 knob is present with type+default+description (+enum where applicable); zero founder literals; docs/04-scope.md cites schema.yml as canonical.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Implement shared loader + standalone validator + tests</name>
+  <files>runtime/lib/arlowe_config.py, runtime/lib/arlowe_config_validate.py, runtime/lib/requirements.txt, runtime/lib/tests/test_arlowe_config.py</files>
+  <action>
+Create `runtime/lib/arlowe_config.py` implementing the Pattern 1 loader from 04-RESEARCH.md:
+- Paths from env with defaults: `ARLOWE_DEFAULTS_PATH=/opt/arlowe/config/defaults.yml`, `ARLOWE_CONFIG_PATH=/etc/arlowe/config.yml`, `ARLOWE_SCHEMA_PATH=/opt/arlowe/config/schema.yml`.
+- `load() -> dict`: parse defaults with `yaml.safe_load`; if the overlay path exists, parse it, else use `{}` (absent overlay == not-yet-paired, NO error — SC3). Merge: shallow at top level, but DEEP-merge nested dict values (so `persona.sentiment_mapping` overlay sub-keys merge over defaults; document the helper). Validate merged dict with `Draft202012Validator(schema).iter_errors`; on any error, print each as `[arlowe-config] schema violation at <path>: <message>` to stderr and `raise SystemExit(78)` (EX_CONFIG). Return the merged dict on success.
+- Provide a `deep_merge(base, overlay)` helper used by load().
+- Never use `yaml.load` (unsafe) — only `yaml.safe_load`.
+
+Create `runtime/lib/arlowe_config_validate.py` as the ExecStartPre entry point (Pattern 2): `python -m arlowe_config_validate` imports `arlowe_config` and calls `load()`, printing `[arlowe-config] OK` on success and propagating SystemExit(78) on violation. It must be runnable both as `python -m arlowe_config_validate` (when `runtime/lib` is on PYTHONPATH) — units set `PYTHONPATH=/opt/arlowe/runtime`, so the installer in 04-02 will place this lib at an importable location; for now make it import-robust (handle both `from arlowe_config import load` and package-relative).
+
+Create `runtime/lib/requirements.txt` pinning `jsonschema` (4.x) and `PyYAML` (==6.0.3 to match runtime/tts/requirements.txt). This file is NOT allow-listed; if you add a provenance comment, keep it founder-literal-free.
+
+Create `runtime/lib/tests/test_arlowe_config.py` (pytest) covering:
+1. defaults-only load (no overlay file) returns a dict equal to parsed defaults.yml.
+2. absent overlay does NOT raise (SC3).
+3. a valid overlay that changes `persona.sentiment_mapping.positive` deep-merges (siblings like `neutral` preserved).
+4. an overlay violating an enum (e.g. `ota.channel: "purple"`) raises `SystemExit` with code 78.
+5. an overlay with a wrong type (e.g. `ports.face: "nope"`) raises SystemExit(78).
+Tests must set the three ARLOWE_*_PATH env vars to tmp files / the repo's config/ so they run without /opt or /etc.
+  </action>
+  <verify>From repo root: `PYTHONPATH=runtime/lib ARLOWE_SCHEMA_PATH=config/schema.yml ARLOWE_DEFAULTS_PATH=config/defaults.yml ARLOWE_CONFIG_PATH=/nonexistent python3 -m arlowe_config_validate` prints `[arlowe-config] OK` and exits 0. Then `cd runtime/lib && python3 -m pytest tests/ -q` passes all cases (including the two SystemExit(78) cases).</verify>
+  <done>load() returns a validated merged dict; absent overlay is non-fatal; enum/type violations raise SystemExit(78) with a greppable stderr line; standalone `-m arlowe_config_validate` works for ExecStartPre; all pytest cases green.</done>
+</task>
+
+</tasks>
+
+<verification>
+- `config/schema.yml` is a valid draft-2020-12 schema and `config/defaults.yml` validates against it.
+- Sanitize gate clean on `config/` (only `arlowe-${device_serial}` template present).
+- `python3 -m arlowe_config_validate` exits 0 with defaults; exits 78 on a deliberately bad overlay.
+- pytest suite green.
+</verification>
+
+<success_criteria>
+CONFIG-01, CONFIG-02, and the loader half of CONFIG-04 are satisfied: every knob defined with type/default/allowed-values/docstring; defaults ship clean; merged config validates and fails fast with EX_CONFIG on violation; absent overlay is a recognized non-error state.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/04-config-overlay/04-01-SUMMARY.md`.
+</output>

--- a/.planning/phases/04-config-overlay/04-01-PLAN.md
+++ b/.planning/phases/04-config-overlay/04-01-PLAN.md
@@ -20,6 +20,7 @@ must_haves:
     - "config/defaults.yml provides a value for every required knob and contains zero founder literals"
     - "A merged defaults+overlay dict validates against the schema; a schema violation raises SystemExit(78) with a greppable stderr line"
     - "Absent /etc/arlowe/config.yml is handled as a non-error state (returns defaults, no crash)"
+    - "A partial persona overlay (only persona.sentiment_mapping.positive set) deep-merges and preserves sibling keys (neutral, negative) — the contract 04-04 SC4 depends on"
   artifacts:
     - path: "config/schema.yml"
       provides: "JSON-Schema-in-YAML defining all knobs (CONFIG-01)"
@@ -34,7 +35,7 @@ must_haves:
     - path: "runtime/lib/arlowe_config_validate.py"
       provides: "python -m arlowe_config_validate standalone ExecStartPre validator"
     - path: "runtime/lib/tests/test_arlowe_config.py"
-      provides: "Unit tests for merge, validation, absent-overlay, EX_CONFIG"
+      provides: "Unit tests for merge, validation, absent-overlay, partial-persona deep-merge, EX_CONFIG"
   key_links:
     - from: "runtime/lib/arlowe_config.py"
       to: "config/schema.yml"
@@ -86,7 +87,8 @@ Define exactly these top-level knobs (the CONFIG-06 inventory from 04-RESEARCH.m
 - `model`:
   - `choice` (string, `enum: ["qwen2.5-7b-int4-ax650", "qwen2.5-1.5b-int4-ax650"]`, default `"qwen2.5-7b-int4-ax650"`, description: which Qwen model dir under /opt/arlowe/models)
 - `persona`:
-  - `sentiment_mapping` (object, default mirrors `DEFAULT_MAPPING` in sentiment_classifier.py: `{positive: ["happy","excited"], negative: ["concerned","sad"], neutral: ["idle","attentive"]}`, description: sentiment->expression mapping consumed by arlowe-face)
+  - `sentiment_mapping` (object, default mirrors `DEFAULT_MAPPING` in sentiment_classifier.py: `{positive: ["happy","excited"], negative: ["concerned","sad"], neutral: ["idle","attentive"]}`, description: sentiment->expression mapping consumed by arlowe-face).
+    CROSS-PLAN CONTRACT (04-04 SC4 depends on this — do NOT tighten it): the `sentiment_mapping` object MUST leave its sub-keys (`positive`/`negative`/`neutral`) individually OPTIONAL. Do NOT put a `required` list inside `sentiment_mapping`, and do NOT set `additionalProperties: false` on it. Each sub-key may be schema'd as `type: array, items: {type: string}` but none may be required. Rationale: 04-04's SC4 demo writes an overlay that sets ONLY `persona.sentiment_mapping.positive` and expects the loader's deep-merge to preserve `neutral`/`negative` from defaults, then validate the merged result. An inner `required`/`additionalProperties:false` would either reject the partial overlay outright or force callers to send all three — breaking the persona slice. The loader merges-then-validates (defaults+overlay deep-merged first, then validated as one dict), so the merged dict will always carry all three sub-keys; the schema just must not demand they appear in the raw overlay.
 - `ports`:
   - `face` (integer, default `8080`, description: face service TCP port — resolves F1 todo's config knob)
   - `stt` (integer, default `8082`)
@@ -101,7 +103,7 @@ Define exactly these top-level knobs (the CONFIG-06 inventory from 04-RESEARCH.m
   - `channel` (string, `enum: ["stable","beta","off"]`, default `"stable"`)
   - `channel_url` (string, default `""`, description: signed-manifest CDN base URL; empty until set at pairing)
 
-Add a top-of-file comment block documenting: (1) merge is SHALLOW at top-level, DEEP for nested objects like `persona.sentiment_mapping` (overlay sub-keys merge, siblings preserved) — Pitfall 5; (2) absent overlay returns defaults unchanged.
+Add a top-of-file comment block documenting: (1) merge is SHALLOW at top-level, DEEP for nested objects like `persona.sentiment_mapping` (overlay sub-keys merge, siblings preserved) — Pitfall 5; (2) absent overlay returns defaults unchanged; (3) `sentiment_mapping` sub-keys are intentionally optional (the 04-04 partial-overlay contract above) so a persona overlay can set one sentiment without re-sending all three.
 
 Create `config/defaults.yml` with a value for EVERY knob above, matching each schema `default`. CRITICAL (Pitfall 3): zero founder literals — `device.hostname` MUST be the literal string `arlowe-${device_serial}`, never `arlowe-1`; no `focal55`, no `casa_ybarra_chelsea`, no `joe@focal55`, no ElevenLabs/API keys. These two files SHIP in the image and will be scanned by the Phase 2 sanitize gate — do NOT add them to `.sanitize-allowlist`.
 
@@ -109,9 +111,10 @@ Create `docs/04-scope.md`: a short doc (resolves CONFIG-02's dangling reference)
   </action>
   <verify>
 `python3 -c "import yaml,json; s=yaml.safe_load(open('config/schema.yml')); d=yaml.safe_load(open('config/defaults.yml')); from jsonschema import Draft202012Validator; Draft202012Validator.check_schema(s); errs=list(Draft202012Validator(s).iter_errors(d)); print('OK' if not errs else errs)"` prints `OK`.
+Confirm the persona contract is intact: `python3 -c "import yaml; s=yaml.safe_load(open('config/schema.yml')); sm=s['properties']['persona']['properties']['sentiment_mapping']; assert 'required' not in sm, 'sentiment_mapping must not require sub-keys'; assert sm.get('additionalProperties', True) is not False, 'sentiment_mapping must not set additionalProperties:false'; print('persona-contract OK')"` prints `persona-contract OK`.
 Run the repo sanitize gate against the two new files: `bash scripts/sanitize/*.sh` equivalent — confirm `git grep -nE 'focal55|arlowe-1|casa_ybarra_chelsea|/home/focal55|joe@focal55|iol-monorepo' config/` returns nothing (the only `arlowe-` token present must be `arlowe-${device_serial}`).
   </verify>
-  <done>schema.yml is a valid draft-2020-12 schema; defaults.yml validates clean against it; every CONFIG-06 knob is present with type+default+description (+enum where applicable); zero founder literals; docs/04-scope.md cites schema.yml as canonical.</done>
+  <done>schema.yml is a valid draft-2020-12 schema; defaults.yml validates clean against it; every CONFIG-06 knob is present with type+default+description (+enum where applicable); persona.sentiment_mapping sub-keys are optional (no inner required / no additionalProperties:false); zero founder literals; docs/04-scope.md cites schema.yml as canonical.</done>
 </task>
 
 <task type="auto">
@@ -120,39 +123,42 @@ Run the repo sanitize gate against the two new files: `bash scripts/sanitize/*.s
   <action>
 Create `runtime/lib/arlowe_config.py` implementing the Pattern 1 loader from 04-RESEARCH.md:
 - Paths from env with defaults: `ARLOWE_DEFAULTS_PATH=/opt/arlowe/config/defaults.yml`, `ARLOWE_CONFIG_PATH=/etc/arlowe/config.yml`, `ARLOWE_SCHEMA_PATH=/opt/arlowe/config/schema.yml`.
-- `load() -> dict`: parse defaults with `yaml.safe_load`; if the overlay path exists, parse it, else use `{}` (absent overlay == not-yet-paired, NO error — SC3). Merge: shallow at top level, but DEEP-merge nested dict values (so `persona.sentiment_mapping` overlay sub-keys merge over defaults; document the helper). Validate merged dict with `Draft202012Validator(schema).iter_errors`; on any error, print each as `[arlowe-config] schema violation at <path>: <message>` to stderr and `raise SystemExit(78)` (EX_CONFIG). Return the merged dict on success.
+- `load() -> dict`: parse defaults with `yaml.safe_load`; if the overlay path exists, parse it, else use `{}` (absent overlay == not-yet-paired, NO error — SC3). Merge: shallow at top level, but DEEP-merge nested dict values (so `persona.sentiment_mapping` overlay sub-keys merge over defaults; document the helper). MERGE-THEN-VALIDATE ORDER IS LOAD-BEARING: deep-merge defaults+overlay FIRST, then validate the merged dict (this is why a partial persona overlay validates — the merged dict carries all three sentiment sub-keys even when the overlay only set one). Validate merged dict with `Draft202012Validator(schema).iter_errors`; on any error, print each as `[arlowe-config] schema violation at <path>: <message>` to stderr and `raise SystemExit(78)` (EX_CONFIG). Return the merged dict on success.
 - Provide a `deep_merge(base, overlay)` helper used by load().
 - Never use `yaml.load` (unsafe) — only `yaml.safe_load`.
 
-Create `runtime/lib/arlowe_config_validate.py` as the ExecStartPre entry point (Pattern 2): `python -m arlowe_config_validate` imports `arlowe_config` and calls `load()`, printing `[arlowe-config] OK` on success and propagating SystemExit(78) on violation. It must be runnable both as `python -m arlowe_config_validate` (when `runtime/lib` is on PYTHONPATH) — units set `PYTHONPATH=/opt/arlowe/runtime`, so the installer in 04-02 will place this lib at an importable location; for now make it import-robust (handle both `from arlowe_config import load` and package-relative).
+Create `runtime/lib/arlowe_config_validate.py` as the ExecStartPre entry point (Pattern 2): `python -m arlowe_config_validate` imports `arlowe_config` and calls `load()`, printing `[arlowe-config] OK` on success and propagating SystemExit(78) on violation. INFO (checker item 7): the lib lives at `/opt/arlowe/runtime/lib` as a directory of FLAT modules (not a package), so the import is a flat-module import — `from arlowe_config import load` (no package prefix). It must be runnable as `python -m arlowe_config_validate` when `/opt/arlowe/runtime/lib` is on PYTHONPATH; for local/dev keep it import-robust (try flat `from arlowe_config import load`, fall back to package-relative only if that fails).
 
 Create `runtime/lib/requirements.txt` pinning `jsonschema` (4.x) and `PyYAML` (==6.0.3 to match runtime/tts/requirements.txt). This file is NOT allow-listed; if you add a provenance comment, keep it founder-literal-free.
 
 Create `runtime/lib/tests/test_arlowe_config.py` (pytest) covering:
 1. defaults-only load (no overlay file) returns a dict equal to parsed defaults.yml.
 2. absent overlay does NOT raise (SC3).
-3. a valid overlay that changes `persona.sentiment_mapping.positive` deep-merges (siblings like `neutral` preserved).
+3. PARTIAL PERSONA OVERLAY (the 04-04 SC4 contract): an overlay that sets ONLY `persona.sentiment_mapping.positive: ["excited"]` deep-merges so the returned dict has `positive == ["excited"]` AND `neutral`/`negative` preserved from defaults, AND the merged dict validates clean (no SystemExit). This locks the contract at the foundation so 04-04 can rely on it.
 4. an overlay violating an enum (e.g. `ota.channel: "purple"`) raises `SystemExit` with code 78.
 5. an overlay with a wrong type (e.g. `ports.face: "nope"`) raises SystemExit(78).
 Tests must set the three ARLOWE_*_PATH env vars to tmp files / the repo's config/ so they run without /opt or /etc.
   </action>
-  <verify>From repo root: `PYTHONPATH=runtime/lib ARLOWE_SCHEMA_PATH=config/schema.yml ARLOWE_DEFAULTS_PATH=config/defaults.yml ARLOWE_CONFIG_PATH=/nonexistent python3 -m arlowe_config_validate` prints `[arlowe-config] OK` and exits 0. Then `cd runtime/lib && python3 -m pytest tests/ -q` passes all cases (including the two SystemExit(78) cases).</verify>
-  <done>load() returns a validated merged dict; absent overlay is non-fatal; enum/type violations raise SystemExit(78) with a greppable stderr line; standalone `-m arlowe_config_validate` works for ExecStartPre; all pytest cases green.</done>
+  <verify>From repo root: `PYTHONPATH=runtime/lib ARLOWE_SCHEMA_PATH=config/schema.yml ARLOWE_DEFAULTS_PATH=config/defaults.yml ARLOWE_CONFIG_PATH=/nonexistent python3 -m arlowe_config_validate` prints `[arlowe-config] OK` and exits 0. Then `cd runtime/lib && python3 -m pytest tests/ -q` passes all cases (including the partial-persona deep-merge case and the two SystemExit(78) cases).</verify>
+  <done>load() returns a validated merged dict; absent overlay is non-fatal; a partial persona overlay deep-merges (siblings preserved) and validates; enum/type violations raise SystemExit(78) with a greppable stderr line; standalone `-m arlowe_config_validate` works for ExecStartPre via a flat-module import; all pytest cases green.</done>
 </task>
 
 </tasks>
 
 <verification>
 - `config/schema.yml` is a valid draft-2020-12 schema and `config/defaults.yml` validates against it.
+- `persona.sentiment_mapping` sub-keys are optional (no inner required / additionalProperties:false) — the 04-04 SC4 partial-overlay contract.
 - Sanitize gate clean on `config/` (only `arlowe-${device_serial}` template present).
 - `python3 -m arlowe_config_validate` exits 0 with defaults; exits 78 on a deliberately bad overlay.
-- pytest suite green.
+- pytest suite green (including the partial-persona deep-merge case).
 </verification>
 
 <success_criteria>
-CONFIG-01, CONFIG-02, and the loader half of CONFIG-04 are satisfied: every knob defined with type/default/allowed-values/docstring; defaults ship clean; merged config validates and fails fast with EX_CONFIG on violation; absent overlay is a recognized non-error state.
+CONFIG-01, CONFIG-02, and the loader half of CONFIG-04 are satisfied: every knob defined with type/default/allowed-values/docstring; defaults ship clean; merged config validates and fails fast with EX_CONFIG on violation; absent overlay is a recognized non-error state; the persona partial-overlay deep-merge contract is locked at the foundation for 04-04.
 </success_criteria>
 
 <output>
 After completion, create `.planning/phases/04-config-overlay/04-01-SUMMARY.md`.
 </output>
+</content>
+</invoke>

--- a/.planning/phases/04-config-overlay/04-02-PLAN.md
+++ b/.planning/phases/04-config-overlay/04-02-PLAN.md
@@ -10,6 +10,7 @@ files_modified:
   - scripts/provision/install-arlowe-config.sh
   - units/arlowe-dashboard.service
   - tests/phase-4/assertions/01-config-install-shape.sh
+  - tests/phase-4/docker/run-tests.sh
 autonomous: true
 package: security
 requirements_covered: [CONFIG-02, CONFIG-03]
@@ -19,6 +20,7 @@ must_haves:
     - "/etc/arlowe is provisioned root:arlowe 0770 (group-writable), and ONLY /etc/arlowe is writable by the dashboard"
     - "arlowe-dashboard.service lists ReadWritePaths=/etc/arlowe scoped to that path only (no broader /etc)"
     - "install-arlowe-config.sh installs schema.yml + defaults.yml into /opt/arlowe/config without creating /etc/arlowe/config.yml"
+    - "A phase-4 docker harness reuses the phase-3 Dockerfile and runs tests/phase-4/assertions/*.sh"
   artifacts:
     - path: "docs/architecture/0003-dashboard-config-write-path.md"
       provides: "ADR for loosen-perms decision + containment requirements"
@@ -27,6 +29,8 @@ must_haves:
       provides: "Content installer for schema.yml + defaults.yml into /opt/arlowe/config"
     - path: "tests/phase-4/assertions/01-config-install-shape.sh"
       provides: "Asserts /etc/arlowe mode 0770 root:arlowe, config files installed, no config.yml created"
+    - path: "tests/phase-4/docker/run-tests.sh"
+      provides: "Phase-4 testbed harness reusing the phase-3 Dockerfile; loops tests/phase-4/assertions/*.sh"
   key_links:
     - from: "units/arlowe-dashboard.service"
       to: "/etc/arlowe"
@@ -36,13 +40,17 @@ must_haves:
       to: "/etc/arlowe"
       via: "install -d mode 0770"
       pattern: "install -d.*-m 0770 /etc/arlowe"
+    - from: "tests/phase-4/docker/run-tests.sh"
+      to: "tests/phase-4/assertions/01-config-install-shape.sh"
+      via: "globs tests/phase-4/assertions/*.sh"
+      pattern: "tests/phase-4/assertions"
 ---
 
 <objective>
-Enable the dashboard to persist the config overlay by implementing the settled LOOSEN-PERMS decision, and install the schema + defaults into the image. This is a package:security change — the ADR and its containment requirements are part of the deliverable.
+Enable the dashboard to persist the config overlay by implementing the settled LOOSEN-PERMS decision, install the schema + defaults into the image, and stand up a phase-4 docker harness that exercises the install shape. This is a package:security change — the ADR and its containment requirements are part of the deliverable.
 
 Purpose: Resolves 04-RESEARCH.md Pitfall 1 / Open-Question 1 (the dashboard cannot write /etc/arlowe/config.yml as provisioned). Satisfies CONFIG-02 (defaults ship in image) and CONFIG-03 (overlay dir is owner-mutable, config.yml absent on factory image). Unblocks 04-03 (dashboard write) and 04-04 (persona slice).
-Output: ADR 0003, loosened /etc/arlowe perms + dashboard ReadWritePaths, config content installer, install-shape assertion.
+Output: ADR 0003, loosened /etc/arlowe perms + dashboard ReadWritePaths, config content installer, install-shape assertion, and a phase-4 docker harness that runs it.
 </objective>
 
 <execution_context>
@@ -55,6 +63,7 @@ Output: ADR 0003, loosened /etc/arlowe perms + dashboard ReadWritePaths, config 
 @scripts/provision/install-arlowe-fs.sh
 @units/arlowe-dashboard.service
 @tests/phase-3/docker/run-tests.sh
+@tests/phase-3/docker/Dockerfile
 @docs/architecture/0001-iol-router-extraction.md
 </context>
 
@@ -80,22 +89,28 @@ Write ADR `docs/architecture/0003-dashboard-config-write-path.md` following the 
 </task>
 
 <task type="auto">
-  <name>Task 2: Loosen /etc/arlowe perms, scope dashboard ReadWritePaths, install config content</name>
-  <files>scripts/provision/install-arlowe-fs.sh, units/arlowe-dashboard.service, scripts/provision/install-arlowe-config.sh, tests/phase-4/assertions/01-config-install-shape.sh</files>
+  <name>Task 2: Loosen /etc/arlowe perms, scope dashboard ReadWritePaths, install config content, wire phase-4 harness</name>
+  <files>scripts/provision/install-arlowe-fs.sh, units/arlowe-dashboard.service, scripts/provision/install-arlowe-config.sh, tests/phase-4/assertions/01-config-install-shape.sh, tests/phase-4/docker/run-tests.sh</files>
   <action>
 1. In `scripts/provision/install-arlowe-fs.sh`: change the `/etc/arlowe` provisioning line from `install -d -o root -g arlowe -m 0755 /etc/arlowe` to `install -d -o root -g arlowe -m 0770 /etc/arlowe`. Update the adjacent comment block to cite ADR 0003 and state the dir is group-writable so the `arlowe`-user dashboard can write the overlay. Keep the existing "config.yml intentionally NOT created" line. Do NOT change any /opt or /var/lib provisioning.
 
 2. In `units/arlowe-dashboard.service`: replace the `FIXME(Phase 4)` comment block with a comment citing ADR 0003, and add `/etc/arlowe` to the existing ReadWritePaths line so it reads: `ReadWritePaths=/var/lib/arlowe/dashboard /var/lib/arlowe/logs/dashboard /etc/arlowe`. Scope is exactly `/etc/arlowe` — do not add a broader `/etc`.
 
-3. Create `scripts/provision/install-arlowe-config.sh` (the Docker testbed auto-discovers `install-arlowe-*.sh`, skipping `staging` names — see tests/phase-3/docker/run-tests.sh). It must: `set -euo pipefail`; assert the arlowe user exists (mirror install-arlowe-fs.sh's getent guard); install `config/schema.yml` and `config/defaults.yml` into `/opt/arlowe/config/` as `root:arlowe 0640` via `install -o root -g arlowe -m 0640`; also install `runtime/lib/arlowe_config.py` and `runtime/lib/arlowe_config_validate.py` to `/opt/arlowe/runtime/lib/` (root:arlowe 0644) so units' `PYTHONPATH=/opt/arlowe/runtime` plus a `lib` dir can import them — confirm the import path matches what 04-01's validator expects (place the lib at `/opt/arlowe/runtime/lib` and document that ExecStartPre uses `PYTHONPATH=/opt/arlowe/runtime/lib`). It must NOT create `/etc/arlowe/config.yml` (CONFIG-03 absence contract). The script must resolve its source files relative to the repo root (the testbed bind-mounts the repo at /arlowe-firmware); use a REPO_ROOT derived from BASH_SOURCE like the staging scripts do, and fall back to copying from the checkout.
+3. Create `scripts/provision/install-arlowe-config.sh` (the Docker testbed auto-discovers `install-arlowe-*.sh`, skipping `staging` names — see tests/phase-3/docker/run-tests.sh). It must: `set -euo pipefail`; assert the arlowe user exists (mirror install-arlowe-fs.sh's getent guard); install `config/schema.yml` and `config/defaults.yml` into `/opt/arlowe/config/` as `root:arlowe 0640` via `install -o root -g arlowe -m 0640`; also install `runtime/lib/arlowe_config.py` and `runtime/lib/arlowe_config_validate.py` to `/opt/arlowe/runtime/lib/` (root:arlowe 0644) so units' `PYTHONPATH=/opt/arlowe/runtime/lib` can flat-import them — confirm the import path matches what 04-01's validator expects (flat modules at `/opt/arlowe/runtime/lib`, imported as `from arlowe_config import load`; ExecStartPre uses `PYTHONPATH=/opt/arlowe/runtime/lib`). It must NOT create `/etc/arlowe/config.yml` (CONFIG-03 absence contract). The script must resolve its source files relative to the repo root (the testbed bind-mounts the repo at /arlowe-firmware); use a REPO_ROOT derived from BASH_SOURCE like the staging scripts do, and fall back to copying from the checkout.
 
-4. Create `tests/phase-4/assertions/01-config-install-shape.sh` (mirror the style of tests/phase-3/assertions/02-fs-layout.sh). Assert: `/etc/arlowe` is mode `0770` owner `root` group `arlowe`; `/opt/arlowe/config/schema.yml` and `/opt/arlowe/config/defaults.yml` exist and are owned root:arlowe; `/opt/arlowe/runtime/lib/arlowe_config.py` exists; `/etc/arlowe/config.yml` does NOT exist. Use `stat -c` checks and explicit pass/fail echoes; exit non-zero on any failure. The Phase 3 docker harness auto-loops `tests/phase-3/assertions/*.sh` — Phase 4 assertions live under `tests/phase-4/`; note in a header comment that this is wired into the testbed in Task verification below (extend the harness glob OR invoke directly).
+4. Create `tests/phase-4/assertions/01-config-install-shape.sh` (mirror the style of tests/phase-3/assertions/02-fs-layout.sh). Assert: `/etc/arlowe` is mode `0770` owner `root` group `arlowe`; `/opt/arlowe/config/schema.yml` and `/opt/arlowe/config/defaults.yml` exist and are owned root:arlowe; `/opt/arlowe/runtime/lib/arlowe_config.py` exists; `/etc/arlowe/config.yml` does NOT exist. Use `stat -c` checks and explicit pass/fail echoes; exit non-zero on any failure. These are STAT-ONLY shape checks (file existence + mode + owner) — they do NOT execute the python validator, so they do not need jsonschema/PyYAML in the image (see Task note on testbed deps).
+
+5. Create `tests/phase-4/docker/run-tests.sh` — a phase-4 harness that REUSES the phase-3 Dockerfile (do NOT edit tests/phase-3/run-tests.sh; that file belongs to a different wave and editing it breaks file-disjointness). Model it on tests/phase-3/docker/run-tests.sh but:
+   - Build from the phase-3 Dockerfile: `IMAGE=arlowe-phase4-testbed`; `docker build -t "${IMAGE}" "${REPO_ROOT}/tests/phase-3/docker"` (the phase-3 Dockerfile already installs python3/python3-venv/nodejs/npm and creates the gpio/spi groups — sufficient for stat-only shape checks).
+   - Keep the same auto-discovery harness body for provision scripts (loop `install-arlowe-*.sh`, skip `staging`, run `install-arlowe-user.sh` first) and `units/install-units.sh` so install-arlowe-config.sh runs.
+   - Change the assertion loop to glob `tests/phase-4/assertions/*.sh` instead of phase-3.
+   - TESTBED DEPS DECISION (checker Warning 4): the phase-4 assertions are STAT-ONLY and do NOT run the python loader, so the harness does NOT pip-install jsonschema/PyYAML. Add a header comment stating explicitly: "Validator EXECUTION (running arlowe_config_validate / pytest) is verified on the provisioned Pi/staging unit and in 04-01's repo-root pytest run, NOT in this Docker testbed; here we assert install SHAPE only (mode/owner/presence)." This keeps the image build cheap and avoids a divergent dep set.
   </action>
   <verify>
-Run the assertion against a provisioned environment. Locally (no Docker), do a dry shape check: `bash -n scripts/provision/install-arlowe-config.sh` and `bash -n tests/phase-4/assertions/01-config-install-shape.sh` parse clean; `grep -q 'm 0770 /etc/arlowe' scripts/provision/install-arlowe-fs.sh`; `grep -qE 'ReadWritePaths=.*/etc/arlowe' units/arlowe-dashboard.service`; confirm no broader `/etc ` (with trailing space/non-arlowe) snuck into ReadWritePaths.
-If Docker available: run `bash tests/phase-3/docker/run-tests.sh` after adding install-arlowe-config.sh to provision/ (auto-discovered), then run the new assertion inside the testbed (extend run-tests.sh to also loop tests/phase-4/assertions/*.sh, or invoke 01-config-install-shape.sh explicitly) and confirm it passes.
+Locally (no Docker), shape checks: `bash -n scripts/provision/install-arlowe-config.sh`, `bash -n tests/phase-4/assertions/01-config-install-shape.sh`, and `bash -n tests/phase-4/docker/run-tests.sh` all parse clean; `grep -q 'm 0770 /etc/arlowe' scripts/provision/install-arlowe-fs.sh`; `grep -qE 'ReadWritePaths=.*/etc/arlowe' units/arlowe-dashboard.service`; confirm no broader `/etc ` (with trailing space/non-arlowe) snuck into ReadWritePaths; `grep -q 'tests/phase-4/assertions' tests/phase-4/docker/run-tests.sh` and `grep -q 'phase-3/docker' tests/phase-4/docker/run-tests.sh` (confirms it reuses the phase-3 Dockerfile).
+If Docker available: `bash tests/phase-4/docker/run-tests.sh` builds from the phase-3 Dockerfile, runs the auto-discovered installers (including install-arlowe-config.sh), then loops tests/phase-4/assertions/*.sh and 01-config-install-shape.sh passes.
   </verify>
-  <done>/etc/arlowe is 0770 root:arlowe; dashboard ReadWritePaths includes /etc/arlowe (and nothing broader); install-arlowe-config.sh installs schema+defaults+lib without creating config.yml; the install-shape assertion passes.</done>
+  <done>/etc/arlowe is 0770 root:arlowe; dashboard ReadWritePaths includes /etc/arlowe (and nothing broader); install-arlowe-config.sh installs schema+defaults+lib without creating config.yml; tests/phase-4/docker/run-tests.sh reuses the phase-3 Dockerfile and runs the phase-4 stat-only assertion green.</done>
 </task>
 
 </tasks>
@@ -104,13 +119,16 @@ If Docker available: run `bash tests/phase-3/docker/run-tests.sh` after adding i
 - ADR 0003 present with all three containment requirements.
 - install-arlowe-fs.sh sets /etc/arlowe to 0770; dashboard unit ReadWritePaths scoped to /etc/arlowe.
 - install-arlowe-config.sh ships schema+defaults+lib, never creates config.yml.
-- 01-config-install-shape.sh asserts the above and passes in the testbed.
+- tests/phase-4/docker/run-tests.sh reuses the phase-3 Dockerfile and loops tests/phase-4/assertions/*.sh.
+- 01-config-install-shape.sh (stat-only) asserts the above and passes in the phase-4 testbed.
 </verification>
 
 <success_criteria>
-CONFIG-02 (defaults ship) and CONFIG-03 (owner-mutable overlay dir, config.yml absent on factory image) satisfied; the loosen-perms decision is documented and bounded; the dashboard now has a write path into /etc/arlowe without breaking the rest of the Phase 3 sandbox.
+CONFIG-02 (defaults ship) and CONFIG-03 (owner-mutable overlay dir, config.yml absent on factory image) satisfied; the loosen-perms decision is documented and bounded; the dashboard now has a write path into /etc/arlowe without breaking the rest of the Phase 3 sandbox; the phase-4 assertion harness is wired (stat-only; validator execution verified on the Pi/staging unit + 04-01 pytest).
 </success_criteria>
 
 <output>
 After completion, create `.planning/phases/04-config-overlay/04-02-SUMMARY.md`.
 </output>
+</content>
+</invoke>

--- a/.planning/phases/04-config-overlay/04-02-PLAN.md
+++ b/.planning/phases/04-config-overlay/04-02-PLAN.md
@@ -1,0 +1,116 @@
+---
+phase: 04-config-overlay
+plan: 02
+type: execute
+wave: 2
+depends_on: ["04-01"]
+files_modified:
+  - docs/architecture/0003-dashboard-config-write-path.md
+  - scripts/provision/install-arlowe-fs.sh
+  - scripts/provision/install-arlowe-config.sh
+  - units/arlowe-dashboard.service
+  - tests/phase-4/assertions/01-config-install-shape.sh
+autonomous: true
+package: security
+requirements_covered: [CONFIG-02, CONFIG-03]
+must_haves:
+  truths:
+    - "An ADR records the loosen-perms decision, scopes it to /etc/arlowe only, and flags ota/support_mode knobs for Phase 10 re-hardening"
+    - "/etc/arlowe is provisioned root:arlowe 0770 (group-writable), and ONLY /etc/arlowe is writable by the dashboard"
+    - "arlowe-dashboard.service lists ReadWritePaths=/etc/arlowe scoped to that path only (no broader /etc)"
+    - "install-arlowe-config.sh installs schema.yml + defaults.yml into /opt/arlowe/config without creating /etc/arlowe/config.yml"
+  artifacts:
+    - path: "docs/architecture/0003-dashboard-config-write-path.md"
+      provides: "ADR for loosen-perms decision + containment requirements"
+      min_lines: 30
+    - path: "scripts/provision/install-arlowe-config.sh"
+      provides: "Content installer for schema.yml + defaults.yml into /opt/arlowe/config"
+    - path: "tests/phase-4/assertions/01-config-install-shape.sh"
+      provides: "Asserts /etc/arlowe mode 0770 root:arlowe, config files installed, no config.yml created"
+  key_links:
+    - from: "units/arlowe-dashboard.service"
+      to: "/etc/arlowe"
+      via: "ReadWritePaths entry"
+      pattern: "ReadWritePaths=.*\\/etc\\/arlowe"
+    - from: "scripts/provision/install-arlowe-fs.sh"
+      to: "/etc/arlowe"
+      via: "install -d mode 0770"
+      pattern: "install -d.*-m 0770 /etc/arlowe"
+---
+
+<objective>
+Enable the dashboard to persist the config overlay by implementing the settled LOOSEN-PERMS decision, and install the schema + defaults into the image. This is a package:security change — the ADR and its containment requirements are part of the deliverable.
+
+Purpose: Resolves 04-RESEARCH.md Pitfall 1 / Open-Question 1 (the dashboard cannot write /etc/arlowe/config.yml as provisioned). Satisfies CONFIG-02 (defaults ship in image) and CONFIG-03 (overlay dir is owner-mutable, config.yml absent on factory image). Unblocks 04-03 (dashboard write) and 04-04 (persona slice).
+Output: ADR 0003, loosened /etc/arlowe perms + dashboard ReadWritePaths, config content installer, install-shape assertion.
+</objective>
+
+<execution_context>
+@~/.claude/get-shit-done/workflows/execute-plan.md
+@~/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/phases/04-config-overlay/04-RESEARCH.md
+@scripts/provision/install-arlowe-fs.sh
+@units/arlowe-dashboard.service
+@tests/phase-3/docker/run-tests.sh
+@docs/architecture/0001-iol-router-extraction.md
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Write ADR 0003 (loosen-perms decision + containment)</name>
+  <files>docs/architecture/0003-dashboard-config-write-path.md</files>
+  <action>
+Write ADR `docs/architecture/0003-dashboard-config-write-path.md` following the format of `0001-iol-router-extraction.md` (Status / Context / Decision / Consequences). Record:
+
+- **Context:** Phase 3 provisioned `/etc/arlowe` as `root:arlowe 0755` with the dashboard unit under `ProtectSystem=strict` and no `/etc/arlowe` in ReadWritePaths. The dashboard (`POST /api/config`) must persist `/etc/arlowe/config.yml`. Two options existed (privileged helper vs loosen perms).
+- **Decision (settled by owner):** LOOSEN PERMS. Set `/etc/arlowe` to `root:arlowe 0770` and add `ReadWritePaths=/etc/arlowe` (scoped to that path ONLY) to `arlowe-dashboard.service`. The dashboard writes the overlay directly via temp-file + rename.
+- **Containment requirements (MUST be explicit in the ADR):**
+  1. `ReadWritePaths` is scoped to `/etc/arlowe` only — never a broader `/etc` path. "Loosen perms" must NOT become "dashboard can write arbitrary /etc files."
+  2. The loader's fail-fast schema validation (Plan 04-01) is retained REGARDLESS — a loosened write path does not relax validation; an invalid overlay still fails the service at ExecStartPre.
+  3. The security-sensitive knobs `ota.channel_url` and `support_mode.*` are flagged for RE-HARDENING in Phase 10: when support-mode lands, those specific knobs move behind a re-auth'd privileged write (not the plain group-writable path). Record this as an explicit future-work item so the decision is revisitable.
+- **Consequences:** dashboard write surface widens to `/etc/arlowe` only; trade-off accepted because the dashboard is already trusted (it can restart units via the Phase 3 polkit rule). Note this supersedes the `FIXME(Phase 4)` in arlowe-dashboard.service.
+- Set Status to Accepted, date 2026-06-07.
+  </action>
+  <verify>`test -f docs/architecture/0003-dashboard-config-write-path.md` and `grep -qi "0770" docs/architecture/0003-dashboard-config-write-path.md` and `grep -qi "Phase 10" docs/architecture/0003-dashboard-config-write-path.md` all pass.</verify>
+  <done>ADR exists, records loosen-perms decision, names the three containment requirements (scope to /etc/arlowe, retain fail-fast validation, re-harden ota/support_mode in Phase 10).</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Loosen /etc/arlowe perms, scope dashboard ReadWritePaths, install config content</name>
+  <files>scripts/provision/install-arlowe-fs.sh, units/arlowe-dashboard.service, scripts/provision/install-arlowe-config.sh, tests/phase-4/assertions/01-config-install-shape.sh</files>
+  <action>
+1. In `scripts/provision/install-arlowe-fs.sh`: change the `/etc/arlowe` provisioning line from `install -d -o root -g arlowe -m 0755 /etc/arlowe` to `install -d -o root -g arlowe -m 0770 /etc/arlowe`. Update the adjacent comment block to cite ADR 0003 and state the dir is group-writable so the `arlowe`-user dashboard can write the overlay. Keep the existing "config.yml intentionally NOT created" line. Do NOT change any /opt or /var/lib provisioning.
+
+2. In `units/arlowe-dashboard.service`: replace the `FIXME(Phase 4)` comment block with a comment citing ADR 0003, and add `/etc/arlowe` to the existing ReadWritePaths line so it reads: `ReadWritePaths=/var/lib/arlowe/dashboard /var/lib/arlowe/logs/dashboard /etc/arlowe`. Scope is exactly `/etc/arlowe` — do not add a broader `/etc`.
+
+3. Create `scripts/provision/install-arlowe-config.sh` (the Docker testbed auto-discovers `install-arlowe-*.sh`, skipping `staging` names — see tests/phase-3/docker/run-tests.sh). It must: `set -euo pipefail`; assert the arlowe user exists (mirror install-arlowe-fs.sh's getent guard); install `config/schema.yml` and `config/defaults.yml` into `/opt/arlowe/config/` as `root:arlowe 0640` via `install -o root -g arlowe -m 0640`; also install `runtime/lib/arlowe_config.py` and `runtime/lib/arlowe_config_validate.py` to `/opt/arlowe/runtime/lib/` (root:arlowe 0644) so units' `PYTHONPATH=/opt/arlowe/runtime` plus a `lib` dir can import them — confirm the import path matches what 04-01's validator expects (place the lib at `/opt/arlowe/runtime/lib` and document that ExecStartPre uses `PYTHONPATH=/opt/arlowe/runtime/lib`). It must NOT create `/etc/arlowe/config.yml` (CONFIG-03 absence contract). The script must resolve its source files relative to the repo root (the testbed bind-mounts the repo at /arlowe-firmware); use a REPO_ROOT derived from BASH_SOURCE like the staging scripts do, and fall back to copying from the checkout.
+
+4. Create `tests/phase-4/assertions/01-config-install-shape.sh` (mirror the style of tests/phase-3/assertions/02-fs-layout.sh). Assert: `/etc/arlowe` is mode `0770` owner `root` group `arlowe`; `/opt/arlowe/config/schema.yml` and `/opt/arlowe/config/defaults.yml` exist and are owned root:arlowe; `/opt/arlowe/runtime/lib/arlowe_config.py` exists; `/etc/arlowe/config.yml` does NOT exist. Use `stat -c` checks and explicit pass/fail echoes; exit non-zero on any failure. The Phase 3 docker harness auto-loops `tests/phase-3/assertions/*.sh` — Phase 4 assertions live under `tests/phase-4/`; note in a header comment that this is wired into the testbed in Task verification below (extend the harness glob OR invoke directly).
+  </action>
+  <verify>
+Run the assertion against a provisioned environment. Locally (no Docker), do a dry shape check: `bash -n scripts/provision/install-arlowe-config.sh` and `bash -n tests/phase-4/assertions/01-config-install-shape.sh` parse clean; `grep -q 'm 0770 /etc/arlowe' scripts/provision/install-arlowe-fs.sh`; `grep -qE 'ReadWritePaths=.*/etc/arlowe' units/arlowe-dashboard.service`; confirm no broader `/etc ` (with trailing space/non-arlowe) snuck into ReadWritePaths.
+If Docker available: run `bash tests/phase-3/docker/run-tests.sh` after adding install-arlowe-config.sh to provision/ (auto-discovered), then run the new assertion inside the testbed (extend run-tests.sh to also loop tests/phase-4/assertions/*.sh, or invoke 01-config-install-shape.sh explicitly) and confirm it passes.
+  </verify>
+  <done>/etc/arlowe is 0770 root:arlowe; dashboard ReadWritePaths includes /etc/arlowe (and nothing broader); install-arlowe-config.sh installs schema+defaults+lib without creating config.yml; the install-shape assertion passes.</done>
+</task>
+
+</tasks>
+
+<verification>
+- ADR 0003 present with all three containment requirements.
+- install-arlowe-fs.sh sets /etc/arlowe to 0770; dashboard unit ReadWritePaths scoped to /etc/arlowe.
+- install-arlowe-config.sh ships schema+defaults+lib, never creates config.yml.
+- 01-config-install-shape.sh asserts the above and passes in the testbed.
+</verification>
+
+<success_criteria>
+CONFIG-02 (defaults ship) and CONFIG-03 (owner-mutable overlay dir, config.yml absent on factory image) satisfied; the loosen-perms decision is documented and bounded; the dashboard now has a write path into /etc/arlowe without breaking the rest of the Phase 3 sandbox.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/04-config-overlay/04-02-SUMMARY.md`.
+</output>

--- a/.planning/phases/04-config-overlay/04-03-PLAN.md
+++ b/.planning/phases/04-config-overlay/04-03-PLAN.md
@@ -1,0 +1,119 @@
+---
+phase: 04-config-overlay
+plan: 03
+type: execute
+wave: 2
+depends_on: ["04-01"]
+files_modified:
+  - runtime/dashboard/package.json
+  - runtime/dashboard/app/api/config/route.ts
+  - runtime/dashboard/app/api/config/restart-map.ts
+  - runtime/dashboard/tests/config-validate.spec.ts
+autonomous: true
+requirements_covered: [CONFIG-04, CONFIG-05]
+must_haves:
+  truths:
+    - "POST /api/config validates the body against config/schema.yml before writing; an invalid body returns 422 and writes nothing"
+    - "A valid POST writes /etc/arlowe/config.yml atomically (temp-file + rename) — preserved from existing route"
+    - "After a successful write, the affected unit(s) for the changed knob restart via the existing ARLOWE_SYSTEMCTL_MODE systemctl seam"
+    - "The restart targets only polkit-authorized units (arlowe-*, qwen-*, whisper-stt)"
+  artifacts:
+    - path: "runtime/dashboard/app/api/config/route.ts"
+      provides: "ajv validate-before-write + atomic write + restart trigger"
+      contains: "Ajv"
+    - path: "runtime/dashboard/app/api/config/restart-map.ts"
+      provides: "knob -> affected unit(s) mapping; only arlowe-*/qwen-*/whisper-stt"
+    - path: "runtime/dashboard/tests/config-validate.spec.ts"
+      provides: "Test: invalid body -> 422 no write; restart-map -> authorized units only"
+  key_links:
+    - from: "runtime/dashboard/app/api/config/route.ts"
+      to: "config/schema.yml"
+      via: "ajv compiled from ARLOWE_SCHEMA_PATH"
+      pattern: "Ajv|ARLOWE_SCHEMA_PATH"
+    - from: "runtime/dashboard/app/api/config/route.ts"
+      to: "systemctl restart <unit>"
+      via: "execFile via ARLOWE_SYSTEMCTL_MODE seam (mirrors api/voice/route.ts)"
+      pattern: "systemctl|execFile"
+---
+
+<objective>
+Make the dashboard's config write path schema-safe and effect-bearing: validate against the same schema.yml before writing, keep the atomic write, and restart the affected service(s) on change.
+
+Purpose: Satisfies CONFIG-04 (dashboard-side validation; "validate before write" prevents an invalid overlay bricking a restart) and CONFIG-05 (dashboard writes atomically; affected services restart on change). Reuses the existing systemctl seam (api/voice/route.ts) and the Phase 3 polkit rule.
+Output: ajv validation in route.ts, a knob->unit restart map, restart trigger, and a Playwright/unit test.
+</objective>
+
+<execution_context>
+@~/.claude/get-shit-done/workflows/execute-plan.md
+@~/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/phases/04-config-overlay/04-RESEARCH.md
+@runtime/dashboard/app/api/config/route.ts
+@runtime/dashboard/app/api/voice/route.ts
+@runtime/dashboard/package.json
+@provision/polkit/50-arlowe-systemctl.rules
+
+# Depends on 04-01 for the schema artifact
+@.planning/phases/04-config-overlay/04-01-PLAN.md
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Add ajv; validate body against schema.yml before atomic write</name>
+  <files>runtime/dashboard/package.json, runtime/dashboard/app/api/config/route.ts</files>
+  <action>
+1. Add `ajv` (^8.x) to `runtime/dashboard/package.json` dependencies. (js-yaml is already present.) Note in the SUMMARY that `pnpm add ajv` / lockfile update is needed during image build; just declare the dep here.
+
+2. Edit `runtime/dashboard/app/api/config/route.ts` POST handler (keep GET unchanged, keep the temp+rename atomic write — it is already correct per 04-RESEARCH.md "Don't Hand-Roll"):
+   - Read the schema from `process.env.ARLOWE_SCHEMA_PATH ?? '/opt/arlowe/config/schema.yml'`, parse with `yaml.load`, compile with `new Ajv({ allErrors: true })`.
+   - Validate the parsed request body BEFORE any write. On failure return `NextResponse.json({ error: 'schema violation', details: validate.errors }, { status: 422 })` and write nothing.
+   - On success: perform the existing `writeFile(CONFIG_TMP_PATH)` + `rename(CONFIG_PATH)` atomic write.
+   - Remove the `TODO(phase-4): validate against config/schema.yml` marker (now done).
+   - Follow the existing JSON-Schema draft used by 04-01 (draft 2020-12). If ajv v8 default needs `ajv/dist/2020` for draft-2020-12 keywords, import from `ajv/dist/2020` and instantiate that — verify against the schema's `$schema` value. Match the validator dialect to schema.yml's declared `$schema`.
+  </action>
+  <verify>`cd runtime/dashboard && npx tsc --noEmit` (or `pnpm exec tsc --noEmit`) passes for route.ts. Confirm `grep -q "Ajv" app/api/config/route.ts` and the `TODO(phase-4)` marker is gone.</verify>
+  <done>POST validates against schema.yml (correct draft-2020-12 dialect) before writing; invalid body -> 422, no file written; valid body -> atomic temp+rename write; ajv declared in package.json.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: knob->unit restart map + restart trigger + test</name>
+  <files>runtime/dashboard/app/api/config/restart-map.ts, runtime/dashboard/app/api/config/route.ts, runtime/dashboard/tests/config-validate.spec.ts</files>
+  <action>
+1. Create `runtime/dashboard/app/api/config/restart-map.ts` exporting a map from top-level config knob -> affected unit name(s), per 04-RESEARCH.md Pitfall 4. At minimum:
+   - `persona` -> `["arlowe-face.service"]` (the SC4 live knob; consumed by 04-04)
+   - `model` -> `["qwen-tokenizer.service", "qwen-api.service"]`
+   - `audio` -> `["arlowe-voice.service"]`
+   - `ports` -> `["arlowe-face.service", "arlowe-voice.service"]`
+   Export a helper `unitsForChange(changedTopLevelKeys: string[]): string[]` returning the de-duplicated union. Add a comment: every returned unit MUST match `arlowe-*` / `qwen-*` / `whisper-stt.service` (the only names the Phase 3 polkit rule authorizes); knobs with no live consumer yet (`support_mode`, `ota`, `logs`, `device`) map to `[]` (no restart in Phase 4).
+
+2. In `route.ts` POST, after a successful write: compute the changed top-level keys (diff against the previous on-disk overlay if present, else all keys in the body), call `unitsForChange(...)`, and for each unit run `systemctl restart <unit>` through the SAME seam api/voice/route.ts uses — reuse/extract its `ARLOWE_SYSTEMCTL_MODE` + `execFile` pattern (mode `system` -> `['systemctl','restart',unit]`, else `['systemctl','--user','restart',unit]`). A restart failure must NOT corrupt the already-written config; log it and include a non-fatal warning in the response (`{ ok: true, written, restarted: [...], restartErrors: [...] }`). Never call `daemon-reload` (polkit denies it).
+
+3. Create `runtime/dashboard/tests/config-validate.spec.ts` (Playwright, mirror tests/sanitize.spec.ts structure or a plain unit test if the suite supports it). Cover:
+   - `unitsForChange(['persona'])` returns exactly `['arlowe-face.service']`.
+   - `unitsForChange(['ota'])` returns `[]`.
+   - every unit any knob maps to matches `/^(arlowe-|qwen-)|^whisper-stt\.service$/` (guards the polkit contract).
+   - (route-level) a POST with an enum-invalid `ota.channel` returns 422 — if the harness can't spin a live server, assert the validation function rejects it instead, keeping the test hermetic.
+  </action>
+  <verify>`cd runtime/dashboard && npx tsc --noEmit` passes. Run the new test: `pnpm exec playwright test tests/config-validate.spec.ts` (or the project's test runner) — all cases green, including the polkit-authorization regex guard.</verify>
+  <done>restart-map maps knobs to only polkit-authorized units; a successful config write restarts the affected unit(s) via the existing seam without daemon-reload; restart failure is non-fatal; tests green.</done>
+</task>
+
+</tasks>
+
+<verification>
+- `tsc --noEmit` clean for the config route + restart-map.
+- POST validates against schema.yml before writing; invalid -> 422 no write.
+- restart-map units all match the polkit-authorized prefixes; persona -> arlowe-face.
+- config-validate.spec.ts green.
+</verification>
+
+<success_criteria>
+CONFIG-04 (dashboard validates before write) and CONFIG-05 (atomic write + affected-service restart) satisfied. The dashboard cannot land an invalid overlay, and a knob change triggers the correct, authorized service restart.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/04-config-overlay/04-03-SUMMARY.md`.
+</output>

--- a/.planning/phases/04-config-overlay/04-03-PLAN.md
+++ b/.planning/phases/04-config-overlay/04-03-PLAN.md
@@ -8,7 +8,7 @@ files_modified:
   - runtime/dashboard/package.json
   - runtime/dashboard/app/api/config/route.ts
   - runtime/dashboard/app/api/config/restart-map.ts
-  - runtime/dashboard/tests/config-validate.spec.ts
+  - runtime/dashboard/tests/unit/config-validate.test.ts
 autonomous: true
 requirements_covered: [CONFIG-04, CONFIG-05]
 must_haves:
@@ -17,14 +17,15 @@ must_haves:
     - "A valid POST writes /etc/arlowe/config.yml atomically (temp-file + rename) — preserved from existing route"
     - "After a successful write, the affected unit(s) for the changed knob restart via the existing ARLOWE_SYSTEMCTL_MODE systemctl seam"
     - "The restart targets only polkit-authorized units (arlowe-*, qwen-*, whisper-stt)"
+    - "ajv is installed (lockfile + node_modules updated) so tsc and the unit tests resolve in a fresh checkout"
   artifacts:
     - path: "runtime/dashboard/app/api/config/route.ts"
       provides: "ajv validate-before-write + atomic write + restart trigger"
       contains: "Ajv"
     - path: "runtime/dashboard/app/api/config/restart-map.ts"
       provides: "knob -> affected unit(s) mapping; only arlowe-*/qwen-*/whisper-stt"
-    - path: "runtime/dashboard/tests/config-validate.spec.ts"
-      provides: "Test: invalid body -> 422 no write; restart-map -> authorized units only"
+    - path: "runtime/dashboard/tests/unit/config-validate.test.ts"
+      provides: "node:test hermetic unit tests: unitsForChange + validate-rejects-invalid; no Next build/boot"
   key_links:
     - from: "runtime/dashboard/app/api/config/route.ts"
       to: "config/schema.yml"
@@ -40,7 +41,7 @@ must_haves:
 Make the dashboard's config write path schema-safe and effect-bearing: validate against the same schema.yml before writing, keep the atomic write, and restart the affected service(s) on change.
 
 Purpose: Satisfies CONFIG-04 (dashboard-side validation; "validate before write" prevents an invalid overlay bricking a restart) and CONFIG-05 (dashboard writes atomically; affected services restart on change). Reuses the existing systemctl seam (api/voice/route.ts) and the Phase 3 polkit rule.
-Output: ajv validation in route.ts, a knob->unit restart map, restart trigger, and a Playwright/unit test.
+Output: ajv installed + wired into route.ts, a knob->unit restart map, restart trigger, and a hermetic node:test unit suite for the pure functions.
 </objective>
 
 <execution_context>
@@ -53,6 +54,7 @@ Output: ajv validation in route.ts, a knob->unit restart map, restart trigger, a
 @runtime/dashboard/app/api/config/route.ts
 @runtime/dashboard/app/api/voice/route.ts
 @runtime/dashboard/package.json
+@runtime/dashboard/playwright.config.ts
 @provision/polkit/50-arlowe-systemctl.rules
 
 # Depends on 04-01 for the schema artifact
@@ -62,58 +64,63 @@ Output: ajv validation in route.ts, a knob->unit restart map, restart trigger, a
 <tasks>
 
 <task type="auto">
-  <name>Task 1: Add ajv; validate body against schema.yml before atomic write</name>
+  <name>Task 1: Install ajv; validate body against schema.yml before atomic write</name>
   <files>runtime/dashboard/package.json, runtime/dashboard/app/api/config/route.ts</files>
   <action>
-1. Add `ajv` (^8.x) to `runtime/dashboard/package.json` dependencies. (js-yaml is already present.) Note in the SUMMARY that `pnpm add ajv` / lockfile update is needed during image build; just declare the dep here.
+1. INSTALL ajv NOW (do not defer to image build — `tsc --noEmit` and the unit tests below must resolve in a fresh checkout): run `cd runtime/dashboard && pnpm add ajv` so it lands in `dependencies` AND updates `pnpm-lock.yaml` + `node_modules`. (js-yaml is already present.) Pin to ^8.x if pnpm picks a different major.
 
 2. Edit `runtime/dashboard/app/api/config/route.ts` POST handler (keep GET unchanged, keep the temp+rename atomic write — it is already correct per 04-RESEARCH.md "Don't Hand-Roll"):
-   - Read the schema from `process.env.ARLOWE_SCHEMA_PATH ?? '/opt/arlowe/config/schema.yml'`, parse with `yaml.load`, compile with `new Ajv({ allErrors: true })`.
+   - Read the schema from `process.env.ARLOWE_SCHEMA_PATH ?? '/opt/arlowe/config/schema.yml'`, parse with `yaml.load`, compile with ajv.
+   - DIALECT MATCH: 04-01's schema declares `$schema: draft 2020-12`. ajv v8's default `Ajv` does NOT support draft-2020-12 keywords; import the 2020 build: `import Ajv2020 from 'ajv/dist/2020'` and instantiate `new Ajv2020({ allErrors: true })`. (Confirm against schema.yml's `$schema` value; if it is draft-07 instead, fall back to the default `ajv` import — but 04-01 specifies 2020-12.)
    - Validate the parsed request body BEFORE any write. On failure return `NextResponse.json({ error: 'schema violation', details: validate.errors }, { status: 422 })` and write nothing.
    - On success: perform the existing `writeFile(CONFIG_TMP_PATH)` + `rename(CONFIG_PATH)` atomic write.
    - Remove the `TODO(phase-4): validate against config/schema.yml` marker (now done).
-   - Follow the existing JSON-Schema draft used by 04-01 (draft 2020-12). If ajv v8 default needs `ajv/dist/2020` for draft-2020-12 keywords, import from `ajv/dist/2020` and instantiate that — verify against the schema's `$schema` value. Match the validator dialect to schema.yml's declared `$schema`.
   </action>
-  <verify>`cd runtime/dashboard && npx tsc --noEmit` (or `pnpm exec tsc --noEmit`) passes for route.ts. Confirm `grep -q "Ajv" app/api/config/route.ts` and the `TODO(phase-4)` marker is gone.</verify>
-  <done>POST validates against schema.yml (correct draft-2020-12 dialect) before writing; invalid body -> 422, no file written; valid body -> atomic temp+rename write; ajv declared in package.json.</done>
+  <verify>`cd runtime/dashboard && pnpm exec tsc --noEmit` passes for route.ts (ajv now resolves). Confirm `grep -q "Ajv" app/api/config/route.ts`, the `TODO(phase-4)` marker is gone, and `grep -q '"ajv"' package.json` (dep declared) and `grep -q 'ajv' pnpm-lock.yaml` (lockfile updated).</verify>
+  <done>ajv installed (dep + lockfile + node_modules); POST validates against schema.yml using the 2020-12 dialect before writing; invalid body -> 422, no file written; valid body -> atomic temp+rename write.</done>
 </task>
 
 <task type="auto">
-  <name>Task 2: knob->unit restart map + restart trigger + test</name>
-  <files>runtime/dashboard/app/api/config/restart-map.ts, runtime/dashboard/app/api/config/route.ts, runtime/dashboard/tests/config-validate.spec.ts</files>
+  <name>Task 2: knob->unit restart map + restart trigger + hermetic node:test suite</name>
+  <files>runtime/dashboard/app/api/config/restart-map.ts, runtime/dashboard/app/api/config/route.ts, runtime/dashboard/package.json, runtime/dashboard/tests/unit/config-validate.test.ts</files>
   <action>
 1. Create `runtime/dashboard/app/api/config/restart-map.ts` exporting a map from top-level config knob -> affected unit name(s), per 04-RESEARCH.md Pitfall 4. At minimum:
    - `persona` -> `["arlowe-face.service"]` (the SC4 live knob; consumed by 04-04)
    - `model` -> `["qwen-tokenizer.service", "qwen-api.service"]`
    - `audio` -> `["arlowe-voice.service"]`
    - `ports` -> `["arlowe-face.service", "arlowe-voice.service"]`
-   Export a helper `unitsForChange(changedTopLevelKeys: string[]): string[]` returning the de-duplicated union. Add a comment: every returned unit MUST match `arlowe-*` / `qwen-*` / `whisper-stt.service` (the only names the Phase 3 polkit rule authorizes); knobs with no live consumer yet (`support_mode`, `ota`, `logs`, `device`) map to `[]` (no restart in Phase 4).
+   Export a helper `unitsForChange(changedTopLevelKeys: string[]): string[]` returning the de-duplicated union. Add a comment: every returned unit MUST match `arlowe-*` / `qwen-*` / `whisper-stt.service` (the only names the Phase 3 polkit rule authorizes); knobs with no live consumer yet (`support_mode`, `ota`, `logs`, `device`) map to `[]` (no restart in Phase 4). INFO (checker item 8): add an inline comment on the `ports` entry noting that `ports` — like `support_mode`/`ota`/`logs` — has NO live consumer in Phase 4 (no service reads the port knob yet; it is wired here for when Phase 5+ services bind configured ports), so a `ports` change restarting face/voice is currently a no-op-on-behavior restart.
 
 2. In `route.ts` POST, after a successful write: compute the changed top-level keys (diff against the previous on-disk overlay if present, else all keys in the body), call `unitsForChange(...)`, and for each unit run `systemctl restart <unit>` through the SAME seam api/voice/route.ts uses — reuse/extract its `ARLOWE_SYSTEMCTL_MODE` + `execFile` pattern (mode `system` -> `['systemctl','restart',unit]`, else `['systemctl','--user','restart',unit]`). A restart failure must NOT corrupt the already-written config; log it and include a non-fatal warning in the response (`{ ok: true, written, restarted: [...], restartErrors: [...] }`). Never call `daemon-reload` (polkit denies it).
 
-3. Create `runtime/dashboard/tests/config-validate.spec.ts` (Playwright, mirror tests/sanitize.spec.ts structure or a plain unit test if the suite supports it). Cover:
-   - `unitsForChange(['persona'])` returns exactly `['arlowe-face.service']`.
-   - `unitsForChange(['ota'])` returns `[]`.
-   - every unit any knob maps to matches `/^(arlowe-|qwen-)|^whisper-stt\.service$/` (guards the polkit contract).
-   - (route-level) a POST with an enum-invalid `ota.channel` returns 422 — if the harness can't spin a live server, assert the validation function rejects it instead, keeping the test hermetic.
+3. TEST RUNNER (checker Blocker 2): the existing Playwright config has `webServer: { command: 'pnpm build && pnpm start' }`, so `playwright test` full-builds and boots Next before every test — that is wrong for hermetic pure-function assertions on `unitsForChange()` and the validator. Add a real unit runner using Node's built-in `node:test` (zero new deps — ships with Node 20, already in devDeps as `@types/node`):
+   - Add a script to `runtime/dashboard/package.json`: `"test:unit": "node --import tsx --test tests/unit/*.test.ts"`. If `tsx` is not already available, install it as a devDependency (`pnpm add -D tsx`) so node:test can load `.ts` directly; otherwise reuse whatever TS loader the repo already uses for node scripts. Keep `test:e2e` (Playwright) untouched and reserve Playwright for genuine route/browser tests.
+   - Create `runtime/dashboard/tests/unit/config-validate.test.ts` using `node:test` + `node:assert` (NOT Playwright). Cover hermetically (no Next build, no server boot):
+     - `unitsForChange(['persona'])` returns exactly `['arlowe-face.service']`.
+     - `unitsForChange(['ota'])` returns `[]`.
+     - every unit any knob maps to matches `/^(arlowe-|qwen-)|^whisper-stt\.service$/` (guards the polkit contract).
+     - the schema validation function rejects an enum-invalid `ota.channel` (compile ajv2020 against config/schema.yml via a relative path and assert it returns invalid) — proves the 422 path without spinning a live server.
+   - Place the test under `tests/unit/` so it is OUTSIDE Playwright's `testDir: './tests'` glob default... NOTE: Playwright's testDir is `./tests`, which WOULD also pick up `tests/unit/*.test.ts`. To keep the two runners disjoint, set Playwright's `testMatch` (or `testIgnore`) in playwright.config.ts to exclude `tests/unit/**` — but playwright.config.ts is NOT in this plan's files_modified and editing it touches shared config. INSTEAD: name the unit test file with a non-`.spec.ts` suffix (`.test.ts`) and rely on `test:unit` globbing only `tests/unit/*.test.ts` while Playwright's default `testMatch` is `**/*.spec.ts` (it ignores `.test.ts`). Confirm Playwright's default testMatch (`.*(test|spec)\.[jt]sx?` vs `.*\.spec\.`) — if Playwright would still collect `.test.ts`, put the unit test under `tests/unit/` and add `testIgnore: ['**/unit/**']` is OUT OF SCOPE; instead just verify `pnpm test:unit` runs the node suite and do not run it through Playwright. The hermetic suite is invoked via `test:unit`, never via `test:e2e`.
   </action>
-  <verify>`cd runtime/dashboard && npx tsc --noEmit` passes. Run the new test: `pnpm exec playwright test tests/config-validate.spec.ts` (or the project's test runner) — all cases green, including the polkit-authorization regex guard.</verify>
-  <done>restart-map maps knobs to only polkit-authorized units; a successful config write restarts the affected unit(s) via the existing seam without daemon-reload; restart failure is non-fatal; tests green.</done>
+  <verify>`cd runtime/dashboard && pnpm exec tsc --noEmit` passes. Run the hermetic suite: `pnpm test:unit` — all cases green (unitsForChange exact matches, polkit regex guard, ajv2020 rejects invalid ota.channel) with NO Next build or server boot occurring. Confirm `grep -q 'test:unit' package.json`.</verify>
+  <done>restart-map maps knobs to only polkit-authorized units (with the ports no-consumer comment); a successful config write restarts the affected unit(s) via the existing seam without daemon-reload; restart failure is non-fatal; the hermetic node:test suite passes via `pnpm test:unit` without building/booting Next.</done>
 </task>
 
 </tasks>
 
 <verification>
-- `tsc --noEmit` clean for the config route + restart-map.
-- POST validates against schema.yml before writing; invalid -> 422 no write.
-- restart-map units all match the polkit-authorized prefixes; persona -> arlowe-face.
-- config-validate.spec.ts green.
+- ajv installed (dependency + pnpm-lock.yaml + node_modules); `tsc --noEmit` clean for the config route + restart-map.
+- POST validates against schema.yml (2020-12 dialect) before writing; invalid -> 422 no write.
+- restart-map units all match the polkit-authorized prefixes; persona -> arlowe-face; ports flagged as no-live-consumer.
+- `pnpm test:unit` (node:test) green and hermetic — no Next build/boot; Playwright `test:e2e` reserved for route tests.
 </verification>
 
 <success_criteria>
-CONFIG-04 (dashboard validates before write) and CONFIG-05 (atomic write + affected-service restart) satisfied. The dashboard cannot land an invalid overlay, and a knob change triggers the correct, authorized service restart.
+CONFIG-04 (dashboard validates before write) and CONFIG-05 (atomic write + affected-service restart) satisfied. The dashboard cannot land an invalid overlay, a knob change triggers the correct authorized service restart, and the pure-function logic is covered by a hermetic unit runner (node:test) rather than a full Next build via Playwright.
 </success_criteria>
 
 <output>
 After completion, create `.planning/phases/04-config-overlay/04-03-SUMMARY.md`.
 </output>
+</content>
+</invoke>

--- a/.planning/phases/04-config-overlay/04-03-PLAN.md
+++ b/.planning/phases/04-config-overlay/04-03-PLAN.md
@@ -9,6 +9,7 @@ files_modified:
   - runtime/dashboard/app/api/config/route.ts
   - runtime/dashboard/app/api/config/restart-map.ts
   - runtime/dashboard/tests/unit/config-validate.test.ts
+  - runtime/dashboard/playwright.config.ts
 autonomous: true
 requirements_covered: [CONFIG-04, CONFIG-05]
 must_haves:
@@ -82,7 +83,7 @@ Output: ajv installed + wired into route.ts, a knob->unit restart map, restart t
 
 <task type="auto">
   <name>Task 2: knob->unit restart map + restart trigger + hermetic node:test suite</name>
-  <files>runtime/dashboard/app/api/config/restart-map.ts, runtime/dashboard/app/api/config/route.ts, runtime/dashboard/package.json, runtime/dashboard/tests/unit/config-validate.test.ts</files>
+  <files>runtime/dashboard/app/api/config/restart-map.ts, runtime/dashboard/app/api/config/route.ts, runtime/dashboard/package.json, runtime/dashboard/tests/unit/config-validate.test.ts, runtime/dashboard/playwright.config.ts</files>
   <action>
 1. Create `runtime/dashboard/app/api/config/restart-map.ts` exporting a map from top-level config knob -> affected unit name(s), per 04-RESEARCH.md Pitfall 4. At minimum:
    - `persona` -> `["arlowe-face.service"]` (the SC4 live knob; consumed by 04-04)
@@ -100,9 +101,9 @@ Output: ajv installed + wired into route.ts, a knob->unit restart map, restart t
      - `unitsForChange(['ota'])` returns `[]`.
      - every unit any knob maps to matches `/^(arlowe-|qwen-)|^whisper-stt\.service$/` (guards the polkit contract).
      - the schema validation function rejects an enum-invalid `ota.channel` (compile ajv2020 against config/schema.yml via a relative path and assert it returns invalid) — proves the 422 path without spinning a live server.
-   - Place the test under `tests/unit/` so it is OUTSIDE Playwright's `testDir: './tests'` glob default... NOTE: Playwright's testDir is `./tests`, which WOULD also pick up `tests/unit/*.test.ts`. To keep the two runners disjoint, set Playwright's `testMatch` (or `testIgnore`) in playwright.config.ts to exclude `tests/unit/**` — but playwright.config.ts is NOT in this plan's files_modified and editing it touches shared config. INSTEAD: name the unit test file with a non-`.spec.ts` suffix (`.test.ts`) and rely on `test:unit` globbing only `tests/unit/*.test.ts` while Playwright's default `testMatch` is `**/*.spec.ts` (it ignores `.test.ts`). Confirm Playwright's default testMatch (`.*(test|spec)\.[jt]sx?` vs `.*\.spec\.`) — if Playwright would still collect `.test.ts`, put the unit test under `tests/unit/` and add `testIgnore: ['**/unit/**']` is OUT OF SCOPE; instead just verify `pnpm test:unit` runs the node suite and do not run it through Playwright. The hermetic suite is invoked via `test:unit`, never via `test:e2e`.
+   - Place the test under `tests/unit/config-validate.test.ts`. CRITICAL — keep the two runners disjoint: Playwright 1.59.1's DEFAULT `testMatch` is `**/*.@(spec|test).?(c|m)[jt]s?(x)` (verified in `playwright/lib/common/config.js:164`), which matches BOTH `.spec.ts` AND `.test.ts`. Because `playwright.config.ts` has `testDir: './tests'`, an unguarded `tests/unit/*.test.ts` WOULD be collected by `pnpm test:e2e` — Playwright would then trigger the `webServer` (`pnpm build && pnpm start`) full build+boot and finally error because the file uses `node:test`/`node:assert`, not Playwright's `test()`. That silently breaks the existing e2e suite. FIX: edit `runtime/dashboard/playwright.config.ts` to add `testIgnore: ['**/unit/**'],` to the top-level `defineConfig({ ... })` (alongside `testDir`), so Playwright never collects anything under `tests/unit/`. 04-03 is the sole owner of this file — no other plan touches it — so disjointness holds. The hermetic suite is invoked ONLY via `test:unit` (globs `tests/unit/*.test.ts`); `test:e2e` (Playwright) now ignores `tests/unit/**` entirely.
   </action>
-  <verify>`cd runtime/dashboard && pnpm exec tsc --noEmit` passes. Run the hermetic suite: `pnpm test:unit` — all cases green (unitsForChange exact matches, polkit regex guard, ajv2020 rejects invalid ota.channel) with NO Next build or server boot occurring. Confirm `grep -q 'test:unit' package.json`.</verify>
+  <verify>`cd runtime/dashboard && pnpm exec tsc --noEmit` passes. Run the hermetic suite: `pnpm test:unit` — all cases green (unitsForChange exact matches, polkit regex guard, ajv2020 rejects invalid ota.channel) with NO Next build or server boot occurring. Confirm `grep -q 'test:unit' package.json` and `grep -q "testIgnore" playwright.config.ts`. Confirm the runners are disjoint: `pnpm exec playwright test --list` does NOT list `tests/unit/config-validate.test.ts` (Playwright still collects only the `.spec.ts` e2e files).</verify>
   <done>restart-map maps knobs to only polkit-authorized units (with the ports no-consumer comment); a successful config write restarts the affected unit(s) via the existing seam without daemon-reload; restart failure is non-fatal; the hermetic node:test suite passes via `pnpm test:unit` without building/booting Next.</done>
 </task>
 
@@ -112,7 +113,7 @@ Output: ajv installed + wired into route.ts, a knob->unit restart map, restart t
 - ajv installed (dependency + pnpm-lock.yaml + node_modules); `tsc --noEmit` clean for the config route + restart-map.
 - POST validates against schema.yml (2020-12 dialect) before writing; invalid -> 422 no write.
 - restart-map units all match the polkit-authorized prefixes; persona -> arlowe-face; ports flagged as no-live-consumer.
-- `pnpm test:unit` (node:test) green and hermetic — no Next build/boot; Playwright `test:e2e` reserved for route tests.
+- `pnpm test:unit` (node:test) green and hermetic — no Next build/boot; `playwright.config.ts` has `testIgnore: ['**/unit/**']` so `test:e2e` ignores the unit suite (verified via `playwright test --list`) and stays reserved for `.spec.ts` route tests.
 </verification>
 
 <success_criteria>

--- a/.planning/phases/04-config-overlay/04-04-PLAN.md
+++ b/.planning/phases/04-config-overlay/04-04-PLAN.md
@@ -9,14 +9,15 @@ files_modified:
   - runtime/face/tests/test_persona_overlay.py
   - units/arlowe-face.service
   - units/arlowe-voice.service
-  - units/qwen-api.service
+  - units/qwen-tokenizer.service
   - docs/operations/phase-4-persona-slice.md
 autonomous: false
 requirements_covered: [CONFIG-04, CONFIG-05, CONFIG-06]
 must_haves:
   truths:
     - "arlowe-face reads the persona.sentiment_mapping knob from the YAML overlay via the shared loader (SC3 absent-overlay behavior preserved)"
-    - "Each long-import service unit runs the standalone validator at ExecStartPre and refuses to start on a bad overlay (SC2)"
+    - "Each python-bearing service unit runs the standalone validator at ExecStartPre and refuses to start on a bad overlay (SC2)"
+    - "A bad overlay fail-fasts the entire qwen chain: qwen-tokenizer's ExecStartPre validator failing blocks qwen-api (which Requires=qwen-tokenizer.service)"
     - "A persona change saved through the dashboard restarts arlowe-face and takes effect on the next interaction (SC4)"
   artifacts:
     - path: "runtime/face/sentiment_classifier.py"
@@ -35,13 +36,17 @@ must_haves:
       to: "arlowe_config_validate"
       via: "ExecStartPre standalone validator"
       pattern: "ExecStartPre=.*arlowe_config_validate"
+    - from: "units/qwen-tokenizer.service"
+      to: "arlowe_config_validate"
+      via: "ExecStartPre standalone validator (gates the qwen chain via qwen-api Requires=)"
+      pattern: "ExecStartPre=.*arlowe_config_validate"
 ---
 
 <objective>
-Wire the one live end-to-end knob (persona) and add the fail-fast ExecStartPre validator to the services, then verify SC4 by hand: a persona change in the dashboard restarts arlowe-face and changes the face's behavior on the next interaction.
+Wire the one live end-to-end knob (persona) and add the fail-fast ExecStartPre validator to the python-bearing services, then verify SC4 by hand: a persona change in the dashboard restarts arlowe-face and changes the face's behavior on the next interaction.
 
-Purpose: Satisfies SC2 (refuse to start on schema violation, clean journal error) via ExecStartPre on the real services, and SC4 (one knob end-to-end) via persona. Closes CONFIG-04/05 on the consumer side and demonstrates CONFIG-06's persona knob with a live consumer. The other CONFIG-06 knobs (hostname, support_mode, ota) are DEFINED in 04-01 but have no consumer until Phases 7-10 — that is by design (04-RESEARCH.md "Key insight for the planner").
-Output: face service consumes the YAML persona knob, ExecStartPre validators on the services, a unit test, and an SC4 verification doc + human checkpoint.
+Purpose: Satisfies SC2 (refuse to start on schema violation, clean journal error) via ExecStartPre on the real python-bearing services, and SC4 (one knob end-to-end) via persona. Closes CONFIG-04/05 on the consumer side and demonstrates CONFIG-06's persona knob with a live consumer. The other CONFIG-06 knobs (hostname, support_mode, ota) are DEFINED in 04-01 but have no consumer until Phases 7-10 — that is by design (04-RESEARCH.md "Key insight for the planner").
+Output: face service consumes the YAML persona knob, ExecStartPre validators on the three python-bearing units, a unit test, and an SC4 verification doc + human checkpoint.
 </objective>
 
 <execution_context>
@@ -54,6 +59,7 @@ Output: face service consumes the YAML persona knob, ExecStartPre validators on 
 @runtime/face/sentiment_classifier.py
 @units/arlowe-face.service
 @units/arlowe-voice.service
+@units/qwen-tokenizer.service
 @units/qwen-api.service
 
 # Depends on the loader, write path, and dashboard restart from prior plans
@@ -69,14 +75,14 @@ Output: face service consumes the YAML persona knob, ExecStartPre validators on 
   <files>runtime/face/sentiment_classifier.py, runtime/face/tests/test_persona_overlay.py</files>
   <action>
 RECONCILE THE FORMAT MISMATCH: `sentiment_classifier.load_config()` currently parses the overlay as JSON (`json.load`) and reads top-level `sentiment_mapping`. The Phase 4 overlay is YAML with the mapping under `persona.sentiment_mapping`. Update `load_config()` so:
-  - It uses the shared loader: `from arlowe_config import load` (the lib is on PYTHONPATH via 04-02's install to /opt/arlowe/runtime/lib; for local/dev keep the existing graceful fallback). Prefer importing the shared loader; if import fails (dev without lib on path), fall back to direct `yaml.safe_load` of `ARLOWE_CONFIG_PATH`.
+  - It uses the shared loader: `from arlowe_config import load` (flat-module import — the lib is on PYTHONPATH via 04-02's install to /opt/arlowe/runtime/lib; for local/dev keep the existing graceful fallback). Prefer importing the shared loader; if import fails (dev without lib on path), fall back to direct `yaml.safe_load` of `ARLOWE_CONFIG_PATH`.
   - Read the persona mapping from `cfg["persona"]["sentiment_mapping"]` (the merged, validated dict), falling back to `DEFAULT_MAPPING` when the overlay is absent (preserve SC3: absent overlay -> defaults, NO crash). Keep `DEFAULT_MAPPING` and `EXPRESSION_TO_STATE` as the source of the defaults.
   - Preserve the existing public function signatures (`load_config`, `sentiment_to_expression`, `analyze_and_express`) so face_service.py keeps working unchanged.
   - The legacy `<state>/whisplay-config.json` dev fallback may remain as a last resort but the overlay (YAML) is now primary. Do not break `save_config` callers (it may stay JSON-to-state for dev, or be left as-is — just ensure load prefers the YAML overlay).
   - Use `yaml.safe_load` only; never `json.load` on the YAML overlay path.
 
 Create `runtime/face/tests/test_persona_overlay.py` (pytest):
-  1. With ARLOWE_CONFIG_PATH pointing at a YAML overlay setting `persona.sentiment_mapping.positive: ["excited"]`, `load_config()` returns a mapping whose `positive` is `["excited"]` and whose `neutral` is preserved from defaults (deep-merge check).
+  1. With ARLOWE_CONFIG_PATH pointing at a YAML overlay setting `persona.sentiment_mapping.positive: ["excited"]`, `load_config()` returns a mapping whose `positive` is `["excited"]` and whose `neutral` is preserved from defaults (deep-merge check — relies on the 04-01 partial-persona contract).
   2. With ARLOWE_CONFIG_PATH unset / nonexistent, `load_config()` returns `DEFAULT_MAPPING` and does not raise (SC3).
   Set ARLOWE_DEFAULTS_PATH / ARLOWE_SCHEMA_PATH to the repo's config/ so the shared loader resolves without /opt.
   </action>
@@ -85,33 +91,40 @@ Create `runtime/face/tests/test_persona_overlay.py` (pytest):
 </task>
 
 <task type="auto">
-  <name>Task 2: Add ExecStartPre fail-fast validator to the services (SC2)</name>
-  <files>units/arlowe-face.service, units/arlowe-voice.service, units/qwen-api.service</files>
+  <name>Task 2: Add ExecStartPre fail-fast validator to the python-bearing services (SC2)</name>
+  <files>units/arlowe-face.service, units/arlowe-voice.service, units/qwen-tokenizer.service</files>
   <action>
-Add a fail-fast config validation step before the heavy ExecStart in the three services whose imports/model-loads are slow (04-RESEARCH.md Pattern 2 / Pitfall 2). For each of `arlowe-face.service`, `arlowe-voice.service`, `qwen-api.service`, add in the `[Service]` block (before ExecStart):
+Add a fail-fast config validation step before the heavy ExecStart in the services that load the python config lib (04-RESEARCH.md Pattern 2 / Pitfall 2). These are the THREE python-bearing units, with their EXACT venv interpreters (confirmed against the merged units):
 
-  `ExecStartPre=/opt/arlowe/venvs/<svc>/bin/python -m arlowe_config_validate`
+  - `units/arlowe-face.service` — ExecStart uses `/opt/arlowe/venvs/voice/bin/python`. Add:
+      `ExecStartPre=/opt/arlowe/venvs/voice/bin/python -m arlowe_config_validate`
+  - `units/arlowe-voice.service` — ExecStart uses `/opt/arlowe/venvs/voice/bin/python`. Add:
+      `ExecStartPre=/opt/arlowe/venvs/voice/bin/python -m arlowe_config_validate`
+  - `units/qwen-tokenizer.service` — ExecStart uses `/opt/arlowe/venvs/llm/bin/python`. Add:
+      `ExecStartPre=/opt/arlowe/venvs/llm/bin/python -m arlowe_config_validate`
 
-Use the venv each unit already uses for ExecStart (face/voice use `/opt/arlowe/venvs/voice/bin/python` per arlowe-face.service; check each unit's existing ExecStart for the right venv path — qwen-api uses its own binary, so for qwen-api use whichever python venv is appropriate or the voice venv if no qwen venv exists; if qwen-api has no python venv, add the validator to a python-bearing unit only and note the limitation). The ExecStartPre MUST be non-`-`-prefixed so a non-zero exit prevents the service from starting (this is what satisfies SC2).
+WHY qwen-tokenizer AND NOT qwen-api (resolves checker Blocker 1): `qwen-api.service` has NO python venv — its ExecStart is the native `/opt/arlowe/runtime/llm/run_api.sh`, so it has no interpreter to run `-m arlowe_config_validate`. But `qwen-api.service` declares `Requires=qwen-tokenizer.service`, and `qwen-tokenizer.service` DOES have `/opt/arlowe/venvs/llm/bin/python`. Putting the validator on qwen-tokenizer therefore fail-fasts the ENTIRE qwen chain: if the overlay is bad, qwen-tokenizer's ExecStartPre exits 78, tokenizer fails to start, and qwen-api (which Requires it) is blocked. Do NOT add any validator to qwen-api.service — it stays untouched.
 
-Ensure the units export `PYTHONPATH` such that `arlowe_config_validate` is importable — units currently set `PYTHONPATH=/opt/arlowe/runtime`. 04-02 installs the lib to `/opt/arlowe/runtime/lib`. Either append `:/opt/arlowe/runtime/lib` to PYTHONPATH in each edited unit, OR set the ExecStartPre's own `PYTHONPATH`. Pick one and apply consistently; confirm it matches where 04-02 installs the lib.
+Each ExecStartPre MUST be non-`-`-prefixed so a non-zero exit prevents the service from starting (this is what satisfies SC2).
+
+Ensure the lib is importable: units currently set `Environment=PYTHONPATH=/opt/arlowe/runtime`, and 04-02 installs the flat lib modules to `/opt/arlowe/runtime/lib`. In each of the three edited units, append `:/opt/arlowe/runtime/lib` to the existing PYTHONPATH so it reads `Environment=PYTHONPATH=/opt/arlowe/runtime:/opt/arlowe/runtime/lib`. (qwen-tokenizer may not currently set PYTHONPATH — if so, add `Environment=PYTHONPATH=/opt/arlowe/runtime/lib`.) Apply consistently; the path must match where 04-02 installs the lib so `from arlowe_config import load` resolves.
 
 Do NOT touch the unrelated Phase 3 debt in these units (e.g. arlowe-face's SupplementaryGroups / /dev/fb0 — out of scope for Phase 4). Only add the ExecStartPre + PYTHONPATH adjustment.
   </action>
-  <verify>`systemd-analyze verify units/arlowe-face.service units/arlowe-voice.service units/qwen-api.service` reports no new errors (run in the testbed if not available locally). Confirm each edited unit contains a non-`-`-prefixed `ExecStartPre=.*arlowe_config_validate` and a PYTHONPATH that includes the lib dir. Sanity: a deliberately bad overlay should make the validator exit 78 (already proven in 04-01); the ExecStartPre wiring just means systemd refuses start.</verify>
-  <done>Each python-bearing service runs arlowe_config_validate at ExecStartPre with the lib importable; a schema violation prevents start (SC2); no Phase 3 sandbox settings changed.</done>
+  <verify>`systemd-analyze verify units/arlowe-face.service units/arlowe-voice.service units/qwen-tokenizer.service` reports no new errors (run in the testbed if not available locally). Confirm each of the three edited units contains a non-`-`-prefixed `ExecStartPre=.*arlowe_config_validate` with the correct venv interpreter (voice venv for face/voice, llm venv for qwen-tokenizer) and a PYTHONPATH that includes `/opt/arlowe/runtime/lib`. Confirm `units/qwen-api.service` was NOT modified (`git diff --quiet units/qwen-api.service`). Sanity: a deliberately bad overlay should make the validator exit 78 (already proven in 04-01); the ExecStartPre wiring just means systemd refuses start, and a tokenizer fail blocks qwen-api via Requires=.</verify>
+  <done>arlowe-face + arlowe-voice (voice venv) and qwen-tokenizer (llm venv) each run arlowe_config_validate at ExecStartPre with the lib importable; a schema violation prevents start (SC2) and fail-fasts the qwen chain via qwen-tokenizer; qwen-api.service is untouched; no Phase 3 sandbox settings changed.</done>
 </task>
 
 <task type="checkpoint:human-verify" gate="blocking">
   <what-built>
-The persona config knob end-to-end: dashboard validates + writes /etc/arlowe/config.yml + restarts arlowe-face (04-03), the face service reads persona.sentiment_mapping from the YAML overlay (Task 1), and ExecStartPre fails fast on a bad overlay (Task 2). docs/operations/phase-4-persona-slice.md documents the procedure.
+The persona config knob end-to-end: dashboard validates + writes /etc/arlowe/config.yml + restarts arlowe-face (04-03), the face service reads persona.sentiment_mapping from the YAML overlay (Task 1), and ExecStartPre fails fast on a bad overlay (Task 2 — on arlowe-face, arlowe-voice, and qwen-tokenizer, the latter gating the qwen chain). docs/operations/phase-4-persona-slice.md documents the procedure. NOTE: validator EXECUTION is verified here on the provisioned unit (the Docker testbed in 04-02 is stat-only, per ADR/Warning 4), so this checkpoint is where the python loader actually runs against installed jsonschema/PyYAML.
   </what-built>
   <how-to-verify>
 On the arlowe-1 staging unit (or the dev Pi with Phase 4 provisioned), follow docs/operations/phase-4-persona-slice.md:
 1. Confirm `/etc/arlowe/config.yml` is absent -> services start, face uses DEFAULT_MAPPING (SC3). `systemctl status arlowe-face` is active.
 2. Through the dashboard Settings (or `curl -X POST http://localhost:3000/api/config` with a body that changes `persona.sentiment_mapping.positive` to a distinct expression, e.g. `["excited"]`): confirm HTTP 200, `/etc/arlowe/config.yml` now exists and is valid YAML, and `journalctl -u arlowe-face` shows the unit restarted.
 3. Trigger an interaction with positive sentiment (or call the face/sentiment path) and confirm the face state reflects the new mapping (e.g. shows the "excited" expression rather than the default "happy").
-4. Negative test (SC2): `curl -X POST` an invalid body (e.g. `ota.channel: "purple"`) -> expect HTTP 422 and NO change to config.yml. Then write a bad overlay directly and `systemctl restart arlowe-face` -> confirm it FAILS to start and `journalctl -u arlowe-face` shows `[arlowe-config] schema violation ...` with exit code 78.
+4. Negative test (SC2): `curl -X POST` an invalid body (e.g. `ota.channel: "purple"`) -> expect HTTP 422 and NO change to config.yml. Then write a bad overlay directly and `systemctl restart arlowe-face` -> confirm it FAILS to start and `journalctl -u arlowe-face` shows `[arlowe-config] schema violation ...` with exit code 78. Also `systemctl restart qwen-tokenizer` with the bad overlay -> confirm it fails to start, and `systemctl start qwen-api` is blocked (Requires= the failed tokenizer).
 Record pass/fail per step in the SUMMARY.
   </how-to-verify>
   <resume-signal>Type "approved" if all four steps pass, or describe which step failed and what you observed.</resume-signal>
@@ -121,14 +134,16 @@ Record pass/fail per step in the SUMMARY.
 
 <verification>
 - test_persona_overlay.py green (overlay overrides default; absent overlay -> default, no crash).
-- systemd-analyze verify clean on the three edited units; each has a fail-fast ExecStartPre validator.
-- Human checkpoint: persona change -> restart -> effect (SC4); invalid overlay -> 422 / service refuses start (SC2).
+- systemd-analyze verify clean on the three edited units (arlowe-face, arlowe-voice, qwen-tokenizer); each has a fail-fast ExecStartPre validator with the correct venv; qwen-api.service untouched.
+- Human checkpoint (validator execution verified on the provisioned unit): persona change -> restart -> effect (SC4); invalid overlay -> 422 / service refuses start, qwen chain blocked via tokenizer (SC2).
 </verification>
 
 <success_criteria>
-SC2 (refuse to start on schema violation with clean journal error), SC3 (absent overlay is a recognized non-error state — preserved), and SC4 (one knob end-to-end: persona change restarts the service and takes effect) are all satisfied on real-ish hardware. CONFIG-06's persona knob has a verified live consumer; the remaining knobs are defined-and-validated for their downstream phases.
+SC2 (refuse to start on schema violation with clean journal error — including the qwen chain via qwen-tokenizer), SC3 (absent overlay is a recognized non-error state — preserved), and SC4 (one knob end-to-end: persona change restarts the service and takes effect) are all satisfied on real-ish hardware. CONFIG-06's persona knob has a verified live consumer; the remaining knobs are defined-and-validated for their downstream phases.
 </success_criteria>
 
 <output>
 After completion, create `.planning/phases/04-config-overlay/04-04-SUMMARY.md`.
 </output>
+</content>
+</invoke>

--- a/.planning/phases/04-config-overlay/04-04-PLAN.md
+++ b/.planning/phases/04-config-overlay/04-04-PLAN.md
@@ -1,0 +1,134 @@
+---
+phase: 04-config-overlay
+plan: 04
+type: execute
+wave: 3
+depends_on: ["04-01", "04-02", "04-03"]
+files_modified:
+  - runtime/face/sentiment_classifier.py
+  - runtime/face/tests/test_persona_overlay.py
+  - units/arlowe-face.service
+  - units/arlowe-voice.service
+  - units/qwen-api.service
+  - docs/operations/phase-4-persona-slice.md
+autonomous: false
+requirements_covered: [CONFIG-04, CONFIG-05, CONFIG-06]
+must_haves:
+  truths:
+    - "arlowe-face reads the persona.sentiment_mapping knob from the YAML overlay via the shared loader (SC3 absent-overlay behavior preserved)"
+    - "Each long-import service unit runs the standalone validator at ExecStartPre and refuses to start on a bad overlay (SC2)"
+    - "A persona change saved through the dashboard restarts arlowe-face and takes effect on the next interaction (SC4)"
+  artifacts:
+    - path: "runtime/face/sentiment_classifier.py"
+      provides: "load_config() consumes persona.sentiment_mapping from YAML overlay via arlowe_config.load()"
+      contains: "persona"
+    - path: "runtime/face/tests/test_persona_overlay.py"
+      provides: "Test: overlay persona mapping overrides default; absent overlay -> default"
+    - path: "docs/operations/phase-4-persona-slice.md"
+      provides: "SC4 end-to-end verification procedure (change -> restart -> effect)"
+  key_links:
+    - from: "runtime/face/sentiment_classifier.py"
+      to: "runtime/lib/arlowe_config.py"
+      via: "imports load() to read persona knob"
+      pattern: "arlowe_config|persona"
+    - from: "units/arlowe-face.service"
+      to: "arlowe_config_validate"
+      via: "ExecStartPre standalone validator"
+      pattern: "ExecStartPre=.*arlowe_config_validate"
+---
+
+<objective>
+Wire the one live end-to-end knob (persona) and add the fail-fast ExecStartPre validator to the services, then verify SC4 by hand: a persona change in the dashboard restarts arlowe-face and changes the face's behavior on the next interaction.
+
+Purpose: Satisfies SC2 (refuse to start on schema violation, clean journal error) via ExecStartPre on the real services, and SC4 (one knob end-to-end) via persona. Closes CONFIG-04/05 on the consumer side and demonstrates CONFIG-06's persona knob with a live consumer. The other CONFIG-06 knobs (hostname, support_mode, ota) are DEFINED in 04-01 but have no consumer until Phases 7-10 — that is by design (04-RESEARCH.md "Key insight for the planner").
+Output: face service consumes the YAML persona knob, ExecStartPre validators on the services, a unit test, and an SC4 verification doc + human checkpoint.
+</objective>
+
+<execution_context>
+@~/.claude/get-shit-done/workflows/execute-plan.md
+@~/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/phases/04-config-overlay/04-RESEARCH.md
+@runtime/face/sentiment_classifier.py
+@units/arlowe-face.service
+@units/arlowe-voice.service
+@units/qwen-api.service
+
+# Depends on the loader, write path, and dashboard restart from prior plans
+@.planning/phases/04-config-overlay/04-01-PLAN.md
+@.planning/phases/04-config-overlay/04-02-PLAN.md
+@.planning/phases/04-config-overlay/04-03-PLAN.md
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Face service consumes persona knob from YAML overlay via shared loader</name>
+  <files>runtime/face/sentiment_classifier.py, runtime/face/tests/test_persona_overlay.py</files>
+  <action>
+RECONCILE THE FORMAT MISMATCH: `sentiment_classifier.load_config()` currently parses the overlay as JSON (`json.load`) and reads top-level `sentiment_mapping`. The Phase 4 overlay is YAML with the mapping under `persona.sentiment_mapping`. Update `load_config()` so:
+  - It uses the shared loader: `from arlowe_config import load` (the lib is on PYTHONPATH via 04-02's install to /opt/arlowe/runtime/lib; for local/dev keep the existing graceful fallback). Prefer importing the shared loader; if import fails (dev without lib on path), fall back to direct `yaml.safe_load` of `ARLOWE_CONFIG_PATH`.
+  - Read the persona mapping from `cfg["persona"]["sentiment_mapping"]` (the merged, validated dict), falling back to `DEFAULT_MAPPING` when the overlay is absent (preserve SC3: absent overlay -> defaults, NO crash). Keep `DEFAULT_MAPPING` and `EXPRESSION_TO_STATE` as the source of the defaults.
+  - Preserve the existing public function signatures (`load_config`, `sentiment_to_expression`, `analyze_and_express`) so face_service.py keeps working unchanged.
+  - The legacy `<state>/whisplay-config.json` dev fallback may remain as a last resort but the overlay (YAML) is now primary. Do not break `save_config` callers (it may stay JSON-to-state for dev, or be left as-is — just ensure load prefers the YAML overlay).
+  - Use `yaml.safe_load` only; never `json.load` on the YAML overlay path.
+
+Create `runtime/face/tests/test_persona_overlay.py` (pytest):
+  1. With ARLOWE_CONFIG_PATH pointing at a YAML overlay setting `persona.sentiment_mapping.positive: ["excited"]`, `load_config()` returns a mapping whose `positive` is `["excited"]` and whose `neutral` is preserved from defaults (deep-merge check).
+  2. With ARLOWE_CONFIG_PATH unset / nonexistent, `load_config()` returns `DEFAULT_MAPPING` and does not raise (SC3).
+  Set ARLOWE_DEFAULTS_PATH / ARLOWE_SCHEMA_PATH to the repo's config/ so the shared loader resolves without /opt.
+  </action>
+  <verify>From repo root: `PYTHONPATH=runtime/lib:runtime/face ARLOWE_SCHEMA_PATH=config/schema.yml ARLOWE_DEFAULTS_PATH=config/defaults.yml python3 -m pytest runtime/face/tests/test_persona_overlay.py -q` passes both cases. Confirm `grep -q "persona" runtime/face/sentiment_classifier.py`.</verify>
+  <done>load_config() reads persona.sentiment_mapping from the validated YAML overlay (deep-merge over defaults), returns defaults when overlay absent without crashing, and existing face_service callers are unaffected.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Add ExecStartPre fail-fast validator to the services (SC2)</name>
+  <files>units/arlowe-face.service, units/arlowe-voice.service, units/qwen-api.service</files>
+  <action>
+Add a fail-fast config validation step before the heavy ExecStart in the three services whose imports/model-loads are slow (04-RESEARCH.md Pattern 2 / Pitfall 2). For each of `arlowe-face.service`, `arlowe-voice.service`, `qwen-api.service`, add in the `[Service]` block (before ExecStart):
+
+  `ExecStartPre=/opt/arlowe/venvs/<svc>/bin/python -m arlowe_config_validate`
+
+Use the venv each unit already uses for ExecStart (face/voice use `/opt/arlowe/venvs/voice/bin/python` per arlowe-face.service; check each unit's existing ExecStart for the right venv path — qwen-api uses its own binary, so for qwen-api use whichever python venv is appropriate or the voice venv if no qwen venv exists; if qwen-api has no python venv, add the validator to a python-bearing unit only and note the limitation). The ExecStartPre MUST be non-`-`-prefixed so a non-zero exit prevents the service from starting (this is what satisfies SC2).
+
+Ensure the units export `PYTHONPATH` such that `arlowe_config_validate` is importable — units currently set `PYTHONPATH=/opt/arlowe/runtime`. 04-02 installs the lib to `/opt/arlowe/runtime/lib`. Either append `:/opt/arlowe/runtime/lib` to PYTHONPATH in each edited unit, OR set the ExecStartPre's own `PYTHONPATH`. Pick one and apply consistently; confirm it matches where 04-02 installs the lib.
+
+Do NOT touch the unrelated Phase 3 debt in these units (e.g. arlowe-face's SupplementaryGroups / /dev/fb0 — out of scope for Phase 4). Only add the ExecStartPre + PYTHONPATH adjustment.
+  </action>
+  <verify>`systemd-analyze verify units/arlowe-face.service units/arlowe-voice.service units/qwen-api.service` reports no new errors (run in the testbed if not available locally). Confirm each edited unit contains a non-`-`-prefixed `ExecStartPre=.*arlowe_config_validate` and a PYTHONPATH that includes the lib dir. Sanity: a deliberately bad overlay should make the validator exit 78 (already proven in 04-01); the ExecStartPre wiring just means systemd refuses start.</verify>
+  <done>Each python-bearing service runs arlowe_config_validate at ExecStartPre with the lib importable; a schema violation prevents start (SC2); no Phase 3 sandbox settings changed.</done>
+</task>
+
+<task type="checkpoint:human-verify" gate="blocking">
+  <what-built>
+The persona config knob end-to-end: dashboard validates + writes /etc/arlowe/config.yml + restarts arlowe-face (04-03), the face service reads persona.sentiment_mapping from the YAML overlay (Task 1), and ExecStartPre fails fast on a bad overlay (Task 2). docs/operations/phase-4-persona-slice.md documents the procedure.
+  </what-built>
+  <how-to-verify>
+On the arlowe-1 staging unit (or the dev Pi with Phase 4 provisioned), follow docs/operations/phase-4-persona-slice.md:
+1. Confirm `/etc/arlowe/config.yml` is absent -> services start, face uses DEFAULT_MAPPING (SC3). `systemctl status arlowe-face` is active.
+2. Through the dashboard Settings (or `curl -X POST http://localhost:3000/api/config` with a body that changes `persona.sentiment_mapping.positive` to a distinct expression, e.g. `["excited"]`): confirm HTTP 200, `/etc/arlowe/config.yml` now exists and is valid YAML, and `journalctl -u arlowe-face` shows the unit restarted.
+3. Trigger an interaction with positive sentiment (or call the face/sentiment path) and confirm the face state reflects the new mapping (e.g. shows the "excited" expression rather than the default "happy").
+4. Negative test (SC2): `curl -X POST` an invalid body (e.g. `ota.channel: "purple"`) -> expect HTTP 422 and NO change to config.yml. Then write a bad overlay directly and `systemctl restart arlowe-face` -> confirm it FAILS to start and `journalctl -u arlowe-face` shows `[arlowe-config] schema violation ...` with exit code 78.
+Record pass/fail per step in the SUMMARY.
+  </how-to-verify>
+  <resume-signal>Type "approved" if all four steps pass, or describe which step failed and what you observed.</resume-signal>
+</task>
+
+</tasks>
+
+<verification>
+- test_persona_overlay.py green (overlay overrides default; absent overlay -> default, no crash).
+- systemd-analyze verify clean on the three edited units; each has a fail-fast ExecStartPre validator.
+- Human checkpoint: persona change -> restart -> effect (SC4); invalid overlay -> 422 / service refuses start (SC2).
+</verification>
+
+<success_criteria>
+SC2 (refuse to start on schema violation with clean journal error), SC3 (absent overlay is a recognized non-error state — preserved), and SC4 (one knob end-to-end: persona change restarts the service and takes effect) are all satisfied on real-ish hardware. CONFIG-06's persona knob has a verified live consumer; the remaining knobs are defined-and-validated for their downstream phases.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/04-config-overlay/04-04-SUMMARY.md`.
+</output>

--- a/.planning/phases/04-config-overlay/04-RESEARCH.md
+++ b/.planning/phases/04-config-overlay/04-RESEARCH.md
@@ -1,0 +1,255 @@
+# Phase 4: Config overlay - Research
+
+**Researched:** 2026-06-07
+**Domain:** Schema-validated config for a mixed Python + Next.js runtime under systemd
+**Confidence:** HIGH (repo facts), MEDIUM (library choice — verified against repo deps + ecosystem)
+
+## Summary
+
+Phase 4 replaces hardcoded runtime literals with a two-file overlay: `/opt/arlowe/config/defaults.yml` (shipped, root-owned, read-only) merged with optional `/etc/arlowe/config.yml` (owner-mutable overlay), both validated against `config/schema.yml`. The runtime is **already wired for this pattern**: every Python service reads `ARLOWE_*` environment variables with sensible defaults (set by the systemd units), and `sentiment_classifier.py` already loads `ARLOWE_CONFIG_PATH=/etc/arlowe/config.yml` with a graceful "fall back to default mapping" path. The dashboard already has a `POST /api/config` route that does temp+rename writes (with a `TODO(phase-4): validate against schema` marker) and a `GET` route that returns `{paired:false}` when the overlay is absent.
+
+The cleanest, lowest-friction architecture given this repo: keep **systemd env vars as the injection layer** and introduce a thin config-resolution step that loads defaults+overlay, validates against the schema, and either (a) is sourced into the unit's environment via `ExecStartPre`/`EnvironmentFile`, or (b) is imported by a shared Python module that services already import. Validation lives in **Python (jsonschema, draft 2020-12)** as the single source of truth; the Next.js dashboard reuses the **same `schema.yml` via a small JSON-Schema validation in JS** (ajv) so both sides validate against one file. PyYAML is already a dependency (tts) and `js-yaml` is already a dashboard dependency — no new YAML libs needed.
+
+**The single biggest blocker to surface:** `/etc/arlowe/` is provisioned `root:arlowe 0755` (Phase 3 `install-arlowe-fs.sh`). The dashboard runs as user `arlowe` under `ProtectSystem=strict`, and the unit's `ReadWritePaths` does **not** include `/etc/arlowe`. With dir mode 0755 the `arlowe` user cannot create `config.yml` even if the path were writable. The unit file already carries a `FIXME(Phase 4)` saying the write must go through "a privileged helper (polkit or setuid helper)." **Phase 4 must resolve how the dashboard persists the overlay** — this is not a detail, it's a design fork.
+
+**Primary recommendation:** Schema authored once as JSON Schema embedded in `config/schema.yml`; validated in Python with `jsonschema`, in the dashboard with `ajv`. Config resolution lives in a shared Python module (`runtime/lib/arlowe_config.py`) imported by services; validation runs at service entry (clean journal error + `sys.exit(1)`) AND a standalone `arlowe-config-validate` invoked by `ExecStartPre=` so a bad overlay fails fast before the interpreter loads heavy ML deps. Dashboard writes via a small root helper invoked through the existing polkit/systemctl seam (see Pitfall 1).
+
+## Standard Stack
+
+### Core
+| Library | Version | Purpose | Why Standard |
+|---------|---------|---------|--------------|
+| PyYAML | 6.0.3 (already pinned in `runtime/tts/requirements.txt`) | Parse `defaults.yml` + overlay in Python | Already in tree; `yaml.safe_load` is the canonical safe parse |
+| jsonschema | latest 4.x (draft 2020-12 support) | Validate merged config against schema in Python | De-facto standard; language-agnostic schema reusable by JS; no model boilerplate |
+| js-yaml | ^4.1.1 (already a dashboard dep) | Parse YAML in the Next.js route | Already imported in `app/api/config/route.ts` |
+| ajv | ^8.x (new dashboard dep) | Validate config against the same JSON Schema in the dashboard | Standard Node JSON-Schema validator; lets the dashboard pre-validate before write |
+
+### Supporting
+| Library | Version | Purpose | When to Use |
+|---------|---------|---------|-------------|
+| (none — stdlib `os`, `pathlib`) | - | Env injection, path merge | Config resolution is small enough to avoid a config framework |
+
+### Alternatives Considered
+| Instead of | Could Use | Tradeoff |
+|------------|-----------|----------|
+| jsonschema (Python) | Pydantic v2 | Pydantic is faster and ergonomic BUT its schema lives in Python classes, not a shareable file — the dashboard could only consume it via a *generated* JSON Schema (extra build step). The success criterion is `config/schema.yml` as the artifact; jsonschema consumes that file directly on both sides. Pick jsonschema for single-source-of-truth. |
+| jsonschema | Cerberus / Voluptuous | Pythonic but not consumable by the Node dashboard; would force a second schema definition. Rejected. |
+| Validate in both Python+JS | Validate only in Python; dashboard POSTs raw, Python rejects | Simpler (one validator) but the dashboard couldn't give the user inline errors before write, and an invalid overlay could land on disk and brick a restart. Recommend validate-before-write in the dashboard too. |
+
+**Installation:**
+```bash
+# Python (add to a shared runtime/lib/requirements.txt or each service that loads config)
+# jsonschema; PyYAML already present
+# Dashboard
+pnpm add ajv          # js-yaml already present
+```
+
+## Architecture Patterns
+
+### Existing injection convention (DO NOT fight this)
+Every Python service already resolves config from `ARLOWE_*` env vars with literal defaults, set by the systemd units. Examples verified in-repo:
+
+- `runtime/voice/voice_client.py`: `ARLOWE_FACE_URL`, `ARLOWE_STT_URL`, `ARLOWE_DASHBOARD_URL`, `ARLOWE_PIPER_MODEL`, `ARLOWE_ALSA_DEVICE` (Phase 5), `ARLOWE_VERIFIER_MODEL`
+- `runtime/llm/router.py`: `ARLOWE_VOICE_MODEL`, `ARLOWE_VOICE_TIMEOUT`, `ARLOWE_STATE_DIR`
+- `runtime/face/sentiment_classifier.py`: **already reads `ARLOWE_CONFIG_PATH=/etc/arlowe/config.yml`** and falls back to a default mapping — this is the reference implementation for "absent overlay = not-yet-paired, no crash."
+- Units inject the env (`arlowe-voice.service`, `arlowe-face.service`, `arlowe-dashboard.service` already set `ARLOWE_CONFIG_PATH`, `ARLOWE_LOGS_DIR`, etc.)
+
+**Implication for the plan:** the config knobs map to env vars the services already consume. The loader's job is to translate `defaults.yml` + overlay → the `ARLOWE_*` values, OR services import a shared resolver that returns a validated dict. Two viable shapes below.
+
+### Recommended Project Structure
+```
+config/
+├── schema.yml          # JSON Schema (CONFIG-01) — type, default, enum, description per knob
+└── defaults.yml        # shipped defaults (CONFIG-02); installed to /opt/arlowe/config/defaults.yml
+runtime/lib/            # NEW shared lib dir (mirror of /opt/arlowe/runtime/lib at runtime)
+├── arlowe_config.py    # load(defaults, overlay) -> validate -> merged dict; raises on violation
+└── requirements.txt    # jsonschema, PyYAML
+scripts/provision/
+└── install-arlowe-config.sh   # NEW: installs defaults.yml + schema.yml into /opt/arlowe/config
+```
+Note: `install-arlowe-fs.sh` already creates `/opt/arlowe/config` and intentionally does NOT create `defaults.yml` (its comments mark that as the Phase-4 contract). Add a content installer; do not modify the fs installer's directory creation.
+
+### Pattern 1: Config resolution + validation in a shared module
+**What:** One module both services and a CLI validator import.
+**When to use:** Always; keeps merge/validate logic in one place.
+```python
+# runtime/lib/arlowe_config.py  (installed to /opt/arlowe/runtime/lib/)
+import os, sys, yaml, json
+from pathlib import Path
+from jsonschema import Draft202012Validator
+
+DEFAULTS = Path(os.environ.get("ARLOWE_DEFAULTS_PATH", "/opt/arlowe/config/defaults.yml"))
+OVERLAY  = Path(os.environ.get("ARLOWE_CONFIG_PATH",   "/etc/arlowe/config.yml"))
+SCHEMA   = Path(os.environ.get("ARLOWE_SCHEMA_PATH",   "/opt/arlowe/config/schema.yml"))
+
+def load() -> dict:
+    defaults = yaml.safe_load(DEFAULTS.read_text())
+    overlay  = yaml.safe_load(OVERLAY.read_text()) if OVERLAY.exists() else {}  # absent overlay == not paired
+    merged   = {**defaults, **(overlay or {})}      # shallow; deep-merge per-knob if nested
+    schema   = yaml.safe_load(SCHEMA.read_text())
+    errors   = sorted(Draft202012Validator(schema).iter_errors(merged), key=lambda e: e.path)
+    if errors:
+        for e in errors:
+            print(f"[arlowe-config] schema violation at {'/'.join(map(str,e.path)) or '<root>'}: {e.message}", file=sys.stderr)
+        raise SystemExit(78)   # EX_CONFIG (sysexits.h) — clean, greppable in journal
+    return merged
+```
+`SystemExit(78)` = `EX_CONFIG`; systemd records it and the journal shows the stderr lines. Distinct from generic crash exit codes.
+
+### Pattern 2: Fail-fast at ExecStartPre (before heavy imports)
+**What:** A standalone validator the unit runs before the real ExecStart.
+**When to use:** For services with slow imports (voice loads openwakeword/onnx; llm loads transformers) — you want the config rejected in milliseconds, not after a 10s model load.
+```ini
+# in each *.service [Service] block
+ExecStartPre=/opt/arlowe/venvs/<svc>/bin/python -m arlowe_config_validate
+ExecStart=...
+```
+A bare `ExecStartPre` that exits non-zero **prevents the main process from starting** (verified: systemd treats a non-`-`-prefixed ExecStartPre failure as a unit start failure; the journal shows the pre-start exit). This directly satisfies SC2 "refuse to start on schema violation with a clear journal error."
+
+### Pattern 3: Env injection vs. in-process load — pick in planning
+- **Option A (in-process):** services `from arlowe_config import load; cfg = load()` and read knobs from the dict. Cleanest single source of truth. Requires `runtime/lib` on `PYTHONPATH` (units already set `PYTHONPATH=/opt/arlowe/runtime`; put the lib under `runtime/lib` and adjust, or under an existing importable package).
+- **Option B (env bridge):** an `ExecStartPre` writes resolved values to an `EnvironmentFile` that the unit reads, preserving the existing `ARLOWE_*` env convention with zero Python-code change in services. Lower blast radius for Phase 4 (services keep reading env), but adds a generated file in `/run`.
+  - Recommend **A for services that already need structured config** (face sentiment mapping, persona), **B as the migration shim** for the pure-env knobs (ports, URLs) so Phase 4 doesn't rewrite every service. Planner should decide per knob.
+
+### Anti-Patterns to Avoid
+- **Re-deriving the schema in two languages.** One `schema.yml`; both validators read it.
+- **Validating only in the dashboard.** The image must boot and validate without the dashboard running (first-boot, pre-pairing). Python validation at service start is the authoritative gate; dashboard validation is UX.
+- **Deep-merging silently.** Decide shallow vs deep merge explicitly and document it in schema comments; mismatched nesting between defaults and overlay is a classic config bug.
+- **Treating absent overlay as an error.** `sentiment_classifier.load_config()` already models the correct behavior: absent overlay → use defaults, no crash (SC3).
+
+## Don't Hand-Roll
+
+| Problem | Don't Build | Use Instead | Why |
+|---------|-------------|-------------|-----|
+| Config validation | Hand-written type/enum checks | `jsonschema` (Py) + `ajv` (JS) against `schema.yml` | Enums, defaults, type coercion, nested errors, path reporting are all solved; hand-rolled checks drift from the schema |
+| Atomic overlay write | Plain `writeFile` | temp-file + `rename()` (already done in `route.ts`) | Already correct in repo — keep it, just add validation before write |
+| YAML parse | regex / manual | `yaml.safe_load` / `js-yaml` (both present) | Never `yaml.load` (unsafe); never hand-parse |
+| Privileged write to /etc | setuid wrapper from scratch | systemd-run/polkit seam OR a tiny audited helper | See Pitfall 1 — getting privilege boundaries right is security-critical (this is package:security territory) |
+
+## Common Pitfalls
+
+### Pitfall 1: The dashboard cannot write /etc/arlowe/config.yml as-is (BLOCKER)
+**What goes wrong:** `route.ts` does `writeFile('/etc/arlowe/.config.yml.tmp')` then `rename()` to `/etc/arlowe/config.yml`. But:
+- The dir is provisioned `root:arlowe 0755` (`install-arlowe-fs.sh`) — group `arlowe` has `r-x`, **not** write. The `arlowe` user cannot create files there.
+- The `arlowe-dashboard.service` unit runs `ProtectSystem=strict` and lists `ReadWritePaths=/var/lib/arlowe/dashboard /var/lib/arlowe/logs/dashboard` — `/etc/arlowe` is **not** writable even if perms allowed it. The unit's own comment: *"`/etc/arlowe/config.yml` is intentionally NOT in ReadWritePaths — the dashboard POST /api/config route goes through a privileged helper. FIXME(Phase 4): wire the privileged-helper write path."*
+
+**Why it happens:** Phase 3 deliberately deferred the write path to Phase 4.
+**How to avoid / options for the planner:**
+1. **Privileged helper via the existing systemctl/polkit seam.** The dashboard already shells out (`child_process.exec`) for nmcli. A small root-owned helper (`/usr/local/sbin/arlowe-write-config`) invoked through a polkit-authorized path can validate-then-write. The polkit rule today only covers `org.freedesktop.systemd1.manage-units` — writing config is a *different* action, so this needs a new authorized mechanism (a dedicated polkit action, a `systemd-run` transient unit, or a setuid helper).
+2. **Loosen perms:** make `/etc/arlowe` `root:arlowe 0775` (group-writable) AND add `ReadWritePaths=/etc/arlowe` to the dashboard unit. Simplest, but widens the dashboard's write surface into `/etc` — weigh against the sandbox hardening Phase 3 invested in.
+3. **State dir instead of /etc:** write the overlay to an `arlowe`-writable path and symlink/bind — rejected, breaks the CONFIG-03 `/etc/arlowe/config.yml` contract that other services and the GET route already hardcode.
+**Recommendation:** Option 1 (helper) is the security-correct answer and matches the unit's own FIXME, but it is the heaviest. Option 2 is defensible if the dashboard is already trusted (it can restart services via polkit anyway). **This is a real design decision — flag for the planner to resolve before writing tasks, likely as an ADR.** Treat any task touching this as `package:security`.
+
+### Pitfall 2: Validation after heavy imports = slow failure
+**What goes wrong:** Validating inside `voice_client.py` after `import openwakeword, onnxruntime` means a bad overlay takes ~10s to reject.
+**How to avoid:** `ExecStartPre` standalone validator (Pattern 2) rejects in <1s before the real process loads.
+
+### Pitfall 3: defaults.yml must contain ZERO founder literals
+**What goes wrong:** CI sanitize gate (Phase 2) fails any tracked file (not in `.sanitize-allowlist`) containing `focal55`, `arlowe-1`, etc. `config/defaults.yml` and `config/schema.yml` will be **scanned** (they ship in the image — they must NOT be allow-listed).
+**How to avoid:** hostname default must be a template like `arlowe-${device_serial}` (resolved Phase 7/8), never `arlowe-1`. Audio device default `plughw:2,0` is Phase 5's concern, not a founder literal. Run `scripts/sanitize` locally before commit.
+**Warning signs:** any concrete personal name, the dev Pi hostname, ElevenLabs keys (`tts_sync.py` reads `ELEVENLABS_API_KEY` from env — keep that out of defaults.yml).
+
+### Pitfall 4: Restart trigger must use the units' real names
+**What goes wrong:** A persona change should restart only the affected unit. The polkit rule authorizes `arlowe` to manage units matching `arlowe-*`, `qwen-*`, or exactly `whisper-stt.service` — nothing else, and NOT `daemon-reload`.
+**How to avoid:** map each knob → affected unit(s). Persona/face → `arlowe-face.service` (+ maybe `arlowe-voice`); model choice → `qwen-api`/`qwen-tokenizer`; audio (Phase 5) → `arlowe-voice`. The dashboard restart goes `systemctl restart <unit>` and succeeds without sudo via the Phase 3 polkit rule (its comment explicitly lists "dashboard POST /api/config (Phase 4 will use)").
+**Warning signs:** attempting `daemon-reload` (denied) or restarting a non-prefixed unit (denied).
+
+### Pitfall 5: Shallow vs deep merge of defaults+overlay
+**What goes wrong:** `{**defaults, **overlay}` replaces whole top-level keys. If `persona` is a nested object and the overlay sets only one sub-field, the rest is lost.
+**How to avoid:** decide per-knob; document; deep-merge nested objects if any knob is structured (persona/face assets likely are).
+
+## CONFIG-06 Knob Inventory (real, against the repo)
+
+Knobs required by CONFIG-06, mapped to where the literal currently lives:
+
+| Knob | Current literal / env | File(s) | Affected unit |
+|------|----------------------|---------|---------------|
+| hostname | (none yet; Phase 7/8 device identity) | — | system; not a service env |
+| audio devices | `ARLOWE_ALSA_DEVICE="plughw:2,0"` (Phase 5 owns the *detection*, Phase 4 owns the *knob*) | `voice_client.py:49-50`, `wake-word/auto_collect.py:21` | arlowe-voice |
+| model choice (7B vs 1.5B) | `QWEN_MODEL_DIR=/opt/arlowe/models/qwen2.5-7b-int4-ax650` | `qwen-api.service` (Environment), implicitly `router.py`/`sentiment_classifier.py` QWEN_URL | qwen-api, qwen-tokenizer |
+| persona / face assets | sentiment→expression mapping; `DEFAULT_MAPPING`, `EXPRESSION_TO_STATE` | `face/sentiment_classifier.py:38-58` (already reads `ARLOWE_CONFIG_PATH`) | arlowe-face (+ arlowe-voice) |
+| log retention | `ARLOWE_LOGS_DIR` exists; **no retention policy literal yet** | `voice_log.py:11`, units | journald/logrotate (Phase 11 consumes) |
+| support-mode policy | (none yet; Phase 10) | — | (Phase 10) |
+| OTA channel URL | (none yet; Phase 9) | — | (Phase 9) |
+| **bonus literals found** | face port `8080` (F1 todo), STT port `8082`, dashboard `3000`, qwen `8000`, `ARLOWE_VOICE_MODEL`, `ARLOWE_VOICE_TIMEOUT`, piper model path | `face_service.py:179`, `stt_server.py:17-18`, multiple | respective units |
+
+**Key insight for the planner:** several CONFIG-06 knobs (hostname, support-mode, OTA URL) have **no consumer yet** — they're defined in `schema.yml` + `defaults.yml` in Phase 4 but actually *used* in Phases 7/8, 9, 10. Phase 4's job is to *define and validate* them, not necessarily wire a live consumer for every one. SC1 says "schema defines every knob"; SC4 only requires *one* knob (persona) to take effect end-to-end. Persona is the right end-to-end demo because `sentiment_classifier.py` already has the overlay-read scaffolding — pick it for the SC4 vertical slice.
+
+The `F1` (face port 8080) and `F4` (voice_client `sudo tee` fan control) todos are tagged Phase 4 in the unit FIXMEs — confirm whether they're in-scope or punt F4 (fan control is unrelated to config; it's a sandbox issue).
+
+## Code Examples
+
+### Dashboard: validate before atomic write (extends existing route.ts)
+```typescript
+// runtime/dashboard/app/api/config/route.ts (add validation; keep temp+rename)
+import Ajv from 'ajv';
+import yaml from 'js-yaml';
+import { readFile } from 'fs/promises';
+
+const SCHEMA_PATH = process.env.ARLOWE_SCHEMA_PATH ?? '/opt/arlowe/config/schema.yml';
+
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+  const schema = yaml.load(await readFile(SCHEMA_PATH, 'utf-8'));
+  const validate = new Ajv({ allErrors: true }).compile(schema as object);
+  if (!validate(body)) {
+    return NextResponse.json({ error: 'schema violation', details: validate.errors }, { status: 422 });
+  }
+  // existing temp+rename write, then restart affected unit via the existing systemctl seam
+}
+```
+Source: existing `runtime/dashboard/app/api/config/route.ts` (verified in repo) + ajv standard usage.
+
+### Reference for graceful absent-overlay handling (already in repo)
+```python
+# runtime/face/sentiment_classifier.py (verified) — the SC3 pattern to copy
+def load_config() -> dict:
+    for path in (CONFIG_OVERLAY, CONFIG_PATH):
+        if path.exists():
+            try: ...  # parse
+    return DEFAULT_MAPPING   # absent overlay -> defaults, no crash
+```
+
+## State of the Art
+
+| Old Approach | Current Approach | Impact |
+|--------------|------------------|--------|
+| Hardcoded literals in source | env-var injection via systemd units (already in place) | Phase 4 layers schema+overlay on top of an existing env convention — low blast radius |
+| One validator per language | shared JSON Schema file, jsonschema + ajv read it | Single source of truth satisfies CONFIG-01's `schema.yml` artifact requirement |
+
+**Deprecated/outdated:** `qwen-openai.service` (ADR-0001); router uses ax-llm native `/api/chat` — relevant only if a knob touches the LLM endpoint.
+
+## Open Questions
+
+1. **How does the dashboard write `/etc/arlowe/config.yml`?** (Pitfall 1) — privileged helper vs. loosening dir perms + ReadWritePaths. **Needs an ADR / planning decision before tasks are written.** Security-sensitive.
+   - What we know: current perms (`root:arlowe 0755`) + sandbox (`ProtectSystem=strict`, no `/etc/arlowe` in ReadWritePaths) block the write; the unit FIXME expects a privileged helper.
+   - Recommendation: decide in planning; default to a small audited root helper if security posture matters, else 0775 + ReadWritePaths.
+
+2. **Env-bridge vs in-process load** (Pattern 3) — per-knob decision. Recommend in-process for structured knobs (persona), env-bridge shim for simple scalars to avoid rewriting every service.
+
+3. **Is `config/schema.yml` literally YAML-encoded JSON Schema, or a custom DSL?** SC1 requires type/default/allowed-values/docstring per knob — JSON Schema (`type`, `default`, `enum`, `description`) covers all four natively. Recommend JSON Schema authored in YAML for readability. Confirm no custom format is expected.
+
+4. **`docs/04-scope.md` referenced by CONFIG-02 does not exist** — CONFIG-02 says defaults.yml "covers every literal flagged in `docs/04-scope.md`." That doc is absent. The knob inventory above substitutes; planner may need to author `docs/04-scope.md` as a Phase-4 deliverable or treat this RESEARCH's inventory as the canonical list.
+
+5. **Scope of F1/F4 todos** — F1 (face port→config) fits Phase 4 cleanly; F4 (voice_client `sudo tee` fan control under NoNewPrivileges) is a sandbox bug, not config. Recommend punt F4 or split it out.
+
+## Sources
+
+### Primary (HIGH confidence)
+- Repo files (verified directly): `scripts/provision/install-arlowe-fs.sh`, `units/*.service`, `units/install-units.sh`, `provision/polkit/50-arlowe-systemctl.rules`, `runtime/dashboard/app/api/config/route.ts`, `runtime/dashboard/package.json`, `runtime/voice/voice_client.py`, `runtime/llm/router.py`, `runtime/face/sentiment_classifier.py`, `runtime/*/requirements.txt`, `.sanitize-allowlist`, `.planning/REQUIREMENTS.md`, `.planning/ROADMAP.md`, `.planning/STATE.md`
+- systemd ExecStartPre fail-fast behavior (non-`-` prefixed failure prevents start): systemd issue #11868, RedHat bz#651797
+
+### Secondary (MEDIUM confidence)
+- Python validation library comparison (jsonschema/pydantic/cerberus/voluptuous), 2026: dev.to, dasroot.net, pydantic docs
+- systemd troubleshooting / exit codes: oneuptime.com
+
+## Metadata
+
+**Confidence breakdown:**
+- Repo facts / knob inventory: HIGH — read directly from source
+- Standard stack (jsonschema + ajv, single schema): MEDIUM — verified against existing deps + ecosystem; final lib choice is the planner's call but justified
+- Pitfall 1 (write-path blocker): HIGH — perms + unit ReadWritePaths + unit FIXME all confirm it
+- Validation/fail-fast pattern: HIGH — systemd behavior verified; matches existing `sentiment_classifier` graceful-fallback
+
+**Research date:** 2026-06-07
+**Valid until:** 2026-07-07 (stable; repo-derived facts don't expire, library minor versions may bump)


### PR DESCRIPTION
Planning artifacts for **Phase 4: Config overlay** (no runtime code — plans + research + state). Produced via `/gsd:plan-phase 4`: research → plan → 2 verification rounds (all issues closed).

## What's here
- `04-RESEARCH.md` — domain research (schema stack, fail-fast pattern, the dashboard-write fork).
- `04-01..04-04-PLAN.md` — 4 executable plans in 3 waves:
  - **04-01** (W1): `config/schema.yml` (JSON-Schema-in-YAML) + `defaults.yml` + shared Python loader/validator (`jsonschema`).
  - **04-02** (W2): **ADR-0003** loosen-perms decision + `/etc/arlowe` 0770 + dashboard `ReadWritePaths` scoped + `install-arlowe-config.sh` + phase-4 docker harness. `package:security`.
  - **04-03** (W2, parallel): dashboard `ajv` validate-before-write + atomic write + knob→restart map + `node:test` unit suite + `testIgnore` so Playwright e2e doesn't collect it.
  - **04-04** (W3, non-autonomous): persona live slice (SC4) + `ExecStartPre` fail-fast validators on the 3 python-bearing units (qwen validator on `qwen-tokenizer`, not the venv-less `qwen-api`).
- `STATE.md` / `ROADMAP.md` — marked Phase 3 complete (passed-with-notes); recorded Phase 3 decisions; noted the `arlowe-face.service` video/fb0 residual (#78).

## Decisions baked in
- **Loosen-perms (owner decision)** for the dashboard→`/etc/arlowe/config.yml` write, scoped tightly, recorded as ADR-0003 (`package:security`), with `ota.channel_url` + `support_mode.*` flagged for Phase 10 re-hardening.
- Schema: one `config/schema.yml`, `jsonschema` (Python) + `ajv` (dashboard), no Pydantic.
- SC4 live slice = persona; other CONFIG-06 knobs defined+validated but consumed in Phases 7–11.

## Verification
3 checker rounds against the merged repo caught + closed: qwen-api no-venv (validator → qwen-tokenizer), dashboard test-runner mismatch (→ node:test + ajv install), phase-4 harness wiring, testbed deps, and a real Playwright 1.59.1 `.test.ts` collection bug.

Merging lands the plans on main; then `/issue-from-plan 4` + `/gsd:execute-phase 4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)