### PR TITLE
feat(config): plan 04-04 — persona live slice + ExecStartPre fail-fast validators

### DIFF
--- a/.planning/phases/04-config-overlay/04-04-SUMMARY.md
+++ b/.planning/phases/04-config-overlay/04-04-SUMMARY.md
@@ -1,0 +1,65 @@
+---
+phase: 04-config-overlay
+plan: 04
+status: complete
+closure: passed-with-notes
+provides:
+  - arlowe-face consumes persona.sentiment_mapping from the merged+validated YAML overlay via the shared arlowe_config loader (deep-merge over defaults); absent overlay returns defaults without raising (SC3 preserved). Reconciles the prior JSON/top-level-sentiment_mapping path.
+  - SC2 fail-fast — ExecStartPre arlowe_config_validate on the three python-bearing units (arlowe-face + arlowe-voice via /opt/arlowe/venvs/voice; qwen-tokenizer via /opt/arlowe/venvs/llm). A schema-violating overlay exits 78 and the unit refuses to start. qwen-tokenizer gates the qwen chain (qwen-api Requires=qwen-tokenizer and has no venv of its own); qwen-api.service untouched.
+  - CONFIG-06 persona knob has a live consumer; the other knobs (hostname, support_mode, ota, logs) are defined+validated in 04-01 but consumed in Phases 7-11 by design.
+affects:
+  - Phase 6 (image build) — runs the on-device SC4 end-to-end (dashboard persona change → arlowe-face restart → visible expression change) and the real validator-execution check. Procedure ready in docs/operations/phase-4-persona-slice.md.
+  - Phase 10 — re-harden ota.channel_url + support_mode.* writes behind support-mode re-auth (per ADR-0003).
+  - Phase 11 — persona is the proven dashboard-knob pattern for the settings view.
+files_written:
+  - runtime/face/sentiment_classifier.py
+  - runtime/face/tests/test_persona_overlay.py
+  - units/arlowe-face.service
+  - units/arlowe-voice.service
+  - units/qwen-tokenizer.service
+  - docs/operations/phase-4-persona-slice.md
+---
+
+## What landed
+
+The persona config knob, end-to-end on the consumer + fail-fast side:
+
+- **`runtime/face/sentiment_classifier.py`** — `load_config()` now reads
+  `persona.sentiment_mapping` from the shared loader (`from arlowe_config import
+  load`), which deep-merges the optional `/etc/arlowe/config.yml` overlay over
+  `defaults.yml` and validates. Resilient fallbacks (direct YAML read → legacy JSON
+  state → `DEFAULT_MAPPING`); absent overlay is the normal pre-pairing state and
+  never raises (SC3). Public signatures unchanged, so `face_service.py` is unaffected.
+- **`units/{arlowe-face,arlowe-voice,qwen-tokenizer}.service`** — added a
+  non-`-`-prefixed `ExecStartPre=… -m arlowe_config_validate` with the correct venv
+  interpreter, and `PYTHONPATH += /opt/arlowe/runtime/lib`. A bad overlay fail-fasts
+  start (SC2). The validator lives on qwen-tokenizer (not the venv-less qwen-api),
+  gating the qwen chain via `Requires=`.
+- **`runtime/face/tests/test_persona_overlay.py`** — 2 pytest cases: a partial
+  persona overlay overrides one sentiment and deep-merge preserves the siblings; an
+  absent overlay returns defaults without raising.
+- **`docs/operations/phase-4-persona-slice.md`** — the SC4 verification procedure.
+
+## Verification
+
+- `pytest runtime/face/tests/test_persona_overlay.py` — 2/2 green (against real
+  `jsonschema` 4.23.0 + `PyYAML` 6.0.3).
+- Sanitize gate green; `git diff --quiet units/qwen-api.service` (untouched).
+- Units edited per plan; `systemd-analyze verify` deferred to the Pi/image (not on macOS).
+
+## Note (why passed-with-notes): SC4 deferred to Phase 6
+
+The on-device SC4 end-to-end — dashboard persona change → `arlowe-face` restart →
+**visible** expression change — could not be run on `arlowe-1`. Confirmed via ssh:
+the dev Pi has **no `arlowe` user, no `/opt/arlowe`, no `/etc/arlowe`, no system
+`arlowe-face.service`, and no venv with `jsonschema`/`PyYAML`**. Its daily-driver
+runs as `focal55` under `--user` units with the pre-firmware code. Phase 4's runtime
+only exists in the arlowe layout, which is built by the **Phase 6 image** — so the
+running-services SC4 check belongs there (same deferral shape as Phase 1 SC4 → Phase
+12 and Phase 3 SC4 → staging/image). The procedure is written and ready to run when
+the image exists.
+
+This closes Phase 4 **passed-with-notes**: CONFIG-01..06 are implemented and
+unit/sanitize-verified; the one hardware-bound demonstration (SC4 persona on a
+running face) is deferred to Phase 6/12.
+</content>

