### PR TITLE
feat(config): plan 04-03 — ajv validate-before-write + atomic write + knob→restart

### DIFF
--- a/.planning/phases/04-config-overlay/04-03-SUMMARY.md
+++ b/.planning/phases/04-config-overlay/04-03-SUMMARY.md
@@ -1,0 +1,29 @@
+---
+phase: 04-config-overlay
+plan: 03
+type: summary
+completed: 2026-06-07
+pr: pending
+requirements_covered: [CONFIG-04, CONFIG-05]
+---
+
+## What was done
+
+- Installed `ajv@^8.20.0` (dependencies) and `tsx@^4.22.4` (devDependencies) via pnpm; both land in `pnpm-lock.yaml` and `node_modules`.
+- Created `runtime/dashboard/app/api/config/restart-map.ts`: knob→unit map with `unitsForChange()` helper; only polkit-authorized unit prefixes (`arlowe-*`, `qwen-*`); `ports` carries the no-live-consumer comment per plan.
+- Rewrote `runtime/dashboard/app/api/config/route.ts` POST handler:
+  - Reads schema from `ARLOWE_SCHEMA_PATH` (default `/opt/arlowe/config/schema.yml`), validates with `Ajv2020` (draft 2020-12 dialect). Invalid body → 422, no write.
+  - Preserved the existing `writeFile(CONFIG_TMP_PATH)` + `rename(CONFIG_PATH)` atomic write.
+  - Removed the `TODO(phase-4): validate against config/schema.yml` marker.
+  - Diffs changed top-level keys against prior on-disk overlay; calls `unitsForChange()` and restarts via the `ARLOWE_SYSTEMCTL_MODE` seam (mirrors `api/voice/route.ts`). Restart failure is non-fatal; response includes `restarted` and `restartErrors` arrays.
+- Added `testIgnore: ['**/unit/**']` to `runtime/dashboard/playwright.config.ts` so `pnpm test:e2e` ignores `tests/unit/`.
+- Added `test:unit` script (`node --import tsx --test tests/unit/*.test.ts`) to `package.json`.
+- Created `runtime/dashboard/tests/unit/config-validate.test.ts` (`node:test` + `node:assert`): covers `unitsForChange` exact matches, deduplication, polkit regex guard, schema accepts valid config, schema rejects invalid `ota.channel` enum, schema rejects missing required keys.
+
+## Verification
+
+- `pnpm test:unit`: 9/9 pass, no Next build or server boot.
+- `pnpm exec tsc --noEmit`: clean.
+- `pnpm exec playwright test --list`: unit test NOT listed (44 tests from 4 `.spec.ts` files only).
+- `scripts/sanitize/check.sh`: clean (152 files, 9 units).
+- Lint: same 8 pre-existing warnings/errors as baseline; no new issues introduced.

--- a/runtime/dashboard/app/api/config/restart-map.ts
+++ b/runtime/dashboard/app/api/config/restart-map.ts
@@ -1,0 +1,35 @@
+// knob -> affected systemd unit(s)
+// INVARIANT: every unit returned here MUST match arlowe-* | qwen-* | whisper-stt.service —
+// those are the only prefixes the Phase 3 polkit rule (50-arlowe-systemctl.rules) authorizes.
+// Never add daemon-reload or a non-prefixed unit name.
+
+const RESTART_MAP: Record<string, string[]> = {
+  persona: ['arlowe-face.service'],
+  model: ['qwen-tokenizer.service', 'qwen-api.service'],
+  audio: ['arlowe-voice.service'],
+  // ports has NO live consumer in Phase 4: no service reads the port knob yet.
+  // It is wired here for when Phase 5+ services bind configured ports. A ports
+  // change restarting face/voice is currently a no-op-on-behavior restart.
+  ports: ['arlowe-face.service', 'arlowe-voice.service'],
+  // knobs with no live consumer in Phase 4 — no restart issued:
+  support_mode: [],
+  ota: [],
+  logs: [],
+  device: [],
+};
+
+/**
+ * Returns the de-duplicated union of units affected by the given top-level knob names.
+ * Only units matching arlowe-* / qwen-* / whisper-stt.service are ever returned,
+ * preserving the Phase 3 polkit contract.
+ */
+export function unitsForChange(changedTopLevelKeys: string[]): string[] {
+  const seen = new Set<string>();
+  for (const key of changedTopLevelKeys) {
+    const units = RESTART_MAP[key] ?? [];
+    for (const unit of units) {
+      seen.add(unit);
+    }
+  }
+  return Array.from(seen);
+}

