### PR TITLE
feat(config): plan 04-01 — schema.yml + defaults.yml + shared Python loader/validator

### DIFF
--- a/.planning/phases/04-config-overlay/04-01-SUMMARY.md
+++ b/.planning/phases/04-config-overlay/04-01-SUMMARY.md
@@ -1,0 +1,35 @@
+---
+phase: 04-config-overlay
+plan: 01
+type: summary
+status: complete
+---
+
+# Plan 04-01 Summary
+
+## What was delivered
+
+- `config/schema.yml` — JSON Schema draft 2020-12 in YAML, 211 lines, all CONFIG-06 knobs with type/default/enum/description. `$schema` present; `additionalProperties: false` at root; `persona.sentiment_mapping` sub-keys intentionally optional (no inner required / no additionalProperties:false).
+- `config/defaults.yml` — 47 lines, value for every knob, zero founder literals. `device.hostname` is the template literal `arlowe-${device_serial}`. Sanitize gate clean.
+- `runtime/lib/arlowe_config.py` — `load()` + `deep_merge()` helper. Merge-then-validate order. SystemExit(78) on schema violation with greppable `[arlowe-config] schema violation at <path>: <message>` stderr. Absent overlay is a non-error state.
+- `runtime/lib/arlowe_config_validate.py` — standalone ExecStartPre entry point. `python -m arlowe_config_validate` exits 0 on success, propagates SystemExit(78) on violation. Flat-module import with fallback.
+- `runtime/lib/requirements.txt` — `jsonschema==4.23.0`, `PyYAML==6.0.3`.
+- `runtime/lib/tests/test_arlowe_config.py` — 7 pytest cases covering: defaults-only load, absent overlay non-fatal, partial persona deep-merge (04-04 SC4 contract), enum violation SystemExit(78), type violation SystemExit(78), greppable stderr prefix.
+- `docs/04-scope.md` — knob table with requirement and phase ownership; merge contract documented.
+
+## Verification results
+
+- Schema valid: `OK`
+- Persona contract: `persona-contract OK`
+- Sanitize clean: `git grep` returns no matches in `config/`
+- Standalone validator: exits 0 with defaults, exits 78 on bad overlay
+- pytest: 7 passed in 0.18s
+
+## Must-haves satisfied
+
+All five `must_haves.truths` and all five `must_haves.artifacts` met.
+Key links: `Draft202012Validator` reads `ARLOWE_SCHEMA_PATH`; `arlowe_config_validate.py` imports `load` from `arlowe_config`.
+
+## 04-02/03/04 readiness
+
+The partial-persona-overlay deep-merge contract is locked in the test suite. Plans 04-02/03/04 can rely on the loader's merge-then-validate semantics.

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -1,0 +1,47 @@
+# Arlowe firmware shipped defaults.
+#
+# This file is installed read-only at /opt/arlowe/config/defaults.yml.
+# The owner-mutable overlay lives at /etc/arlowe/config.yml (absent on factory image).
+# Every key here must satisfy config/schema.yml; the loader validates the merged result.
+#
+# Sanitize contract: this file contains zero founder literals.
+#   device.hostname is a template literal resolved at pairing, never a concrete hostname.
+
+device:
+  hostname: "arlowe-${device_serial}"
+
+audio:
+  capture_device: "auto"
+  playback_device: "auto"
+
+model:
+  choice: "qwen2.5-7b-int4-ax650"
+
+persona:
+  sentiment_mapping:
+    positive:
+      - "happy"
+      - "excited"
+    negative:
+      - "concerned"
+      - "sad"
+    neutral:
+      - "idle"
+      - "attentive"
+
+ports:
+  face: 8080
+  stt: 8082
+  dashboard: 3000
+
+logs:
+  transcript_retention_days: 7
+  transcript_logging_enabled: true
+
+support_mode:
+  enabled: false
+  window_hours: 24
+
+ota:
+  channel: "stable"
+  channel_url: ""

