### PR TITLE
feat(config): plan 04-02 — ADR-0003 loosen-perms + /etc/arlowe install + phase-4 docker harness

### DIFF
--- a/.planning/phases/04-config-overlay/04-02-SUMMARY.md
+++ b/.planning/phases/04-config-overlay/04-02-SUMMARY.md
@@ -1,0 +1,47 @@
+---
+phase: 04-config-overlay
+plan: 02
+type: summary
+status: complete
+date: 2026-06-07
+pr: pending
+---
+
+## What was done
+
+Implemented the settled LOOSEN-PERMS decision (ADR-0003) for the dashboard→`/etc/arlowe/config.yml` write path, installed schema and defaults into the image layout, and stood up the phase-4 Docker harness.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `docs/architecture/0003-dashboard-config-write-path.md` | New ADR: records loosen-perms decision, three containment requirements, Phase 10 re-hardening flag |
+| `scripts/provision/install-arlowe-fs.sh` | `/etc/arlowe` mode changed from `0755` → `0770` (group-writable, ADR-0003) |
+| `scripts/provision/install-arlowe-config.sh` | New: installs `schema.yml`, `defaults.yml`, `arlowe_config.py`, `arlowe_config_validate.py`; never creates `config.yml` |
+| `units/arlowe-dashboard.service` | Replaced FIXME(Phase 4) block with ADR-0003 citation; added `/etc/arlowe` to `ReadWritePaths` (scoped, not broader `/etc`) |
+| `tests/phase-4/assertions/01-config-install-shape.sh` | New: stat-only assertion — `/etc/arlowe` is `770 root:arlowe`; config files installed; `config.yml` absent |
+| `tests/phase-4/docker/run-tests.sh` | New: phase-4 harness reusing the phase-3 Dockerfile; auto-discovers installers + loops `tests/phase-4/assertions/*.sh` |
+| `tests/phase-3/assertions/02-fs-layout.sh` | Updated `/etc/arlowe` expected mode from `755` → `770` to match the installer change |
+
+## Verification
+
+- All new scripts pass `bash -n` syntax check.
+- `grep -q 'm 0770 /etc/arlowe' scripts/provision/install-arlowe-fs.sh` passes.
+- `grep -qE 'ReadWritePaths=.*/etc/arlowe' units/arlowe-dashboard.service` passes.
+- `grep -q 'tests/phase-4/assertions' tests/phase-4/docker/run-tests.sh` passes.
+- `grep -q 'phase-3/docker' tests/phase-4/docker/run-tests.sh` passes (confirms Dockerfile reuse).
+- ADR contains "0770" and "Phase 10" per plan verification criteria.
+- Sanitize gate: clean (grep gate + units gate, 152 files).
+- `install-arlowe-config.sh` never creates `/etc/arlowe/config.yml`.
+
+## Requirements satisfied
+
+- **CONFIG-02**: `defaults.yml` ships in the image via `install-arlowe-config.sh`.
+- **CONFIG-03**: `/etc/arlowe/config.yml` absent on factory image (absence contract enforced in installer + asserted in `01-config-install-shape.sh`).
+- **ADR-0003**: loosen-perms decision documented with all three containment requirements.
+
+## Notes
+
+- Phase-3 assertion `02-fs-layout.sh` updated to expect `770` (not `755`) for `/etc/arlowe` — this is required correctness, not scope creep; the assertion must match the installer.
+- Validator execution (pytest + `arlowe_config_validate`) is NOT exercised in the Docker testbed by design; it runs in 04-01's repo-root pytest and on the Pi. The harness comment states this explicitly.
+- `ota.channel_url` and `support_mode.*` re-hardening is deferred to Phase 10 as documented in ADR-0003.