--- a/runtime/dashboard/app/api/config/route.ts
+++ b/runtime/dashboard/app/api/config/route.ts
@@ -1,10 +1,40 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { readFile, rename, writeFile } from 'fs/promises';
 import { existsSync } from 'fs';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
 import yaml from 'js-yaml';
+import Ajv2020 from 'ajv/dist/2020';
+import { unitsForChange } from './restart-map';
+
+const execFileAsync = promisify(execFile);
 
 const CONFIG_PATH = '/etc/arlowe/config.yml';
 const CONFIG_TMP_PATH = '/etc/arlowe/.config.yml.tmp';
+const SCHEMA_PATH = process.env.ARLOWE_SCHEMA_PATH ?? '/opt/arlowe/config/schema.yml';
+
+// Mirrors the ARLOWE_SYSTEMCTL_MODE seam from api/voice/route.ts.
+// system = polkit-authorized system units (Phase 3+); user = dev fallback.
+const SYSTEMCTL_MODE = process.env.ARLOWE_SYSTEMCTL_MODE ?? 'user';
+
+function systemctlArgs(subcommand: string, unit: string): string[] {
+  return SYSTEMCTL_MODE === 'system'
+    ? ['systemctl', subcommand, unit]
+    : ['systemctl', '--user', subcommand, unit];
+}
+
+function changedTopLevelKeys(
+  body: Record<string, unknown>,
+  previous: Record<string, unknown> | null
+): string[] {
+  if (previous === null) {
+    // No prior overlay on disk — treat all body keys as changed.
+    return Object.keys(body);
+  }
+  return Object.keys(body).filter(
+    k => JSON.stringify(body[k]) !== JSON.stringify(previous[k])
+  );
+}
 
 export async function GET(_request: NextRequest) {
   if (!existsSync(CONFIG_PATH)) {
@@ -23,14 +53,60 @@ export async function GET(_request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
-    const raw = yaml.dump(body);
+    const body = await request.json() as Record<string, unknown>;
 
+    // Validate against config/schema.yml (JSON Schema draft 2020-12) before writing.
+    // An invalid body is rejected with 422; nothing is written to disk.
+    const schemaRaw = await readFile(SCHEMA_PATH, 'utf-8');
+    const schema = yaml.load(schemaRaw) as object;
+    const ajv = new Ajv2020({ allErrors: true });
+    const validate = ajv.compile(schema);
+    if (!validate(body)) {
+      return NextResponse.json(
+        { error: 'schema violation', details: validate.errors },
+        { status: 422 }
+      );
+    }
+
+    // Read the current on-disk overlay (if present) to diff for restart targeting.
+    let previous: Record<string, unknown> | null = null;
+    if (existsSync(CONFIG_PATH)) {
+      try {
+        const prevRaw = await readFile(CONFIG_PATH, 'utf-8');
+        const parsed = yaml.load(prevRaw);
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          previous = parsed as Record<string, unknown>;
+        }
+      } catch {
+        // Unreadable overlay: treat all body keys as changed (conservative).
+      }
+    }
+
+    // Atomic write: temp file + rename so a crash mid-write cannot leave a partial overlay.
+    const raw = yaml.dump(body);
     await writeFile(CONFIG_TMP_PATH, raw, 'utf-8');
     await rename(CONFIG_TMP_PATH, CONFIG_PATH);
 
-    // TODO(phase-4): validate against config/schema.yml before writing.
-    return NextResponse.json({ ok: true, written: CONFIG_PATH });
+    // Restart affected units for changed knobs. A restart failure is non-fatal:
+    // the config is already written; log the error and include it in the response.
+    const changed = changedTopLevelKeys(body, previous);
+    const units = unitsForChange(changed);
+    const restarted: string[] = [];
+    const restartErrors: string[] = [];
+
+    for (const unit of units) {
+      try {
+        const args = systemctlArgs('restart', unit);
+        await execFileAsync(args[0], args.slice(1), { timeout: 10000 });
+        restarted.push(unit);
+      } catch (err) {
+        const msg = `${unit}: ${String(err)}`;
+        console.error('Restart failed (non-fatal):', msg);
+        restartErrors.push(msg);
+      }
+    }
+
+    return NextResponse.json({ ok: true, written: CONFIG_PATH, restarted, restartErrors });
   } catch (error) {
     console.error('Failed to write config:', error);
     return NextResponse.json({ error: String(error) }, { status: 500 });

--- a/runtime/dashboard/package.json
+++ b/runtime/dashboard/package.json
@@ -7,11 +7,13 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "test:unit": "node --import tsx --test tests/unit/*.test.ts"
   },
   "dependencies": {
     "@tailwindcss/typography": "^0.5.19",
     "@types/js-yaml": "^4.0.9",
+    "ajv": "^8.20.0",
     "js-yaml": "^4.1.1",
     "next": "16.1.6",
     "react": "19.2.3",
@@ -28,6 +30,7 @@
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
     "tailwindcss": "^4",
+    "tsx": "^4.22.4",
     "typescript": "^5"
   }
 }