--- a/docs/operations/phase-4-persona-slice.md
+++ b/docs/operations/phase-4-persona-slice.md
@@ -1,0 +1,76 @@
+# Phase 4 persona slice — SC4 verification procedure
+
+The persona knob is the one CONFIG-06 knob with a live end-to-end consumer in
+Phase 4 (the others are defined + validated but consumed in Phases 7–11). This
+doc is the manual verification for **SC2** (refuse to start on a bad overlay) and
+**SC4** (a knob change restarts the service and takes effect).
+
+The chain: dashboard validates (ajv) + atomically writes `/etc/arlowe/config.yml`
++ restarts `arlowe-face` (plan 04-03) → `arlowe-face` reads
+`persona.sentiment_mapping` from the merged+validated overlay via the shared
+loader (`runtime/face/sentiment_classifier.py`) → `ExecStartPre` runs
+`arlowe_config_validate` and exits 78 on a bad overlay (plan 04-04).
+
+Run on a Pi with Phase 4 provisioned (the runtime services installed under
+`/opt/arlowe`, the dashboard reachable on `http://localhost:3000`).
+
+## 1. Baseline — absent overlay (SC3)
+
+```bash
+ls /etc/arlowe/config.yml          # expect: No such file (pre-pairing state)
+systemctl status arlowe-face       # expect: active (running)
+```
+Face uses `DEFAULT_MAPPING` (positive → happy). No crash, no error in the journal.
+
+## 2. Persona change → restart → effect (SC4)
+
+Through the dashboard Settings, or directly:
+
+```bash
+curl -sS -X POST http://localhost:3000/api/config \
+  -H 'Content-Type: application/json' \
+  -d '{"persona":{"sentiment_mapping":{"positive":["excited"]}}}'
+# expect: HTTP 200
+cat /etc/arlowe/config.yml          # now exists, valid YAML, positive: [excited]
+journalctl -u arlowe-face -n 20     # shows the unit restarted
+```
+
+Then trigger a positive-sentiment interaction and confirm the face shows the
+**excited** expression rather than the default **happy**. (Deep-merge preserved
+the untouched `negative`/`neutral` siblings — verify they still behave.)
+
+## 3. Fail-fast on an invalid overlay (SC2)
+
+Reject at the write boundary:
+```bash
+curl -sS -o /dev/null -w '%{http_code}\n' -X POST http://localhost:3000/api/config \
+  -H 'Content-Type: application/json' -d '{"ota":{"channel":"purple"}}'
+# expect: 422, and /etc/arlowe/config.yml UNCHANGED
+```
+
+Then prove the service-level fail-fast (write a bad overlay directly and restart):
+```bash
+sudo tee /etc/arlowe/config.yml >/dev/null <<'EOF'
+ota:
+  channel: purple
+EOF
+sudo systemctl restart arlowe-face
+systemctl status arlowe-face        # expect: failed
+journalctl -u arlowe-face -n 20     # expect: [arlowe-config] schema violation ... ; status=78
+
+# qwen chain: tokenizer fails, and qwen-api (Requires=qwen-tokenizer) is blocked
+sudo systemctl restart qwen-tokenizer   # expect: failed (exit 78)
+sudo systemctl start qwen-api            # expect: blocked / dependency failed
+```
+
+Restore: remove the bad overlay (or write a valid one) and restart the services.
+
+## Notes
+
+- `ExecStartPre` execution is where the python loader actually runs against the
+  installed `jsonschema`/`PyYAML` — the Phase-4 Docker testbed is stat-only, so
+  this on-device run is the real validator-execution check.
+- `qwen-api.service` has no python venv (native `run_api.sh`); the validator
+  lives on `qwen-tokenizer.service`, which `qwen-api` `Requires=`, so a bad
+  overlay fail-fasts the whole qwen chain without touching qwen-api.
+- Record pass/fail per step in `04-04-SUMMARY.md`.

