### PR TITLE
feat(audio): wire record/stt/speak CLIs to arlowe_audio device resolver

### DIFF
--- a/.planning/phases/05-audio-device-auto-detection/05-03-SUMMARY.md
+++ b/.planning/phases/05-audio-device-auto-detection/05-03-SUMMARY.md
@@ -1,0 +1,65 @@
+# 05-03 Summary: bash CLI audio device wiring
+
+**Completed:** 2026-06-13
+**PR:** feat/05-03-cli-audio-wiring (Closes #90)
+
+---
+
+## What changed
+
+Three operator CLI helpers in `runtime/cli/` now resolve their ALSA device at
+invocation via the `arlowe_audio` CLI (05-01), instead of hardcoding `plughw:2,0`.
+
+- `record` — capture from resolved device (`--resolve-capture`)
+- `stt` — capture from resolved device (`--resolve-capture`)
+- `speak` — playback to resolved device (`--resolve-playback`)
+
+---
+
+## Env-var contract
+
+| Variable            | Used by        | Purpose                                          |
+|---------------------|----------------|--------------------------------------------------|
+| `ARLOWE_ALSA_DEVICE`| record, stt    | Override capture device; skips resolver entirely |
+| `ARLOWE_PLAY_DEVICE`| speak          | Override playback device; skips resolver entirely|
+| `ARLOWE_LIB`        | all three      | Path to runtime/lib; defaults to /opt/arlowe/runtime/lib |
+
+Capture and playback env vars are kept distinct (no shared variable), consistent
+with the split in 05-02.
+
+---
+
+## Resolution pattern
+
+Each script uses the same three-tier pattern:
+
+```bash
+ARLOWE_LIB="${ARLOWE_LIB:-/opt/arlowe/runtime/lib}"
+CAPTURE_DEV="${ARLOWE_ALSA_DEVICE:-$(PYTHONPATH="$ARLOWE_LIB" python3 -m arlowe_audio --resolve-capture 2>/dev/null)}"
+CAPTURE_DEV="${CAPTURE_DEV:-plughw:2,0}"
+```
+
+Priority:
+1. Explicit env override (`ARLOWE_ALSA_DEVICE` / `ARLOWE_PLAY_DEVICE`)
+2. `arlowe_audio` CLI resolution (reads `/proc/asound`, honors `/etc/arlowe/config.yml` override)
+3. Literal `plughw:2,0` fallback — degrades gracefully rather than failing hard
+
+---
+
+## PYTHONPATH shim
+
+The bash scripts reach the lib via `PYTHONPATH="$ARLOWE_LIB"` in the command
+substitution. This avoids installing `arlowe_audio` as a system package and
+mirrors how the Python services are invoked. `ARLOWE_LIB` defaults to
+`/opt/arlowe/runtime/lib` (the production install path from 04-02).
+
+---
+
+## Preserved flags
+
+Each script's existing format flags are untouched:
+- `record`: `-c 2` (stereo)
+- `stt`: `-c 1` (mono)
+
+The channel difference is pre-existing and intentional; 05-03 only touches the
+device argument.

--- a/runtime/cli/record
+++ b/runtime/cli/record
@@ -5,6 +5,9 @@
 DURATION=${1:-5}
 OUTPUT=${2:-/tmp/recording.wav}
 
-# TODO(phase-5): plughw:2,0 hardcoded; replace with auto-detected device.
-arecord -D plughw:2,0 -f S16_LE -r 16000 -c 2 -d $DURATION $OUTPUT 2>/dev/null
+ARLOWE_LIB="${ARLOWE_LIB:-/opt/arlowe/runtime/lib}"
+CAPTURE_DEV="${ARLOWE_ALSA_DEVICE:-$(PYTHONPATH="$ARLOWE_LIB" python3 -m arlowe_audio --resolve-capture 2>/dev/null)}"
+CAPTURE_DEV="${CAPTURE_DEV:-plughw:2,0}"
+
+arecord -D "$CAPTURE_DEV" -f S16_LE -r 16000 -c 2 -d $DURATION $OUTPUT 2>/dev/null
 echo $OUTPUT

--- a/runtime/cli/speak
+++ b/runtime/cli/speak
@@ -24,6 +24,10 @@ MODEL="${PIPER_VOICE:-/opt/arlowe/models/piper-voices/en_US-lessac-medium.onnx}"
 TMPFILE=$(mktemp /tmp/tts_XXXXXX.wav)
 FACE_URL="http://localhost:8080/state"
 
+ARLOWE_LIB="${ARLOWE_LIB:-/opt/arlowe/runtime/lib}"
+PLAY_DEV="${ARLOWE_PLAY_DEVICE:-$(PYTHONPATH="$ARLOWE_LIB" python3 -m arlowe_audio --resolve-playback 2>/dev/null)}"
+PLAY_DEV="${PLAY_DEV:-plughw:2,0}"
+
 # Notify face we're about to talk
 if [ "$FACE_SYNC" = true ]; then
     # Save current state (best effort)
@@ -36,9 +40,8 @@ fi
 # Generate speech
 echo "$TEXT" | $PIPER --model $MODEL --output_file $TMPFILE 2>/dev/null
 
-# TODO(phase-5): plughw:2,0 hardcoded; replace with auto-detected device.
 # Resample to 48kHz for WM8960 and play
-sox $TMPFILE -r 48000 -c 2 -t wav - 2>/dev/null | aplay -D plughw:2,0 -q 2>/dev/null
+sox $TMPFILE -r 48000 -c 2 -t wav - 2>/dev/null | aplay -D "$PLAY_DEV" -q 2>/dev/null
 
 # Restore face state
 if [ "$FACE_SYNC" = true ]; then

--- a/runtime/cli/stt
+++ b/runtime/cli/stt
@@ -5,9 +5,12 @@
 DURATION=${1:-5}
 TMPFILE=$(mktemp --suffix=.wav)
 
+ARLOWE_LIB="${ARLOWE_LIB:-/opt/arlowe/runtime/lib}"
+CAPTURE_DEV="${ARLOWE_ALSA_DEVICE:-$(PYTHONPATH="$ARLOWE_LIB" python3 -m arlowe_audio --resolve-capture 2>/dev/null)}"
+CAPTURE_DEV="${CAPTURE_DEV:-plughw:2,0}"
+
 echo "Recording for ${DURATION}s..."
-# TODO(phase-5): plughw:2,0 hardcoded; replace with auto-detected device.
-arecord -D plughw:2,0 -f S16_LE -r 16000 -c 1 -d "$DURATION" "$TMPFILE" 2>/dev/null
+arecord -D "$CAPTURE_DEV" -f S16_LE -r 16000 -c 1 -d "$DURATION" "$TMPFILE" 2>/dev/null
 
 echo "Transcribing..."
 RESULT=$(curl -s -X POST http://localhost:8082/transcribe --data-binary @"$TMPFILE")


### PR DESCRIPTION
## Summary

- `runtime/cli/record` and `runtime/cli/stt` resolve their ALSA capture device via `python3 -m arlowe_audio --resolve-capture` at invocation, replacing hardcoded `plughw:2,0`
- `runtime/cli/speak` resolves its playback device via `--resolve-playback`, replacing hardcoded `plughw:2,0`
- Three-tier priority for each: env override → arlowe_audio resolver → `plughw:2,0` literal fallback (degrades gracefully, never fails hard)
- Capture env var: `ARLOWE_ALSA_DEVICE`; playback env var: `ARLOWE_PLAY_DEVICE` (distinct, consistent with 05-02)
- `ARLOWE_LIB` controls the PYTHONPATH shim (defaults to `/opt/arlowe/runtime/lib`)
- Existing format flags preserved: `record` keeps `-c 2` (stereo), `stt` keeps `-c 1` (mono)

## Verification evidence

**Syntax check:** `bash -n runtime/cli/record runtime/cli/stt runtime/cli/speak` → exits 0

**Sanitize gate:** `bash scripts/sanitize/check.sh` → `sanitize grep: clean (194 files scanned)` / `sanitize units: clean (9 unit files checked)`

**`plughw:2,0` only as fallback:**
```
runtime/cli/record:10:CAPTURE_DEV="${CAPTURE_DEV:-plughw:2,0}"
runtime/cli/speak:29:PLAY_DEV="${PLAY_DEV:-plughw:2,0}"
runtime/cli/stt:10:CAPTURE_DEV="${CAPTURE_DEV:-plughw:2,0}"
```

**Resolver calls confirmed:**
```
runtime/cli/record:9: python3 -m arlowe_audio --resolve-capture
runtime/cli/stt:9: python3 -m arlowe_audio --resolve-capture
runtime/cli/speak:28: python3 -m arlowe_audio --resolve-playback
```

**Resolver against fixture (`usb_plus_wm8960`):** `capture=plughw:1,0`, `playback=plughw:1,0` (USB card correctly selected)

**Env override path:** `ARLOWE_ALSA_DEVICE=plughw:3,0` → `CAPTURE_DEV=plughw:3,0` (override wins)

**Fallback path (no resolver):** invalid PYTHONPATH → `CAPTURE_DEV=plughw:2,0` (fallback fires)

**43/43 Python tests pass** (arlowe_audio + arlowe_config test suites)

## Test plan

- [ ] Confirm syntax check passes on all three files
- [ ] Confirm sanitize gate stays clean
- [ ] Confirm `plughw:2,0` only appears as `:-` fallback default in each file
- [ ] Confirm `--resolve-capture` present in record and stt, `--resolve-playback` present in speak
- [ ] Confirm `arecord -D "$CAPTURE_DEV"` and `aplay -D "$PLAY_DEV"` in each respective script
- [ ] Confirm `-c 2` (record) and `-c 1` (stt) format flags unchanged

Closes #90