--- a/config/schema.yml
+++ b/config/schema.yml
@@ -1,0 +1,211 @@
+# Arlowe firmware config schema — JSON Schema draft 2020-12 encoded in YAML.
+#
+# Merge semantics (implemented in runtime/lib/arlowe_config.py):
+#   - Top-level keys: SHALLOW merge (overlay key replaces default key entirely),
+#     EXCEPT for nested objects like persona.sentiment_mapping which are DEEP-merged
+#     so a partial overlay that sets only one sub-key preserves its siblings from
+#     defaults.
+#   - Absent overlay (/etc/arlowe/config.yml missing) returns defaults unchanged —
+#     this is the expected factory/pre-pairing state, not an error.
+#   - persona.sentiment_mapping sub-keys (positive/negative/neutral) are intentionally
+#     OPTIONAL (no inner required list, no additionalProperties:false). The loader
+#     merges defaults+overlay BEFORE validating, so the merged dict always carries
+#     all three sub-keys even when the overlay only sets one. This is the 04-04 SC4
+#     partial-overlay contract: an overlay that sets only persona.sentiment_mapping.positive
+#     must validate cleanly after merge.
+
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: ArloweConfig
+description: Arlowe firmware runtime configuration schema. config/schema.yml is the canonical
+  source — docs/04-scope.md and the dashboard both consume this file. Do not duplicate
+  the knob inventory elsewhere.
+type: object
+additionalProperties: false
+
+required:
+  - device
+  - audio
+  - model
+  - persona
+  - ports
+  - logs
+  - support_mode
+  - ota
+
+properties:
+
+  device:
+    type: object
+    additionalProperties: false
+    description: Device identity knobs. hostname is resolved to a concrete name at pairing
+      (Phase 7/8); the default is a template literal, not a concrete hostname.
+    required:
+      - hostname
+    properties:
+      hostname:
+        type: string
+        default: "arlowe-${device_serial}"
+        description: >
+          Device hostname. The default is a template literal resolved at pairing
+          (Phase 7/8) by substituting the device serial number. Never set to a
+          concrete founder-era hostname.
+
+  audio:
+    type: object
+    additionalProperties: false
+    description: Audio device selection. Phase 5 owns auto-detection; Phase 4 defines the knobs.
+    required:
+      - capture_device
+      - playback_device
+    properties:
+      capture_device:
+        type: string
+        default: "auto"
+        description: ALSA capture device name, or "auto" for Phase 5 detection.
+      playback_device:
+        type: string
+        default: "auto"
+        description: ALSA playback device name, or "auto" for Phase 5 detection.
+
+  model:
+    type: object
+    additionalProperties: false
+    description: On-device model selection.
+    required:
+      - choice
+    properties:
+      choice:
+        type: string
+        enum:
+          - "qwen2.5-7b-int4-ax650"
+          - "qwen2.5-1.5b-int4-ax650"
+        default: "qwen2.5-7b-int4-ax650"
+        description: >
+          Which Qwen model directory to load from /opt/arlowe/models. The 7B model
+          is the default; the 1.5B is a lower-resource alternative.
+
+  persona:
+    type: object
+    additionalProperties: false
+    description: Persona and face-expression configuration consumed by arlowe-face.
+    required:
+      - sentiment_mapping
+    properties:
+      sentiment_mapping:
+        type: object
+        description: >
+          Maps sentiment categories to lists of face expressions consumed by
+          arlowe-face (sentiment_classifier.py). Sub-keys are intentionally
+          OPTIONAL — a partial overlay that sets only one sentiment preserves
+          the others via deep-merge in the loader. See merge semantics at the
+          top of this file and the 04-04 SC4 partial-overlay contract.
+        properties:
+          positive:
+            type: array
+            items:
+              type: string
+            description: Face expressions for positive sentiment.
+          negative:
+            type: array
+            items:
+              type: string
+            description: Face expressions for negative sentiment.
+          neutral:
+            type: array
+            items:
+              type: string
+            description: Face expressions for neutral sentiment.
+        default:
+          positive:
+            - "happy"
+            - "excited"
+          negative:
+            - "concerned"
+            - "sad"
+          neutral:
+            - "idle"
+            - "attentive"
+
+  ports:
+    type: object
+    additionalProperties: false
+    description: TCP port assignments for each service.
+    required:
+      - face
+      - stt
+      - dashboard
+    properties:
+      face:
+        type: integer
+        default: 8080
+        description: arlowe-face service TCP port.
+      stt:
+        type: integer
+        default: 8082
+        description: whisper-stt service TCP port.
+      dashboard:
+        type: integer
+        default: 3000
+        description: arlowe-dashboard service TCP port.
+
+  logs:
+    type: object
+    additionalProperties: false
+    description: Log retention policy. Phase 11 consumes these knobs for logrotate / purge-logs.
+    required:
+      - transcript_retention_days
+      - transcript_logging_enabled
+    properties:
+      transcript_retention_days:
+        type: integer
+        default: 7
+        description: Number of days voice transcript logs are retained before purge.
+      transcript_logging_enabled:
+        type: boolean
+        default: true
+        description: Whether voice transcripts are written to disk at all.
+
+  support_mode:
+    type: object
+    additionalProperties: false
+    description: >
+      Owner-consented remote support access. Defined here but not consumed until
+      Phase 10 (SUPP requirements). Default is off.
+    required:
+      - enabled
+      - window_hours
+    properties:
+      enabled:
+        type: boolean
+        default: false
+        description: Whether support mode is active.
+      window_hours:
+        type: integer
+        default: 24
+        description: >
+          Duration in hours of a support-mode session. Valid range 1–168.
+
+  ota:
+    type: object
+    additionalProperties: false
+    description: >
+      App-only OTA update configuration. Defined here but not consumed until
+      Phase 9 (OTA requirements).
+    required:
+      - channel
+      - channel_url
+    properties:
+      channel:
+        type: string
+        enum:
+          - "stable"
+          - "beta"
+          - "off"
+        default: "stable"
+        description: OTA update channel. "off" disables update polling entirely.
+      channel_url:
+        type: string
+        default: ""
+        description: >
+          Signed-manifest CDN base URL for the selected channel. Empty until
+          set at pairing (Phase 8/9).