--- a/runtime/face/sentiment_classifier.py
+++ b/runtime/face/sentiment_classifier.py
@@ -16,9 +16,10 @@ from typing import Tuple, Optional
 # the OpenAI-compat path doesn't exist on the running ax-llm build).
 QWEN_URL = "http://localhost:8000/api/chat"
 
-# Load order: /etc/arlowe/config.yml (post-pairing overlay, Phase 4),
-# falling back to <state>/whisplay-config.json for dev.
-# During Phase 1 we accept the fallback path; Phase 4 wires the overlay.
+# Load order (Phase 4): the merged+validated YAML overlay via the shared
+# arlowe_config loader (persona.sentiment_mapping), then a direct YAML read of
+# /etc/arlowe/config.yml, then the legacy <state>/whisplay-config.json dev file,
+# then DEFAULT_MAPPING. Absent overlay is a normal pre-pairing state (SC3).
 CONFIG_OVERLAY = Path(os.environ.get("ARLOWE_CONFIG_PATH", "/etc/arlowe/config.yml"))
 CONFIG_PATH = Path(os.environ.get("ARLOWE_STATE_DIR", "/var/lib/arlowe/state")) / "whisplay-config.json"
 
@@ -49,20 +50,63 @@ EXPRESSION_TO_STATE = {
 }
 
 
-def load_config() -> dict:
-    """Load configuration file with sentiment-to-expression mapping.
+def _mapping_via_shared_loader() -> Optional[dict]:
+    """Return persona.sentiment_mapping from the merged+validated config, or None.
 