--- a/docs/architecture/0003-dashboard-config-write-path.md
+++ b/docs/architecture/0003-dashboard-config-write-path.md
@@ -1,0 +1,83 @@
+# ADR-0003: Dashboard config write path — loosen-perms decision
+
+<!-- status: accepted -->
+**Status:** Accepted
+**Date:** 2026-06-07
+**Phase:** 4 (Config overlay)
+**Closes:** CONFIG-02, CONFIG-03
+**Supersedes:** FIXME(Phase 4) comment in `units/arlowe-dashboard.service`
+
+## Context
+
+Phase 3 provisioned `/etc/arlowe` as `root:arlowe 0755` (group has `r-x`, not write).
+The `arlowe-dashboard.service` unit runs under `ProtectSystem=strict` with
+`ReadWritePaths` scoped to `/var/lib/arlowe/dashboard` and `/var/lib/arlowe/logs/dashboard`
+only. The unit file carried an explicit `FIXME(Phase 4)` noting that the dashboard's
+`POST /api/config` route, which does a temp-file + rename write to `/etc/arlowe/config.yml`,
+must go through a privileged helper because `/etc/arlowe` was not writable.
+
+Two options were evaluated:
+
+1. **Privileged helper via polkit or setuid.** A small root-owned helper validates then
+   writes the overlay. Most restrictive, but requires a new polkit action or setuid binary —
+   additional auditable surface with no proportional gain given the dashboard's existing
+   trust level.
+2. **Loosen perms (LOOSEN-PERMS).** Set `/etc/arlowe` to `root:arlowe 0770` (group-writable)
+   and add `ReadWritePaths=/etc/arlowe` to the dashboard unit. The dashboard writes the
+   overlay directly via temp-file + rename (already implemented correctly in `route.ts`).
+
+The dashboard is already a trusted process: the Phase 3 polkit rule grants it the ability
+to restart `arlowe-*`, `qwen-*`, and `whisper-stt.service` units without sudo. Adding a
+write path into `/etc/arlowe` is a proportionate extension of that trust, not an
+escalation.
+
+## Decision
+
+**LOOSEN-PERMS.** `/etc/arlowe` is provisioned `root:arlowe 0770` and
+`ReadWritePaths=/etc/arlowe` is added to `arlowe-dashboard.service` (scoped to that
+path only).
+
+## Containment requirements
+
+These constraints are MANDATORY and must not be relaxed without a superseding ADR:
+
+1. **`ReadWritePaths` is scoped to `/etc/arlowe` exactly.** The entry in the dashboard
+   unit is `ReadWritePaths=/etc/arlowe`, never a broader `/etc` path. The dashboard's
+   write surface widens to one config directory — not to arbitrary `/etc` files.
+
+2. **The loader's fail-fast schema validation (Plan 04-01) is retained regardless.**
+   Loosening the write path does not relax validation. An invalid overlay still causes
+   `ExecStartPre` (which runs `arlowe_config_validate`) to exit 78 (EX_CONFIG) and
+   prevents the affected service from starting. The `ProtectSystem=strict` sandbox
+   on all other units is unchanged.
+
+3. **`ota.channel_url` and `support_mode.*` are flagged for re-hardening in Phase 10.**
+   These knobs are defined in `config/schema.yml` and accepted by the loader today, but
+   they govern privileged operations (firmware update source, remote support access).
+   When Phase 10 (support-mode) lands, those specific knobs must move behind a
+   re-authenticated privileged write path — the plain group-writable `/etc/arlowe`
+   write is NOT the correct final surface for them. This ADR explicitly records that
+   future-work item so the decision is revisitable.
+
+## Consequences
+
+**Positive:**
+- Dashboard can persist `/etc/arlowe/config.yml` via the existing temp+rename path in
+  `route.ts` without introducing a new privileged binary or polkit action.
+- Implementation is minimal: one `install -d` mode change and one `ReadWritePaths` entry.
+- The write surface is bounded by `ProtectSystem=strict` + scoped `ReadWritePaths`; the
+  dashboard cannot write any `/etc` file outside `/etc/arlowe`.
+
+**Negative / known gaps:**
+- `ota.channel_url` and `support_mode.*` knobs are writable by the dashboard in Phase 4;
+  re-hardening is deferred to Phase 10 (see containment requirement 3 above).
+- The dashboard process has a broader write surface than in Phase 3, which is a trade-off
+  accepted because the dashboard is already the most trusted runtime process.
+
+## References
+
+- Research: `.planning/phases/04-config-overlay/04-RESEARCH.md` §Pitfall 1, §Open-Question 1
+- Plan: `.planning/phases/04-config-overlay/04-02-PLAN.md`
+- Superseded comment: `units/arlowe-dashboard.service` FIXME(Phase 4) block (removed in this plan)
+- Perms change: `scripts/provision/install-arlowe-fs.sh` `/etc/arlowe` line → `0770`
+- Unit change: `units/arlowe-dashboard.service` `ReadWritePaths` → includes `/etc/arlowe`