--- a/docs/04-scope.md
+++ b/docs/04-scope.md
@@ -1,0 +1,47 @@
+# Phase 4: Config Overlay Scope
+
+`config/schema.yml` is the canonical, authoritative inventory of every Arlowe firmware
+config knob. This document points at that file rather than duplicating its contents.
+
+## What schema.yml defines
+
+Each knob in `config/schema.yml` carries: `type`, `default`, allowed values (`enum`
+where applicable), and `description`. The schema is JSON Schema draft 2020-12 encoded
+in YAML, consumed by:
+
+- Python runtime services via `runtime/lib/arlowe_config.py` (jsonschema library)
+- Dashboard (Phase 11) via ajv reading the same file
+
+## Knob ownership table
+
+| Knob | Requirement | Defined in Phase | Consumed in Phase |
+|------|-------------|-----------------|-------------------|
+| `device.hostname` | SANIT-02, CONFIG-06 | 4 | 7/8 (pairing resolves template) |
+| `audio.capture_device` | AUDIO-03, CONFIG-06 | 4 | 5 (auto-detection), 11 (dashboard) |
+| `audio.playback_device` | AUDIO-03, CONFIG-06 | 4 | 5 (auto-detection), 11 (dashboard) |
+| `model.choice` | CONFIG-06 | 4 | 4 (qwen-api unit), 11 (dashboard setting) |
+| `persona.sentiment_mapping` | CONFIG-06 | 4 | 4 (arlowe-face/sentiment_classifier) |
+| `ports.face` | CONFIG-06 | 4 | 4 (service wiring) |
+| `ports.stt` | CONFIG-06 | 4 | 4 (service wiring) |
+| `ports.dashboard` | CONFIG-06 | 4 | 4 (service wiring) |
+| `logs.transcript_retention_days` | LOG-02, LOG-03, CONFIG-06 | 4 | 11 (purge-logs) |
+| `logs.transcript_logging_enabled` | LOG-03, CONFIG-06 | 4 | 11 (purge-logs, dashboard) |
+| `support_mode.enabled` | SUPP-01, CONFIG-06 | 4 | 10 |
+| `support_mode.window_hours` | SUPP-03, CONFIG-06 | 4 | 10 |
+| `ota.channel` | OTA-06, CONFIG-06 | 4 | 9 |
+| `ota.channel_url` | OTA-02, CONFIG-06 | 4 | 9 |
+
+## File layout at runtime
+
+| File | Location on device | Owner / perms |
+|------|--------------------|---------------|
+| `config/schema.yml` | `/opt/arlowe/config/schema.yml` | `root:arlowe 0644` |
+| `config/defaults.yml` | `/opt/arlowe/config/defaults.yml` | `root:arlowe 0644` |
+| overlay | `/etc/arlowe/config.yml` | `root:arlowe 0644` (written via privileged helper, Phase 4) |
+
+## Merge contract
+
+The loader (`runtime/lib/arlowe_config.py`) merges defaults and overlay before
+validating. Absent overlay returns defaults unchanged — this is the factory/pre-pairing
+state. `persona.sentiment_mapping` sub-keys are deep-merged so a partial overlay that
+sets only one sentiment preserves the others.