-    Returns DEFAULT_MAPPING if neither config path exists or is unreadable.
-    This is the expected state during Phase 1 / pre-pairing.
+    Uses the shared arlowe_config loader (defaults + overlay, deep-merged and
+    schema-validated). Returns None when the loader is unavailable (dev env
+    without runtime/lib on PYTHONPATH) or the overlay fails validation — in
+    which case the caller falls back. The fail-fast SC2 guarantee is provided by
+    the units' ExecStartPre validator at startup, so at runtime we degrade to
+    defaults rather than crash the running face.
     """
-    for path in (CONFIG_OVERLAY, CONFIG_PATH):
-        if path.exists():
-            try:
-                with open(path) as f:
-                    config = json.load(f)
-                    return config.get("sentiment_mapping", DEFAULT_MAPPING)
-            except Exception as e:
-                print(f"  [sentiment] Config load error ({path}): {e}, using defaults", flush=True)
+    try:
+        from arlowe_config import load
+    except ImportError:
+        return None
+    try:
+        cfg = load()
+    except SystemExit:
+        print("  [sentiment] overlay failed schema validation, using defaults", flush=True)
+        return None
+    except Exception as e:
+        print(f"  [sentiment] shared loader error ({e}), using defaults", flush=True)
+        return None
+    return (cfg.get("persona") or {}).get("sentiment_mapping") or None
+
+
+def load_config() -> dict:
+    """Load the sentiment-to-expression mapping.
+
+    Primary: persona.sentiment_mapping from the shared loader (merged YAML
+    overlay). Fallbacks: a direct YAML read of the overlay, then the legacy JSON
+    state file, then DEFAULT_MAPPING. Absent overlay is a normal pre-pairing
+    state and never raises (SC3).
+    """
+    mapping = _mapping_via_shared_loader()
+    if mapping:
+        return mapping
+
+    # Fallback for dev/local without the installed lib+config on PYTHONPATH.
+    if CONFIG_OVERLAY.exists():
+        try:
+            import yaml
+            with open(CONFIG_OVERLAY) as f:
+                cfg = yaml.safe_load(f) or {}
+            mapping = (cfg.get("persona") or {}).get("sentiment_mapping")
+            if mapping:
+                # Shallow-merge over defaults so a partial overlay keeps siblings.
+                return {**DEFAULT_MAPPING, **mapping}
+        except Exception as e:
+            print(f"  [sentiment] overlay read error ({CONFIG_OVERLAY}): {e}, using defaults", flush=True)
+
+    if CONFIG_PATH.exists():
+        try:
+            with open(CONFIG_PATH) as f:
+                return json.load(f).get("sentiment_mapping", DEFAULT_MAPPING)
+        except Exception as e:
+            print(f"  [sentiment] legacy config read error ({CONFIG_PATH}): {e}, using defaults", flush=True)
+
     return DEFAULT_MAPPING
 
 

--- a/runtime/face/tests/test_persona_overlay.py
+++ b/runtime/face/tests/test_persona_overlay.py
@@ -1,0 +1,44 @@
+"""Phase 4 (04-04): arlowe-face consumes persona.sentiment_mapping from the YAML
+overlay via the shared loader, deep-merged over defaults; absent overlay -> defaults.
+
+Run from repo root:
+  PYTHONPATH=runtime/lib:runtime/face \
+  ARLOWE_SCHEMA_PATH=config/schema.yml ARLOWE_DEFAULTS_PATH=config/defaults.yml \
+  python3 -m pytest runtime/face/tests/test_persona_overlay.py -q
+"""
+import importlib
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[3]
+
+
+def _load_config(monkeypatch, overlay_path):
+    """Point both the shared loader and sentiment_classifier at repo config +
+    the given overlay path, then (re)load and call load_config()."""
+    monkeypatch.setenv("ARLOWE_SCHEMA_PATH", str(REPO / "config" / "schema.yml"))
+    monkeypatch.setenv("ARLOWE_DEFAULTS_PATH", str(REPO / "config" / "defaults.yml"))
+    monkeypatch.setenv("ARLOWE_CONFIG_PATH", str(overlay_path))
+    # Both modules read their path env vars at import time — reload so each case
+    # sees the case-specific env.
+    import arlowe_config
+    import sentiment_classifier
+    importlib.reload(arlowe_config)
+    importlib.reload(sentiment_classifier)
+    return sentiment_classifier.load_config()
+
+
+def test_overlay_overrides_one_sentiment_preserves_siblings(tmp_path, monkeypatch):
+    overlay = tmp_path / "config.yml"
+    overlay.write_text("persona:\n  sentiment_mapping:\n    positive:\n      - excited\n")
+    mapping = _load_config(monkeypatch, overlay)
+    # Overlay wins for positive; defaults preserved for the untouched siblings.
+    assert mapping["positive"] == ["excited"]
+    assert mapping["neutral"] == ["idle", "attentive"]
+    assert mapping["negative"] == ["concerned", "sad"]
+
+
+def test_absent_overlay_returns_defaults_without_raising(tmp_path, monkeypatch):
+    # ARLOWE_CONFIG_PATH points at a nonexistent file — the pre-pairing state (SC3).
+    mapping = _load_config(monkeypatch, tmp_path / "nonexistent.yml")
+    assert mapping["positive"] == ["happy", "excited"]
+    assert mapping["neutral"] == ["idle", "attentive"]

--- a/units/arlowe-face.service
+++ b/units/arlowe-face.service
@@ -11,10 +11,12 @@ Group=arlowe
 SupplementaryGroups=gpio spi video
 WorkingDirectory=/opt/arlowe/runtime
 Environment=PYTHONUNBUFFERED=1
-Environment=PYTHONPATH=/opt/arlowe/runtime
+Environment=PYTHONPATH=/opt/arlowe/runtime:/opt/arlowe/runtime/lib
 Environment=ARLOWE_WHISPLAY_DRIVER_PATH=/opt/arlowe/third_party/whisplay-driver
 Environment=ARLOWE_STATE_DIR=/var/lib/arlowe/state
 Environment=ARLOWE_LOGS_DIR=/var/lib/arlowe/logs
+# Fail-fast (SC2): refuse to start on an invalid config overlay (exit 78).
+ExecStartPre=/opt/arlowe/venvs/voice/bin/python -m arlowe_config_validate
 ExecStart=/opt/arlowe/venvs/voice/bin/python -m face.face_service
 Restart=on-failure
 RestartSec=5

--- a/units/arlowe-voice.service
+++ b/units/arlowe-voice.service
@@ -11,7 +11,7 @@ Group=arlowe
 SupplementaryGroups=audio dialout
 WorkingDirectory=/opt/arlowe/runtime
 Environment=PYTHONUNBUFFERED=1
-Environment=PYTHONPATH=/opt/arlowe/runtime
+Environment=PYTHONPATH=/opt/arlowe/runtime:/opt/arlowe/runtime/lib
 Environment=ARLOWE_PIPER_PATH=/opt/arlowe/runtime/tts/bin/piper
 Environment=ARLOWE_PIPER_MODEL=/opt/arlowe/models/piper-voices/en_US-lessac-medium.onnx
 Environment=ARLOWE_VERIFIER_MODEL=/var/lib/arlowe/wake-word/verifier.pkl
@@ -19,6 +19,8 @@ Environment=ARLOWE_FACE_URL=http://localhost:8080
 Environment=ARLOWE_STT_URL=http://localhost:8082/transcribe
 Environment=ARLOWE_LOGS_DIR=/var/lib/arlowe/logs
 Environment=ARLOWE_STATE_DIR=/var/lib/arlowe/state
+# Fail-fast (SC2): refuse to start on an invalid config overlay (exit 78).
+ExecStartPre=/opt/arlowe/venvs/voice/bin/python -m arlowe_config_validate
 ExecStart=/opt/arlowe/venvs/voice/bin/python -m voice.voice_client
 Restart=on-failure
 RestartSec=10

--- a/units/qwen-tokenizer.service
+++ b/units/qwen-tokenizer.service
@@ -8,6 +8,11 @@ User=arlowe
 Group=arlowe
 WorkingDirectory=/opt/arlowe/runtime/llm
 Environment=PYTHONUNBUFFERED=1
+Environment=PYTHONPATH=/opt/arlowe/runtime/lib
+# Fail-fast (SC2): refuse to start on an invalid config overlay (exit 78). This
+# gates the whole qwen chain — qwen-api Requires=qwen-tokenizer.service and has
+# no python venv of its own, so a bad overlay here blocks qwen-api too.
+ExecStartPre=/opt/arlowe/venvs/llm/bin/python -m arlowe_config_validate
 ExecStart=/opt/arlowe/venvs/llm/bin/python /opt/arlowe/runtime/llm/qwen2.5_tokenizer_uid.py
 Restart=on-failure
 RestartSec=5


### PR DESCRIPTION
Closes #83. Final plan of Phase 4 (config overlay). **Closure: passed-with-notes** — code implemented + unit/sanitize-verified; the one hardware-bound SC4 demonstration is deferred to Phase 6 (see below).

## What this does
- **`runtime/face/sentiment_classifier.py`** — `load_config()` reads `persona.sentiment_mapping` from the merged+validated YAML overlay via the shared `arlowe_config` loader (deep-merge over defaults), with resilient fallbacks. Absent overlay → defaults, never raises (SC3). Reconciles the old JSON/top-level path. Public signatures unchanged.
- **`units/{arlowe-face,arlowe-voice,qwen-tokenizer}.service`** — `ExecStartPre=… -m arlowe_config_validate` (correct venv each) + `PYTHONPATH += /opt/arlowe/runtime/lib`. Bad overlay → exit 78, service refuses start (SC2). Validator on **qwen-tokenizer** (not venv-less qwen-api) gates the qwen chain via `Requires=`. **qwen-api.service untouched.**
- **`runtime/face/tests/test_persona_overlay.py`** — 2 green (partial-overlay deep-merge preserves siblings; absent → defaults).
- **`docs/operations/phase-4-persona-slice.md`** — SC4 verification procedure.

## Verification
`pytest` 2/2 green (real jsonschema/PyYAML); sanitize gate green; `qwen-api.service` untouched; units edited per the verified plan.

## SC4 deferred to Phase 6 (the "note")
The on-device SC4 (dashboard persona change → `arlowe-face` restart → **visible** expression change) can't run on `arlowe-1`: it has no `arlowe` user, no `/opt/arlowe`, no `/etc/arlowe`, no system `arlowe-face.service`, and no venv with the new deps. The dev Pi's daily-driver is `focal55` `--user` with pre-firmware code. Phase 4's runtime only exists in the **Phase 6 image** — same deferral shape as Phase 1 SC4 → Phase 12 and Phase 3 SC4 → staging. Procedure is written and ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)