--- a/scripts/provision/install-arlowe-config.sh
+++ b/scripts/provision/install-arlowe-config.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Installs schema.yml, defaults.yml, and the shared config loader library into
+# the image. Does NOT create /etc/arlowe/config.yml — its absence is the
+# CONFIG-03 pairing trigger (Phase 8 creates it on first pairing).
+#
+# Destination layout (mirrors what units expect at runtime):
+#   /opt/arlowe/config/schema.yml         root:arlowe 0640  (read-only at runtime)
+#   /opt/arlowe/config/defaults.yml       root:arlowe 0640  (read-only at runtime)
+#   /opt/arlowe/runtime/lib/              root:arlowe 0755  (directory; created here)
+#   /opt/arlowe/runtime/lib/arlowe_config.py          root:arlowe 0644
+#   /opt/arlowe/runtime/lib/arlowe_config_validate.py root:arlowe 0644
+#
+# Units import the loader with PYTHONPATH=/opt/arlowe/runtime/lib as flat modules:
+#   from arlowe_config import load
+#   python -m arlowe_config_validate   (ExecStartPre validator)
+#
+# Idempotency: install(1) sets owner and mode on each invocation — safe to re-run.
+# Must be run as root. Requires install-arlowe-user.sh and install-arlowe-fs.sh
+# to have run first (arlowe user and /opt/arlowe/config directory must exist).
+set -euo pipefail
+
+# Resolve repo root relative to this script so it works both on the Pi (cloned
+# checkout) and inside the Docker testbed (bind-mounted at /arlowe-firmware).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+# Verify prerequisite: arlowe user must exist.
+getent passwd arlowe >/dev/null 2>&1 \
+    || { echo "[install-arlowe-config] ERROR: arlowe user not found; run install-arlowe-user.sh first" >&2; exit 1; }
+
+# Verify prerequisite: /opt/arlowe/config directory must exist (install-arlowe-fs.sh owns it).
+[[ -d /opt/arlowe/config ]] \
+    || { echo "[install-arlowe-config] ERROR: /opt/arlowe/config not found; run install-arlowe-fs.sh first" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Config content: schema.yml + defaults.yml → /opt/arlowe/config/
+# ---------------------------------------------------------------------------
+
+install -o root -g arlowe -m 0640 \
+    "${REPO_ROOT}/config/schema.yml" /opt/arlowe/config/schema.yml
+
+install -o root -g arlowe -m 0640 \
+    "${REPO_ROOT}/config/defaults.yml" /opt/arlowe/config/defaults.yml
+
+# ---------------------------------------------------------------------------
+# Shared loader library → /opt/arlowe/runtime/lib/
+# ---------------------------------------------------------------------------
+
+install -d -o root -g arlowe -m 0755 /opt/arlowe/runtime/lib
+
+install -o root -g arlowe -m 0644 \
+    "${REPO_ROOT}/runtime/lib/arlowe_config.py" /opt/arlowe/runtime/lib/arlowe_config.py
+
+install -o root -g arlowe -m 0644 \
+    "${REPO_ROOT}/runtime/lib/arlowe_config_validate.py" /opt/arlowe/runtime/lib/arlowe_config_validate.py
+
+# ---------------------------------------------------------------------------
+# Absence contract: /etc/arlowe/config.yml must NOT be created here.
+# Its absence is the CONFIG-03 factory-image pairing trigger.
+# Phase 8 creates it on first pairing.
+# ---------------------------------------------------------------------------
+
+echo "[install-arlowe-config] config content installed"

--- a/scripts/provision/install-arlowe-fs.sh
+++ b/scripts/provision/install-arlowe-fs.sh
@@ -4,7 +4,8 @@
 # Purpose:
 #   Provisions /opt/arlowe/ (code root, root:arlowe 0750), /var/lib/arlowe/
 #   (owner state, arlowe:arlowe 0750), and /etc/arlowe/ (config dir, root:arlowe
-#   0755) per the Phase 3 layout contract (docs/operations/phase-3-layout.md).
+#   0770 group-writable per ADR-0003) per the Phase 3 layout contract
+#   (docs/operations/phase-3-layout.md).
 #
 # Idempotency contract:
 #   `install -d` is idempotent — it sets owner and mode on each invocation,
@@ -75,11 +76,13 @@ install -d -o arlowe -g arlowe -m 0750 /var/lib/arlowe/dashboard
 install -d -o arlowe -g arlowe -m 0750 /var/lib/arlowe/dashboard/cache
 
 # ---------------------------------------------------------------------------
-# /etc/arlowe/ — config overlay dir; root:arlowe 0755
-# config.yml intentionally NOT created — its absence is the Phase 8 pairing trigger
+# /etc/arlowe/ — config overlay dir; root:arlowe 0770 (ADR-0003)
+# Group-writable so the arlowe-user dashboard can write the config overlay
+# via a scoped ReadWritePaths entry. Write surface is bounded to this dir only.
+# config.yml intentionally NOT created — its absence is the CONFIG-03 pairing trigger
 # ---------------------------------------------------------------------------
 
-install -d -o root -g arlowe -m 0755 /etc/arlowe
+install -d -o root -g arlowe -m 0770 /etc/arlowe
 
 # Summary output — aids diagnosis in pi-gen log and Docker testbed output
 if command -v tree >/dev/null 2>&1; then

--- a/tests/phase-3/assertions/02-fs-layout.sh
+++ b/tests/phase-3/assertions/02-fs-layout.sh
@@ -58,8 +58,9 @@ check_path "${ARLOWE_HOME}/wake-word"         "${ARLOWE_USER}:${ARLOWE_GROUP} 75
 check_path "${ARLOWE_HOME}/dashboard/cache"   "${ARLOWE_USER}:${ARLOWE_GROUP} 750"
 
 # /etc/arlowe: directory exists but config.yml is ABSENT
+# Mode is 0770 (root:arlowe group-writable) per ADR-0003 (plan 04-02).
 # Absence of config.yml is the CONFIG-03 pairing trigger (Phase 8 creates it).
-check_path "${ARLOWE_ETC}" "root:${ARLOWE_GROUP} 755"
+check_path "${ARLOWE_ETC}" "root:${ARLOWE_GROUP} 770"
 test ! -f "${ARLOWE_ETC}/config.yml" \
   || fail "${ARLOWE_ETC}/config.yml must not exist in Phase 3 (its absence triggers pairing)"
 

--- a/tests/phase-4/assertions/01-config-install-shape.sh
+++ b/tests/phase-4/assertions/01-config-install-shape.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Phase 4 assertion: validates the config install shape (stat-only checks).
+#
+# Asserts:
+#   - /etc/arlowe is mode 0770 owner root group arlowe (ADR-0003)
+#   - /opt/arlowe/config/schema.yml exists and is owned root:arlowe
+#   - /opt/arlowe/config/defaults.yml exists and is owned root:arlowe
+#   - /opt/arlowe/runtime/lib/arlowe_config.py exists and is owned root:arlowe
+#   - /opt/arlowe/runtime/lib/arlowe_config_validate.py exists and is owned root:arlowe
+#   - /etc/arlowe/config.yml does NOT exist (CONFIG-03 factory absence contract)
+#
+# These are STAT-ONLY shape checks (file existence + mode + owner). The Python
+# loader is NOT executed here; validator execution is verified on the provisioned
+# Pi/staging unit and in 04-01's repo-root pytest run (runtime/lib/tests/).
+set -euo pipefail
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+check_stat() {
+    local path="$1" expected="$2"
+    local actual
+    actual="$(stat -c '%U:%G %a' "${path}" 2>/dev/null)" \
+        || fail "path does not exist: ${path}"
+    echo "${actual}" | grep -q "^${expected}$" \
+        || fail "${path}: expected '${expected}', got '${actual}'"
+}
+
+echo "Phase 4 config install shape assertion"
+
+# /etc/arlowe: root:arlowe 0770 (ADR-0003 loosen-perms decision)
+check_stat /etc/arlowe "root:arlowe 770"
+
+# /opt/arlowe/config content files: present and owned root:arlowe
+check_stat /opt/arlowe/config/schema.yml   "root:arlowe 640"
+check_stat /opt/arlowe/config/defaults.yml "root:arlowe 640"
+
+# Shared loader library: present and owned root:arlowe
+check_stat /opt/arlowe/runtime/lib/arlowe_config.py          "root:arlowe 644"
+check_stat /opt/arlowe/runtime/lib/arlowe_config_validate.py "root:arlowe 644"
+
+# CONFIG-03 absence contract: config.yml must NOT exist on a factory image
+test ! -f /etc/arlowe/config.yml \
+    || fail "/etc/arlowe/config.yml must not exist on factory image (CONFIG-03 pairing trigger)"
+
+echo "Phase 4 config install shape: PASS"

--- a/tests/phase-4/docker/run-tests.sh
+++ b/tests/phase-4/docker/run-tests.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# Phase 4 Docker test harness.
+# Reuses the phase-3 Dockerfile (do NOT edit tests/phase-3/docker/run-tests.sh —
+# that file belongs to plan 03 and editing it would break file-disjointness).
+#
+# Validator EXECUTION (running arlowe_config_validate / pytest) is verified on
+# the provisioned Pi/staging unit and in 04-01's repo-root pytest run, NOT in
+# this Docker testbed. Here we assert install SHAPE only (mode/owner/presence).
+# The phase-3 Dockerfile already provides python3, so the image build stays cheap
+# and avoids a divergent dep set (no pip-install of jsonschema/PyYAML needed).
+#
+# Auto-discovery design (mirrors plan 03):
+#   - Runs install-arlowe-user.sh first (prerequisite for all other installers).
+#   - Loops over scripts/provision/install-arlowe-*.sh (sorted), skipping any
+#     with 'staging' in the name (those target the dev-Pi side-by-side install).
+#   - Invokes units/install-units.sh if present.
+#   - Loops over tests/phase-4/assertions/*.sh and executes each.
+#
+# Usage:
+#   bash tests/phase-4/docker/run-tests.sh
+#
+# Options:
+#   PHASE_4_TESTBED_KEEP=1   Leave container running for debugging instead of --rm.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+IMAGE="arlowe-phase4-testbed"
+
+echo "=== Phase 4 testbed: building image (reusing phase-3 Dockerfile) ==="
+docker build -t "${IMAGE}" "${REPO_ROOT}/tests/phase-3/docker"
+
+# Harness body executed inside the container.
+HARNESS='
+set -euo pipefail
+REPO=/arlowe-firmware
+
+echo "--- installing provision scripts (auto-discovery) ---"
+USER_SCRIPT="${REPO}/scripts/provision/install-arlowe-user.sh"
+if [[ -f "${USER_SCRIPT}" ]]; then
+    echo "  running install-arlowe-user.sh (prerequisite)"
+    bash "${USER_SCRIPT}"
+fi
+
+for script in $(ls "${REPO}/scripts/provision/install-arlowe-"*.sh 2>/dev/null | sort); do
+    basename_script="$(basename "${script}")"
+    if echo "${basename_script}" | grep -q "staging"; then
+        echo "  skipping ${basename_script} (staging variant)"
+        continue
+    fi
+    if [[ "${basename_script}" == "install-arlowe-user.sh" ]]; then
+        continue
+    fi
+    if echo "${basename_script}" | grep -q "install-arlowe-cli"; then
+        echo "  pre-staging CLI marker files for ${basename_script}"
+        mkdir -p /opt/arlowe/runtime/cli
+        for cmd in face speak stt record boot-check purge-logs run-logrotate wake-train; do
+            src="${REPO}/runtime/cli/${cmd}"
+            dst="/opt/arlowe/runtime/cli/${cmd}"
+            if [[ -f "${src}" ]]; then
+                cp "${src}" "${dst}"
+            else
+                touch "${dst}"
+            fi
+            chmod 0755 "${dst}"
+            chown root:arlowe "${dst}" 2>/dev/null || true
+        done
+    fi
+    echo "  running ${basename_script}"
+    bash "${script}"
+done
+
+echo "--- running units/install-units.sh (if present) ---"
+if [[ -f "${REPO}/units/install-units.sh" ]]; then
+    bash "${REPO}/units/install-units.sh"
+else
+    echo "  units/install-units.sh not present (skipping)"
+fi
+
+echo "--- running phase-4 assertion scripts ---"
+failed=0
+for assertion in $(ls "${REPO}/tests/phase-4/assertions/"*.sh 2>/dev/null | sort); do
+    echo "  running $(basename "${assertion}")"
+    if bash "${assertion}"; then
+        echo "  $(basename "${assertion}"): PASS"
+    else
+        echo "  $(basename "${assertion}"): FAIL" >&2
+        failed=$((failed + 1))
+    fi
+done
+
+if [[ "${failed}" -gt 0 ]]; then
+    echo "=== FAIL: ${failed} assertion script(s) failed ===" >&2
+    exit 1
+fi
+echo "=== all phase-4 assertions passed ==="
+'
+
+echo "=== Phase 4 testbed: running harness ==="
+
+if [[ "${PHASE_4_TESTBED_KEEP:-0}" == "1" ]]; then
+    container_id=$(docker run -d --privileged \
+        --tmpfs /run --tmpfs /tmp \
+        --entrypoint /bin/bash \
+        -v "${REPO_ROOT}:/arlowe-firmware:ro" \
+        "${IMAGE}" \
+        -c "${HARNESS}")
+    echo "Container started (PHASE_4_TESTBED_KEEP=1): ${container_id}"
+    echo "Attach with: docker exec -it ${container_id} bash"
+else
+    docker run --rm --privileged \
+        --tmpfs /run --tmpfs /tmp \
+        --entrypoint /bin/bash \
+        -v "${REPO_ROOT}:/arlowe-firmware:ro" \
+        "${IMAGE}" \
+        -c "${HARNESS}"
+fi

--- a/units/arlowe-dashboard.service
+++ b/units/arlowe-dashboard.service
@@ -40,12 +40,10 @@ SystemCallFilter=@system-service
 SystemCallFilter=~@privileged @resources
 RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
 
-# Dashboard writes cache and logs only. /etc/arlowe/config.yml is intentionally
-# NOT in ReadWritePaths — the dashboard POST /api/config route goes through a
-# privileged helper.
-# FIXME(Phase 4): wire the privileged-helper write path (polkit or setuid helper)
-# so the dashboard can persist config to /etc/arlowe/config.yml.
-ReadWritePaths=/var/lib/arlowe/dashboard /var/lib/arlowe/logs/dashboard
+# ADR-0003: /etc/arlowe added to ReadWritePaths (scoped to that path only — not
+# a broader /etc). The dashboard POST /api/config route writes the overlay via
+# temp-file + rename directly. All other sandbox hardening is unchanged.
+ReadWritePaths=/var/lib/arlowe/dashboard /var/lib/arlowe/logs/dashboard /etc/arlowe
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

- Writes ADR-0003 documenting the settled LOOSEN-PERMS decision for the dashboard config write path, with all three containment requirements (scoped `ReadWritePaths`, retained fail-fast validation, Phase 10 re-hardening flag for `ota.channel_url` and `support_mode.*`).
- Changes `/etc/arlowe` from `root:arlowe 0755` to `root:arlowe 0770` in `install-arlowe-fs.sh` and adds `/etc/arlowe` (scoped only) to `ReadWritePaths` in `arlowe-dashboard.service`, removing the FIXME(Phase 4) block.
- Adds `install-arlowe-config.sh` that installs `schema.yml`, `defaults.yml`, `arlowe_config.py`, and `arlowe_config_validate.py` into `/opt/arlowe` — never creates `/etc/arlowe/config.yml` (CONFIG-03 absence contract).
- Adds `tests/phase-4/assertions/01-config-install-shape.sh` (stat-only shape checks) and `tests/phase-4/docker/run-tests.sh` (new harness reusing the phase-3 Dockerfile; validator execution is NOT run in Docker per plan decision).
- Updates `tests/phase-3/assertions/02-fs-layout.sh` to expect `/etc/arlowe` mode `770` (required correctness — must match the installer).

## Test plan

- [ ] `bash -n` passes on all three new scripts and modified `install-arlowe-fs.sh`.
- [ ] `grep -q 'm 0770 /etc/arlowe' scripts/provision/install-arlowe-fs.sh` passes.
- [ ] `grep -qE 'ReadWritePaths=.*/etc/arlowe' units/arlowe-dashboard.service` passes and no broader `/etc` is present.
- [ ] `bash tests/phase-4/docker/run-tests.sh` (requires Docker): builds from phase-3 Dockerfile, runs all `install-arlowe-*.sh` scripts (including new config installer), then `01-config-install-shape.sh` passes.
- [ ] Sanitize gate clean: `bash scripts/sanitize/check.sh`.
- [ ] ADR contains "0770", "Phase 10", and all three containment requirements.

## Security note (`package:security`)

This is a `package:security` change. The write surface opened is `/etc/arlowe` only — the `ReadWritePaths` entry is exactly `/etc/arlowe`, not `/etc`. `ProtectSystem=strict` and all other sandbox hardening on `arlowe-dashboard.service` is unchanged. The ADR explicitly flags `ota.channel_url` and `support_mode.*` for re-hardening in Phase 10.

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)