### PR TITLE
feat(audio): wire arlowe_audio resolver into voice_client, tts_sync, auto_collect

### DIFF
--- a/.planning/phases/05-audio-device-auto-detection/05-02-SUMMARY.md
+++ b/.planning/phases/05-audio-device-auto-detection/05-02-SUMMARY.md
@@ -1,0 +1,64 @@
+# 05-02 Summary: Python audio wiring
+
+**Completed:** 2026-06-13
+**PR:** feat/05-02-python-audio-wiring (Closes #89)
+
+---
+
+## Files changed
+
+- `runtime/voice/voice_client.py`
+- `runtime/tts/tts_sync.py`
+- `runtime/wake-word/auto_collect.py`
+
+---
+
+## Device resolution strategy
+
+### Env-var precedence (all three files)
+
+```
+ARLOWE_ALSA_DEVICE / ARLOWE_PLAY_DEVICE  (manual escape hatch, highest)
+  > arlowe_audio.resolve_capture / resolve_playback  (auto-detect or override token)
+  > "plughw:2,0"  (last-ditch literal; service stays up degraded)
+```
+
+Capture and playback are resolved independently in every file — they may be different physical cards.
+
+### Config override tokens
+
+All three files load `arlowe_config.load()["audio"]["capture_device"]` and `["playback_device"]` as override tokens for the resolver. The config load is guarded with `except Exception` so the modules import cleanly outside the deployed layout.
+
+---
+
+## Critical fix: pyaudio device-index alignment (voice_client.py)
+
+`voice_client.py` had two independent capture surfaces:
+1. `arecord` subprocess — used `RECORD_DEVICE` (ALSA plughw string).
+2. pyaudio wake-word stream — grabbed "first PortAudio input by index", ignoring `RECORD_DEVICE`.
+
+These could target different physical cards, causing the always-on wake-word mic to diverge from the STT-capture mic.
+
+Fix: at wake-word stream init, `device_index` is now resolved via `arlowe_audio.portaudio_index_for_card(RECORD_DEVICE, pa)`. PortAudio uses a separate namespace from ALSA; the helper maps the resolved ALSA card to a PortAudio input index by name-substring match. If no match, the original "first input-capable device" loop runs as fallback with a stderr log line.
+
+The resolved `device_index` is assigned once at its definition (~line 358) and reused by both `pa.open` call sites: the initial stream (~line 374) and the post-conversation re-open (~line 558). No second assignment or literal between the two opens.
+
+---
+
+## tts_sync.py
+
+Constructor default changed from `play_device: str = "plughw:2,0"` to `play_device: str | None = None`. When `None`, the `__init__` body resolves via `arlowe_audio.resolve_playback` with a config-sourced override token, falling back to the literal. Imports are lazy (inside `__init__`) to avoid import-time config dependency in environments without the overlay. The `aplay -D {self.play_device}` call site is unchanged.
+
+---
+
+## auto_collect.py
+
+Added `_PLAY_DEVICE` alongside the existing `_ALSA_DEVICE`. The `beep()` function previously used `_ALSA_DEVICE` for the `aplay` call, conflating capture and playback. It now uses `_PLAY_DEVICE`. Both are resolved via `arlowe_audio` with config override tokens and env-var escape hatches.
+
+The `sys.path.insert` for `../lib` ensures `arlowe_audio` is importable when the script is run directly; the entire import block is wrapped in `except Exception` so the script still imports if run outside the deployed layout.
+
+---
+
+## Residual concern
+
+If a device is hotplugged mid-recording (P5 in the research doc), the running session continues with the stale `RECORD_DEVICE` / `device_index` since resolution happens at module load and stream init. This is acceptable for now — the boot-check (05-06) is the formal failure surface, and hotplug-restart is tracked separately. The service will pick up the new device on next restart.

--- a/runtime/tts/tts_sync.py
+++ b/runtime/tts/tts_sync.py
@@ -88,7 +88,7 @@ class TTSWithSync:
     def __init__(self,
                  piper_path: Path,
                  piper_model: Path,
-                 play_device: str = "plughw:2,0",
+                 play_device: str | None = None,
                  face_api: str = "http://localhost:8080",
                  sync_rate: int = 30,
                  backend: TTSBackend = TTSBackend.PIPER):
@@ -98,13 +98,22 @@ class TTSWithSync:
         Args:
             piper_path: Path to Piper TTS executable
             piper_model: Path to Piper voice model
-            play_device: ALSA playback device
+            play_device: ALSA playback device; resolved via arlowe_audio if None
             face_api: URL of face control API
             sync_rate: Face update rate in Hz
             backend: TTS backend to use (PIPER or ELEVENLABS)
         """
         self.piper_path = piper_path
         self.piper_model = piper_model
+        if play_device is None:
+            try:
+                import arlowe_audio  # noqa: PLC0415 — lazy; avoids import-time config dep
+                import arlowe_config
+                _cfg = arlowe_config.load()
+                _play_override = _cfg.get("audio", {}).get("playback_device", "auto")
+                play_device = arlowe_audio.resolve_playback(_play_override) or "plughw:2,0"
+            except Exception:
+                play_device = "plughw:2,0"
         self.play_device = play_device
         self.face_api = face_api
         self.sync_rate = sync_rate

--- a/runtime/voice/voice_client.py
+++ b/runtime/voice/voice_client.py
@@ -45,9 +45,26 @@ VERIFIER_MODEL = Path(os.environ.get(
     "ARLOWE_VERIFIER_MODEL",
     "/var/lib/arlowe/wake-word/verifier.pkl",
 ))
-# TODO(phase-5): Replace plughw:2,0 with config-driven audio device selection.
-RECORD_DEVICE = os.environ.get("ARLOWE_ALSA_DEVICE", "plughw:2,0")
-PLAY_DEVICE = os.environ.get("ARLOWE_ALSA_DEVICE", "plughw:2,0")
+
+# Audio device resolution: env override (manual escape hatch) > arlowe_audio resolver > literal fallback.
+# Capture and playback are resolved independently — they may be different physical cards.
+import arlowe_audio as _arlowe_audio  # noqa: E402 — module-level; placed here for clarity
+
+try:
+    from arlowe_config import load as _load_config
+    _cfg = _load_config()
+    _cap_override = _cfg.get("audio", {}).get("capture_device", "auto")
+    _play_override = _cfg.get("audio", {}).get("playback_device", "auto")
+except Exception:
+    _cap_override = "auto"
+    _play_override = "auto"
+
+_resolved_capture = _arlowe_audio.resolve_capture(_cap_override)
+if _resolved_capture is None:
+    print("[arlowe-audio] no capture device found; service running degraded", file=sys.stderr, flush=True)
+
+RECORD_DEVICE = os.environ.get("ARLOWE_ALSA_DEVICE") or _resolved_capture or "plughw:2,0"
+PLAY_DEVICE = os.environ.get("ARLOWE_PLAY_DEVICE") or _arlowe_audio.resolve_playback(_play_override) or "plughw:2,0"
 
 # Wake word detection thresholds
 BASE_THRESHOLD = 0.20
@@ -335,13 +352,24 @@ def main_loop():
     
     print("\n[3/4] Opening audio stream...", flush=True)
     pa = pyaudio.PyAudio()
-    device_index = 0
-    for i in range(pa.get_device_count()):
-        info = pa.get_device_info_by_index(i)
-        if info['maxInputChannels'] > 0:
-            device_index = i
-            print(f"  Device: {info['name']}", flush=True)
-            break
+    # PortAudio uses a separate device namespace from ALSA; map the resolved ALSA
+    # card to a PortAudio index by name-substring match so the wake-word mic and
+    # the arecord/STT capture path target the same physical card.
+    device_index = _arlowe_audio.portaudio_index_for_card(RECORD_DEVICE, pa)
+    if device_index is None:
+        print(
+            f"[arlowe-audio] pyaudio could not match ALSA card {RECORD_DEVICE}; "
+            "using PortAudio default",
+            file=sys.stderr, flush=True,
+        )
+        # Fallback: first PortAudio input-capable device (original behaviour).
+        for i in range(pa.get_device_count()):
+            info = pa.get_device_info_by_index(i)
+            if info['maxInputChannels'] > 0:
+                device_index = i
+                break
+    if device_index is not None:
+        print(f"  Device: {pa.get_device_info_by_index(device_index)['name']}", flush=True)
     
     stream = pa.open(
         format=pyaudio.paInt16,

--- a/runtime/wake-word/auto_collect.py
+++ b/runtime/wake-word/auto_collect.py
@@ -18,7 +18,28 @@ from pathlib import Path
 
 _STATE_DIR = os.environ.get("ARLOWE_WAKE_WORD_STATE", "/var/lib/arlowe/wake-word")
 _SPEAK_BIN = os.environ.get("ARLOWE_SPEAK_BIN", "/usr/local/bin/speak")
-_ALSA_DEVICE = os.environ.get("ARLOWE_ALSA_DEVICE", "plughw:2,0")
+
+# Resolve capture and playback devices independently via arlowe_audio.
+# env override (manual escape hatch) > arlowe_audio resolver > literal fallback.
+try:
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))
+    import arlowe_audio as _arlowe_audio
+    try:
+        from arlowe_config import load as _load_config
+        _ac = _load_config().get("audio", {})
+        _cap_override = _ac.get("capture_device", "auto")
+        _play_override = _ac.get("playback_device", "auto")
+    except Exception:
+        _cap_override = "auto"
+        _play_override = "auto"
+    _resolved_cap = _arlowe_audio.resolve_capture(_cap_override)
+    _resolved_play = _arlowe_audio.resolve_playback(_play_override)
+except Exception:
+    _resolved_cap = None
+    _resolved_play = None
+
+_ALSA_DEVICE = os.environ.get("ARLOWE_ALSA_DEVICE") or _resolved_cap or "plughw:2,0"
+_PLAY_DEVICE = os.environ.get("ARLOWE_PLAY_DEVICE") or _resolved_play or "plughw:2,0"
 
 POSITIVE_DIR = Path(_STATE_DIR) / "positive"
 NEGATIVE_DIR = Path(_STATE_DIR) / "negative"
@@ -41,7 +62,7 @@ def record_sample(output_path, duration=2):
 def beep():
     """Short beep sound via speaker."""
     subprocess.run(
-        f"sox -n -r 48000 -c 2 /tmp/beep.wav synth 0.15 sine 800 vol 0.5 && aplay -D {_ALSA_DEVICE} -q /tmp/beep.wav",
+        f"sox -n -r 48000 -c 2 /tmp/beep.wav synth 0.15 sine 800 vol 0.5 && aplay -D {_PLAY_DEVICE} -q /tmp/beep.wav",
         shell=True, capture_output=True
     )
 


### PR DESCRIPTION
## Summary

- `voice_client.py`: Both capture surfaces (arecord + pyaudio wake-word stream) now resolve to the same physical card. `RECORD_DEVICE` is resolved via `arlowe_audio.resolve_capture`; the pyaudio `device_index` is mapped from that ALSA card via `arlowe_audio.portaudio_index_for_card`. The resolved `device_index` is assigned once and reused by both `pa.open` call sites (initial stream and post-conversation re-open). `PLAY_DEVICE` is resolved independently via `resolve_playback`.
- `tts_sync.py`: Constructor default changed to `play_device: str | None = None`; when `None`, resolves via `arlowe_audio.resolve_playback` with config override token. Lazy imports keep the module clean outside the deployed layout.
- `auto_collect.py`: `_ALSA_DEVICE` resolved via `resolve_capture`; new `_PLAY_DEVICE` resolved via `resolve_playback`. The `beep()` function now uses `_PLAY_DEVICE` instead of the capture device.

All three files use precedence: `ARLOWE_ALSA_DEVICE`/`ARLOWE_PLAY_DEVICE` env vars (escape hatch) > resolver > `"plughw:2,0"` literal (service stays up degraded).

## Test plan

- [x] `PYTHONPATH=runtime/lib python3 -m pytest runtime/lib/tests/test_arlowe_audio.py -v` — 36/36 passed
- [x] `PYTHONPATH=runtime/lib python3 -m pytest runtime/lib/tests/test_arlowe_config.py -v` — 7/7 passed
- [x] `python3 -m py_compile runtime/voice/voice_client.py runtime/tts/tts_sync.py runtime/wake-word/auto_collect.py` — all exit 0
- [x] `grep -n "plughw:2,0" runtime/voice/voice_client.py runtime/tts/tts_sync.py runtime/wake-word/auto_collect.py` — only fallback literals, no primary paths
- [x] `grep -n "input_device_index" runtime/voice/voice_client.py` — two hits (lines 380, 564), both referencing the shared `device_index`; no re-assignment between opens
- [x] `bash scripts/sanitize/check.sh` — grep gate clean (194 files), units gate clean (9 unit files)
- [x] Pre-existing face test failures (`sentiment_classifier` missing) confirmed unchanged on both main and this branch

Closes #89