--- a/runtime/lib/arlowe_config.py
+++ b/runtime/lib/arlowe_config.py
@@ -1,0 +1,75 @@
+"""
+Shared config loader for Arlowe runtime services.
+
+Installed flat at /opt/arlowe/runtime/lib/arlowe_config.py; import as:
+    from arlowe_config import load
+
+Merge semantics:
+  - defaults.yml is loaded unconditionally.
+  - /etc/arlowe/config.yml (overlay) is optional; absent == pre-pairing, no error.
+  - Merge is SHALLOW at the top level but DEEP for nested dicts, so a partial
+    persona overlay that sets only persona.sentiment_mapping.positive merges over
+    the defaults while preserving neutral/negative siblings.
+  - The merged dict is validated AFTER merge; a partial overlay is valid because
+    the merged dict always carries all keys from defaults.
+  - Schema violations print a greppable stderr line and raise SystemExit(78)
+    (EX_CONFIG from sysexits.h) — systemd records the exit code and shows stderr.
+"""
+
+import os
+import sys
+import yaml
+from pathlib import Path
+from jsonschema import Draft202012Validator
+
+DEFAULTS = Path(os.environ.get("ARLOWE_DEFAULTS_PATH", "/opt/arlowe/config/defaults.yml"))
+OVERLAY = Path(os.environ.get("ARLOWE_CONFIG_PATH", "/etc/arlowe/config.yml"))
+SCHEMA = Path(os.environ.get("ARLOWE_SCHEMA_PATH", "/opt/arlowe/config/schema.yml"))
+
+
+def deep_merge(base: dict, overlay: dict) -> dict:
+    """Return a new dict that is overlay deep-merged onto base.
+
+    Nested dicts are merged recursively so sub-keys from base are preserved
+    when the overlay only sets some of them. All other types are replaced by
+    the overlay value (no list-appending, no coercion).
+    """
+    result = dict(base)
+    for key, value in overlay.items():
+        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+            result[key] = deep_merge(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
+def load() -> dict:
+    """Load, merge, validate, and return the resolved config dict.
+
+    Returns:
+        Merged and validated config dict.
+
+    Raises:
+        SystemExit(78): On any JSON Schema violation (EX_CONFIG).
+        FileNotFoundError: If defaults.yml or schema.yml is missing.
+    """
+    defaults = yaml.safe_load(DEFAULTS.read_text())
+
+    if OVERLAY.exists():
+        overlay = yaml.safe_load(OVERLAY.read_text()) or {}
+    else:
+        overlay = {}
+
+    merged = deep_merge(defaults, overlay)
+
+    schema = yaml.safe_load(SCHEMA.read_text())
+    validator = Draft202012Validator(schema)
+    errors = sorted(validator.iter_errors(merged), key=lambda e: list(e.path))
+
+    if errors:
+        for e in errors:
+            path = "/".join(map(str, e.path)) or "<root>"
+            print(f"[arlowe-config] schema violation at {path}: {e.message}", file=sys.stderr)
+        raise SystemExit(78)
+
+    return merged

--- a/runtime/lib/arlowe_config_validate.py
+++ b/runtime/lib/arlowe_config_validate.py
@@ -1,0 +1,29 @@
+"""
+Standalone config validator for use as a systemd ExecStartPre entry point.
+
+Usage (in each *.service [Service] block):
+    ExecStartPre=/opt/arlowe/venvs/<svc>/bin/python -m arlowe_config_validate
+
+Exits 0 on success (prints "[arlowe-config] OK" to stdout).
+Exits 78 (EX_CONFIG) on schema violation (stderr lines from arlowe_config.load()).
+
+The module lives at /opt/arlowe/runtime/lib alongside arlowe_config.py as a flat
+module (not a package). Runnable when /opt/arlowe/runtime/lib is on PYTHONPATH.
+"""
+
+try:
+    from arlowe_config import load
+except ImportError:
+    import importlib.util as _util
+    import pathlib as _pathlib
+    _spec = _util.spec_from_file_location(
+        "arlowe_config",
+        _pathlib.Path(__file__).parent / "arlowe_config.py",
+    )
+    _mod = _util.module_from_spec(_spec)
+    _spec.loader.exec_module(_mod)
+    load = _mod.load
+
+if __name__ == "__main__":
+    load()
+    print("[arlowe-config] OK")

--- a/runtime/lib/requirements.txt
+++ b/runtime/lib/requirements.txt
@@ -1,0 +1,2 @@
+jsonschema==4.23.0
+PyYAML==6.0.3

--- a/runtime/lib/tests/test_arlowe_config.py
+++ b/runtime/lib/tests/test_arlowe_config.py
@@ -1,0 +1,124 @@
+"""
+Unit tests for arlowe_config loader.
+
+Run from repo root:
+    PYTHONPATH=runtime/lib \
+    ARLOWE_SCHEMA_PATH=config/schema.yml \
+    ARLOWE_DEFAULTS_PATH=config/defaults.yml \
+    ARLOWE_CONFIG_PATH=/nonexistent \
+    python3 -m pytest runtime/lib/tests/ -q
+
+Or from runtime/lib/:
+    python3 -m pytest tests/ -q
+"""
+
+import os
+import sys
+import pytest
+import yaml
+import tempfile
+import textwrap
+from pathlib import Path
+
+# Ensure arlowe_config is importable when tests run from within runtime/lib/
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import arlowe_config
+
+
+REPO_ROOT = Path(__file__).parent.parent.parent.parent
+SCHEMA_PATH = REPO_ROOT / "config" / "schema.yml"
+DEFAULTS_PATH = REPO_ROOT / "config" / "defaults.yml"
+
+
+def _set_paths(monkeypatch, *, overlay_path: str):
+    monkeypatch.setenv("ARLOWE_SCHEMA_PATH", str(SCHEMA_PATH))
+    monkeypatch.setenv("ARLOWE_DEFAULTS_PATH", str(DEFAULTS_PATH))
+    monkeypatch.setenv("ARLOWE_CONFIG_PATH", overlay_path)
+    monkeypatch.setattr(arlowe_config, "SCHEMA", Path(str(SCHEMA_PATH)))
+    monkeypatch.setattr(arlowe_config, "DEFAULTS", Path(str(DEFAULTS_PATH)))
+    monkeypatch.setattr(arlowe_config, "OVERLAY", Path(overlay_path))
+
+
+class TestDefaultsOnlyLoad:
+    def test_returns_dict_equal_to_parsed_defaults(self, monkeypatch):
+        _set_paths(monkeypatch, overlay_path="/nonexistent/config.yml")
+        result = arlowe_config.load()
+        expected = yaml.safe_load(DEFAULTS_PATH.read_text())
+        assert result == expected
+
+    def test_absent_overlay_does_not_raise(self, monkeypatch):
+        _set_paths(monkeypatch, overlay_path="/nonexistent/config.yml")
+        result = arlowe_config.load()
+        assert isinstance(result, dict)
+
+
+class TestPartialPersonaOverlay:
+    def test_partial_sentiment_mapping_deep_merges(self, monkeypatch, tmp_path):
+        overlay_file = tmp_path / "config.yml"
+        overlay_file.write_text(textwrap.dedent("""\
+            persona:
+              sentiment_mapping:
+                positive:
+                  - "excited"
+        """))
+        _set_paths(monkeypatch, overlay_path=str(overlay_file))
+
+        result = arlowe_config.load()
+
+        sm = result["persona"]["sentiment_mapping"]
+        assert sm["positive"] == ["excited"], "overlay value must replace default"
+        assert sm["neutral"] == ["idle", "attentive"], "neutral must be preserved from defaults"
+        assert sm["negative"] == ["concerned", "sad"], "negative must be preserved from defaults"
+
+    def test_partial_persona_overlay_validates_clean(self, monkeypatch, tmp_path):
+        overlay_file = tmp_path / "config.yml"
+        overlay_file.write_text(textwrap.dedent("""\
+            persona:
+              sentiment_mapping:
+                positive:
+                  - "excited"
+        """))
+        _set_paths(monkeypatch, overlay_path=str(overlay_file))
+        result = arlowe_config.load()
+        assert isinstance(result, dict)
+
+
+class TestSchemaViolations:
+    def test_invalid_enum_raises_system_exit_78(self, monkeypatch, tmp_path):
+        overlay_file = tmp_path / "config.yml"
+        overlay_file.write_text(textwrap.dedent("""\
+            ota:
+              channel: "purple"
+        """))
+        _set_paths(monkeypatch, overlay_path=str(overlay_file))
+
+        with pytest.raises(SystemExit) as exc_info:
+            arlowe_config.load()
+        assert exc_info.value.code == 78
+
+    def test_wrong_type_raises_system_exit_78(self, monkeypatch, tmp_path):
+        overlay_file = tmp_path / "config.yml"
+        overlay_file.write_text(textwrap.dedent("""\
+            ports:
+              face: "nope"
+        """))
+        _set_paths(monkeypatch, overlay_path=str(overlay_file))
+
+        with pytest.raises(SystemExit) as exc_info:
+            arlowe_config.load()
+        assert exc_info.value.code == 78
+
+    def test_violation_stderr_contains_greppable_prefix(self, monkeypatch, tmp_path, capsys):
+        overlay_file = tmp_path / "config.yml"
+        overlay_file.write_text(textwrap.dedent("""\
+            ota:
+              channel: "purple"
+        """))
+        _set_paths(monkeypatch, overlay_path=str(overlay_file))
+
+        with pytest.raises(SystemExit):
+            arlowe_config.load()
+
+        captured = capsys.readouterr()
+        assert "[arlowe-config] schema violation at" in captured.err


### PR DESCRIPTION
## Summary

- `config/schema.yml`: JSON Schema draft 2020-12 defining all CONFIG-06 knobs (device, audio, model, persona, ports, logs, support_mode, ota) with type/default/enum/description. `persona.sentiment_mapping` sub-keys are intentionally optional to preserve the 04-04 SC4 partial-overlay contract.
- `config/defaults.yml`: sanitize-clean defaults; `device.hostname = arlowe-${device_serial}` (template literal, never a concrete hostname). Sanitize gate clean.
- `runtime/lib/arlowe_config.py`: flat `load()` + `deep_merge()` helper; merge-then-validate order; `SystemExit(78)` on violation with greppable `[arlowe-config] schema violation at <path>: <message>` stderr. Absent overlay is a non-error state.
- `runtime/lib/arlowe_config_validate.py`: `ExecStartPre` standalone entry point; `python -m arlowe_config_validate` exits 0 on success, 78 on violation.
- `runtime/lib/requirements.txt`: `jsonschema==4.23.0`, `PyYAML==6.0.3`.
- `runtime/lib/tests/test_arlowe_config.py`: 7 pytest cases including the partial-persona deep-merge test locking the 04-04 SC4 contract.
- `docs/04-scope.md`: knob ownership table (knob → requirement → phase).

## Test plan

- [ ] `python3 -c "...Draft202012Validator(s).iter_errors(d)..."` prints `OK`
- [ ] Persona contract assertion prints `persona-contract OK`
- [ ] `git grep -nE 'focal55|arlowe-1|...' config/` returns nothing
- [ ] `python3 -m arlowe_config_validate` exits 0 with defaults, exits 78 on bad overlay
- [ ] `python3 -m pytest runtime/lib/tests/ -q` — 7 passed

All verified locally before push.

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)