--- a/runtime/dashboard/playwright.config.ts
+++ b/runtime/dashboard/playwright.config.ts
@@ -13,6 +13,7 @@ import { defineConfig, devices } from '@playwright/test';
  */
 export default defineConfig({
   testDir: './tests',
+  testIgnore: ['**/unit/**'],
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/runtime/dashboard/pnpm-lock.yaml
+++ b/runtime/dashboard/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@types/js-yaml':
         specifier: ^4.0.9
         version: 4.0.9
+      ajv:
+        specifier: ^8.20.0
+        version: 8.20.0
       js-yaml:
         specifier: ^4.1.1
         version: 4.1.1
@@ -57,6 +60,9 @@ importers:
       tailwindcss:
         specifier: ^4
         version: 4.2.4
+      tsx:
+        specifier: ^4.22.4
+        version: 4.22.4
       typescript:
         specifier: ^5
         version: 5.9.3
@@ -142,6 +148,162 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -748,6 +910,9 @@ packages:
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
@@ -1017,6 +1182,11 @@ packages:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
 
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -1168,6 +1338,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
@@ -1205,6 +1378,11 @@ packages:
 
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
@@ -1483,6 +1661,9 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -1960,6 +2141,10 @@ packages:
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -2150,6 +2335,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.22.4:
+    resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -2391,6 +2581,84 @@ snapshots:
   '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.6.1))':
@@ -2918,6 +3186,13 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
@@ -3268,6 +3543,35 @@ snapshots:
       is-date-object: 1.1.0
       is-symbol: 1.1.1
 
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
+
   escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
@@ -3497,6 +3801,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-uri@3.1.2: {}
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -3530,6 +3836,9 @@ snapshots:
       is-callable: 1.2.7
 
   fsevents@2.3.2:
+    optional: true
+
+  fsevents@2.3.3:
     optional: true
 
   function-bind@1.1.2: {}
@@ -3822,6 +4131,8 @@ snapshots:
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -4542,6 +4853,8 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
+  require-from-string@2.0.2: {}
+
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -4794,6 +5107,12 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  tsx@4.22.4:
+    dependencies:
+      esbuild: 0.28.0
+    optionalDependencies:
+      fsevents: 2.3.3
 
   type-check@0.4.0:
     dependencies:

--- a/runtime/dashboard/tests/unit/config-validate.test.ts
+++ b/runtime/dashboard/tests/unit/config-validate.test.ts
@@ -1,0 +1,114 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import yaml from 'js-yaml';
+import Ajv2020 from 'ajv/dist/2020';
+import { unitsForChange } from '../../app/api/config/restart-map.js';
+
+// Resolve schema relative to this file: runtime/dashboard/tests/unit/ -> repo root -> config/
+const SCHEMA_PATH = resolve(import.meta.dirname, '../../../../config/schema.yml');
+
+function buildValidator() {
+  const schemaRaw = readFileSync(SCHEMA_PATH, 'utf-8');
+  const schema = yaml.load(schemaRaw) as object;
+  const ajv = new Ajv2020({ allErrors: true });
+  return ajv.compile(schema);
+}
+
+// Polkit-authorized unit name pattern (Phase 3 rule).
+const POLKIT_PATTERN = /^(arlowe-|qwen-)|^whisper-stt\.service$/;
+
+describe('unitsForChange', () => {
+  it('persona maps to arlowe-face.service', () => {
+    const units = unitsForChange(['persona']);
+    assert.deepEqual(units, ['arlowe-face.service']);
+  });
+
+  it('ota maps to [] (no live consumer in Phase 4)', () => {
+    const units = unitsForChange(['ota']);
+    assert.deepEqual(units, []);
+  });
+
+  it('support_mode maps to [] (no live consumer in Phase 4)', () => {
+    assert.deepEqual(unitsForChange(['support_mode']), []);
+  });
+
+  it('logs maps to [] (no live consumer in Phase 4)', () => {
+    assert.deepEqual(unitsForChange(['logs']), []);
+  });
+
+  it('deduplicates units when multiple knobs share a unit', () => {
+    const units = unitsForChange(['persona', 'ports']);
+    // both include arlowe-face.service; it should appear once
+    const faceCount = units.filter(u => u === 'arlowe-face.service').length;
+    assert.equal(faceCount, 1);
+  });
+
+  it('every unit returned by any knob matches the polkit-authorized prefix', () => {
+    const allKnobs = ['persona', 'model', 'audio', 'ports', 'support_mode', 'ota', 'logs', 'device'];
+    const units = unitsForChange(allKnobs);
+    for (const unit of units) {
+      assert.match(
+        unit,
+        POLKIT_PATTERN,
+        `Unit "${unit}" does not match polkit-authorized prefix (arlowe-* | qwen-* | whisper-stt.service)`
+      );
+    }
+  });
+});
+
+describe('ajv schema validation', () => {
+  const validate = buildValidator();
+
+  it('accepts a valid minimal config', () => {
+    const config = {
+      device: { hostname: 'arlowe-${device_serial}' },
+      audio: { capture_device: 'auto', playback_device: 'auto' },
+      model: { choice: 'qwen2.5-7b-int4-ax650' },
+      persona: {
+        sentiment_mapping: {
+          positive: ['happy'],
+          negative: ['concerned'],
+          neutral: ['idle'],
+        },
+      },
+      ports: { face: 8080, stt: 8082, dashboard: 3000 },
+      logs: { transcript_retention_days: 7, transcript_logging_enabled: true },
+      support_mode: { enabled: false, window_hours: 24 },
+      ota: { channel: 'stable', channel_url: '' },
+    };
+    const ok = validate(config);
+    assert.equal(ok, true, JSON.stringify(validate.errors));
+  });
+
+  it('rejects an invalid ota.channel enum value', () => {
+    const config = {
+      device: { hostname: 'arlowe-${device_serial}' },
+      audio: { capture_device: 'auto', playback_device: 'auto' },
+      model: { choice: 'qwen2.5-7b-int4-ax650' },
+      persona: {
+        sentiment_mapping: {
+          positive: ['happy'],
+          negative: ['concerned'],
+          neutral: ['idle'],
+        },
+      },
+      ports: { face: 8080, stt: 8082, dashboard: 3000 },
+      logs: { transcript_retention_days: 7, transcript_logging_enabled: true },
+      support_mode: { enabled: false, window_hours: 24 },
+      ota: { channel: 'nightly', channel_url: '' }, // 'nightly' is not in the enum
+    };
+    const ok = validate(config);
+    assert.equal(ok, false, 'Expected validation to fail for invalid ota.channel');
+    assert.ok(
+      validate.errors && validate.errors.length > 0,
+      'Expected at least one validation error'
+    );
+  });
+
+  it('rejects a body missing required top-level keys', () => {
+    const ok = validate({ model: { choice: 'qwen2.5-7b-int4-ax650' } });
+    assert.equal(ok, false, 'Expected validation to fail for missing required keys');
+  });
+});


### PR DESCRIPTION
## Summary

- Installs `ajv@^8.20.0` and wires ajv draft 2020-12 dialect into `POST /api/config`: the body is validated against `config/schema.yml` (via `ARLOWE_SCHEMA_PATH`) before any write; an invalid body returns 422 and writes nothing to disk.
- Preserves the existing `writeFile(CONFIG_TMP_PATH)` + `rename(CONFIG_PATH)` atomic write.
- Adds `app/api/config/restart-map.ts`: knob→polkit-authorized unit mapping with `unitsForChange()` helper. Units are restricted to `arlowe-*`/`qwen-*`/`whisper-stt.service`. The `ports` knob carries an inline comment that it has no live consumer in Phase 4.
- Triggers `systemctl restart <unit>` for changed knobs via the `ARLOWE_SYSTEMCTL_MODE` seam (mirrors `api/voice/route.ts`). Restart failure is non-fatal; response includes `restarted` and `restartErrors`.
- Adds `testIgnore: ['**/unit/**']` to `playwright.config.ts` so `pnpm test:e2e` does not collect the node:test file.
- Adds `test:unit` script (`node --import tsx --test tests/unit/*.test.ts`) and `tests/unit/config-validate.test.ts` (9 hermetic `node:test` cases; no Next build or server boot).

## Test plan

- [x] `pnpm test:unit` — 9/9 pass (unitsForChange exact matches, deduplication, polkit regex guard, schema accepts valid, rejects invalid `ota.channel`, rejects missing required keys)
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec playwright test --list` — unit test NOT listed; only 44 tests from 4 `.spec.ts` files
- [x] `scripts/sanitize/check.sh` — clean (152 files, 9 units)
- [x] Lint errors unchanged from baseline (5 pre-existing errors in unrelated React components)

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)