### PR TITLE
feat(provision): udev hotplug rule — debounced arlowe-voice restart on USB audio events

### DIFF
--- a/.planning/phases/05-audio-device-auto-detection/05-05-SUMMARY.md
+++ b/.planning/phases/05-audio-device-auto-detection/05-05-SUMMARY.md
@@ -1,0 +1,96 @@
+# 05-05 Summary: udev hotplug rule — debounced arlowe-voice restart
+
+**Completed:** 2026-06-13
+**PR:** feat/05-05-udev-audio-hotplug (Closes #92)
+**Security note:** package:security — reviewed by Opus per label contract.
+
+---
+
+## What was built
+
+`provision/udev/92-arlowe-audio.rules` — a udev rule that restarts
+`arlowe-voice.service` on USB audio device add/remove, so the arlowe_audio
+resolver (05-01) re-picks the device on the running system.
+
+`tests/docker/phase-5-hotplug/test-udev-rule.sh` — a CI-runnable shape test
+that verifies rule scope, debounce anchor, `--no-block`, target unit, and
+install shape without real hardware.
+
+---
+
+## Rule scope and anchor
+
+```
+SUBSYSTEM=="sound", KERNEL=="controlC[0-9]*", ACTION=="add",    RUN+="/bin/systemctl --no-block restart arlowe-voice.service"
+SUBSYSTEM=="sound", KERNEL=="controlC[0-9]*", ACTION=="remove", RUN+="/bin/systemctl --no-block restart arlowe-voice.service"
+```
+
+- **SUBSYSTEM=="sound"** — strictly scoped, not a broad device match.
+- **KERNEL=="controlC[0-9]*"** — the debounce anchor. A single USB audio plug
+  fires multiple kernel sound sub-events (controlC*, pcmC*D*c, pcmC*D*p, timer).
+  Anchoring on the control node fires exactly once per card add/remove, not once
+  per sub-node. Avoids a restart storm from a single physical plug.
+- **RUN+="/bin/systemctl --no-block restart arlowe-voice.service"** — `--no-block`
+  returns immediately; mandatory to avoid the udev<->systemd deadlock where udev
+  waits for the unit transaction and systemd needs udev to settle devices.
+
+---
+
+## Install glob
+
+`scripts/provision/install-arlowe-udev-polkit.sh` line 42 installs
+`provision/udev/*.rules` to `/etc/udev/rules.d/` with mode 0644. The `92-`
+prefix follows existing `90-`/`91-` numbering; no script edit required.
+
+---
+
+## v1 mechanism and known trade-off
+
+The rule is a thin trigger — device-selection logic is entirely in arlowe_audio
+(05-01). The mechanism is a full service restart, reusing the Phase 4 restart
+pattern. An in-process reconfigure (SIGHUP or D-Bus signal) is a future
+optimization and is not in scope here.
+
+**Known trade-off (Pitfall P5):** a restart mid-recording aborts an in-flight
+interaction. Acceptable for v1 because a hotplug event is inherently disruptive
+(the device itself changed); the consistent restart behavior is easier to reason
+about than a partial-reconfigure path.
+
+---
+
+## systemctl path assumption
+
+The rule uses `/bin/systemctl`. Pi OS provides `/bin/systemctl` as a symlink to
+`/usr/bin/systemctl`. If the target image ever loses that symlink, plan 05-07's
+real-hardware verification step should confirm the path.
+
+---
+
+## Deferred: hardware confirmation (plan 05-07)
+
+The exact sound events fired by this Pi's USB adapter and whether `controlC*`
+is the correct anchor must be confirmed with `udevadm monitor --subsystem-match=sound`
+on real hardware (research Open Q2). The controlC anchor is the standard Linux
+ALSA event model and is correct by construction, but multi-sub-event behavior
+can vary across USB audio class drivers and kernel versions.
+
+---
+
+## Shape test evidence (CI, no hardware)
+
+```
+=== Phase 5 hotplug rule shape test ===
+  SKIP: udevadm not available — skipping syntax verification (acceptable in CI without udev)
+  PASS: rule is scoped to SUBSYSTEM=="sound"
+  PASS: rule uses --no-block
+  PASS: rule anchored on controlC* (debounce: one restart per card, not per pcm sub-node)
+  PASS: rule does not match pcmC* sub-nodes (debounce intact)
+  PASS: rule targets arlowe-voice.service
+  PASS: no non-arlowe-* unit referenced in RUN+= lines
+  PASS: install glob places 92-arlowe-audio.rules at expected path
+  PASS: installed file has mode 0644
+  PASS: filename 92-arlowe-audio.rules matches installer glob 9?-arlowe-*.rules
+
+=== Results: 9 passed, 0 failed ===
+=== PASS ===
+```

--- a/provision/udev/92-arlowe-audio.rules
+++ b/provision/udev/92-arlowe-audio.rules
@@ -1,0 +1,46 @@
+# Arlowe Phase 5: USB audio hotplug — debounced arlowe-voice restart.
+#
+# Purpose:
+#   When a USB audio device is plugged in or removed, restart arlowe-voice so
+#   the arlowe_audio resolver (05-01) re-enumerates and selects the best device
+#   on the running system, not only at next boot.
+#
+# Why controlC* anchor (debounce):
+#   A single USB audio plug event fires multiple kernel sound sub-events:
+#     - KERNEL=="controlC*"    — the ALSA control node (fires once per card)
+#     - KERNEL=="pcmC*D*c"     — PCM capture nodes  (one per channel mode)
+#     - KERNEL=="pcmC*D*p"     — PCM playback nodes (one per channel mode)
+#   Triggering on all sub-nodes would cause several rapid restarts for each
+#   physical plug/unplug. Anchoring on controlC* limits the restart to exactly
+#   one event per card add/remove. Hardware confirmation that controlC* is the
+#   correct anchor for this Pi's USB adapter is deferred to plan 05-07
+#   (requires `udevadm monitor --subsystem-match=sound` on real hardware).
+#
+# Why --no-block:
+#   udev rules run synchronously in the udev worker. Calling systemctl without
+#   --no-block causes udev to wait for the unit transaction to complete, which
+#   can deadlock because systemd may itself need to communicate with udev to
+#   settle devices as part of the restart. --no-block fires the restart request
+#   and returns immediately, keeping udev unblocked.
+#
+# v1 mechanism: full service restart.
+#   The actual device-selection logic lives in arlowe_audio (05-01); this rule
+#   is a thin trigger only. An in-process reconfigure (SIGHUP or D-Bus signal)
+#   is a future optimization — avoided here to keep the change small and reuse
+#   the Phase 4 restart pattern. Known trade-off: a restart mid-recording aborts
+#   an in-flight interaction (research Pitfall P5). Acceptable for v1; noted.
+#
+# systemctl path:
+#   Pi OS provides /bin/systemctl as a symlink to /usr/bin/systemctl. This rule
+#   uses /bin/systemctl. If the target image symlink is absent, the install/verify
+#   step in plan 05-07 should confirm the correct path.
+#
+# Install glob:
+#   scripts/provision/install-arlowe-udev-polkit.sh installs provision/udev/*.rules
+#   (line 42). The 92- prefix follows 90-/91- numbering and is picked up
+#   automatically with no script edit.
+#
+# Required by: arlowe-voice.service (hotplug re-detection, CONTEXT §decisions).
+
+SUBSYSTEM=="sound", KERNEL=="controlC[0-9]*", ACTION=="add",    RUN+="/bin/systemctl --no-block restart arlowe-voice.service"
+SUBSYSTEM=="sound", KERNEL=="controlC[0-9]*", ACTION=="remove", RUN+="/bin/systemctl --no-block restart arlowe-voice.service"

--- a/tests/docker/phase-5-hotplug/test-udev-rule.sh
+++ b/tests/docker/phase-5-hotplug/test-udev-rule.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+# Phase 5 shape test: 92-arlowe-audio.rules correctness (no hardware required).
+#
+# Verifies the udev rule file's form, scope, debounce anchor, and install shape
+# using grep assertions and, if udevadm is available, syntax validation. No real
+# hotplug event is simulated — hardware confirmation is deferred to plan 05-07.
+#
+# Assertions:
+#   1. udevadm verify passes on the rule (skip with message if udevadm absent)
+#   2. Rule is scoped to SUBSYSTEM=="sound" (not broad)
+#   3. Rule uses --no-block (no udev<->systemd deadlock)
+#   4. Rule is anchored on controlC* (debounce; does not fire on every pcm sub-node)
+#   5. Rule targets only arlowe-voice.service (no non-arlowe unit)
+#   6. Rule file is installed at the expected path with mode 0644 (install glob)
+#
+# Usage:
+#   bash tests/docker/phase-5-hotplug/test-udev-rule.sh
+#   (run from repo root or any directory; paths are resolved relative to this script)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+RULES_SRC="${REPO_ROOT}/provision/udev/92-arlowe-audio.rules"
+
+pass_count=0
+fail_count=0
+
+pass() { echo "  PASS: $*"; pass_count=$((pass_count + 1)); }
+fail() { echo "  FAIL: $*" >&2; fail_count=$((fail_count + 1)); }
+skip() { echo "  SKIP: $*"; }
+
+echo "=== Phase 5 hotplug rule shape test ==="
+echo "    rule: ${RULES_SRC}"
+
+# ---- 0. Rule file exists ----
+if [[ ! -f "${RULES_SRC}" ]]; then
+    echo "FATAL: rule file not found at ${RULES_SRC}" >&2
+    exit 1
+fi
+
+# ---- 1. udevadm verify (skip if absent) ----
+if command -v udevadm >/dev/null 2>&1; then
+    if udevadm verify "${RULES_SRC}" 2>&1; then
+        pass "udevadm verify ${RULES_SRC}"
+    else
+        fail "udevadm verify failed on ${RULES_SRC}"
+    fi
+else
+    skip "udevadm not available — skipping syntax verification (acceptable in CI without udev)"
+fi
+
+# ---- 2. Scoped to SUBSYSTEM=="sound" ----
+if grep -qE 'SUBSYSTEM=="sound"' "${RULES_SRC}"; then
+    pass "rule is scoped to SUBSYSTEM==\"sound\""
+else
+    fail "rule does not contain SUBSYSTEM==\"sound\""
+fi
+
+# ---- 3. Uses --no-block ----
+if grep -qE -- '--no-block' "${RULES_SRC}"; then
+    pass "rule uses --no-block"
+else
+    fail "rule does not use --no-block (required to avoid udev<->systemd deadlock)"
+fi
+
+# ---- 4. Debounced via controlC anchor ----
+if grep -qE 'KERNEL=="controlC' "${RULES_SRC}"; then
+    pass "rule anchored on controlC* (debounce: one restart per card, not per pcm sub-node)"
+else
+    fail "rule does not anchor on controlC* — restart storm risk on single USB plug"
+fi
+
+# 4b. Must NOT fire on raw pcm sub-node events (no broad sound/* match without anchor)
+if grep -qP 'KERNEL=="pcmC' "${RULES_SRC}" 2>/dev/null; then
+    fail "rule matches pcmC* nodes — this defeats the controlC debounce anchor"
+else
+    pass "rule does not match pcmC* sub-nodes (debounce intact)"
+fi
+
+# ---- 5. Targets only arlowe-voice.service; no foreign unit names ----
+if grep -qE 'arlowe-voice\.service' "${RULES_SRC}"; then
+    pass "rule targets arlowe-voice.service"
+else
+    fail "rule does not reference arlowe-voice.service"
+fi
+
+# Check that the only unit name in RUN+= lines is arlowe-voice.service.
+# Extract all words after 'restart' in RUN lines and verify they match.
+non_arlowe=$(grep -E 'RUN\+=' "${RULES_SRC}" \
+    | grep -oE 'restart [a-zA-Z0-9_@.-]+' \
+    | awk '{print $2}' \
+    | grep -v '^arlowe-' || true)
+if [[ -z "${non_arlowe}" ]]; then
+    pass "no non-arlowe-* unit referenced in RUN+= lines"
+else
+    fail "non-arlowe-* unit(s) found in RUN+= lines: ${non_arlowe}"
+fi
+
+# ---- 6. Install shape: glob installs rule at expected path with mode 0644 ----
+TMPDIR_RULES="$(mktemp -d /tmp/arlowe-udev-test-XXXXXX)"
+trap 'rm -rf "${TMPDIR_RULES}"' EXIT
+
+# Simulate the install glob from install-arlowe-udev-polkit.sh line 42:
+#   install -m 0644 -o root -g root "${UDEV_SRC}"/*.rules /etc/udev/rules.d/
+# We install into a temp dir (can't write /etc in CI without root).
+install -m 0644 "${RULES_SRC}" "${TMPDIR_RULES}/"
+
+INSTALLED="${TMPDIR_RULES}/92-arlowe-audio.rules"
+
+if [[ -f "${INSTALLED}" ]]; then
+    pass "install glob places 92-arlowe-audio.rules at expected path"
+else
+    fail "92-arlowe-audio.rules not found after install simulation"
+fi
+
+# stat format differs: GNU coreutils (-c '%a') vs BSD/macOS (-f '%OLp').
+if stat --version >/dev/null 2>&1; then
+    actual_mode="$(stat -c '%a' "${INSTALLED}" 2>/dev/null)"
+else
+    actual_mode="$(stat -f '%OLp' "${INSTALLED}" 2>/dev/null)"
+fi
+if [[ "${actual_mode}" == "644" ]]; then
+    pass "installed file has mode 0644"
+else
+    fail "installed file mode is ${actual_mode}, expected 644"
+fi
+
+# Confirm the file name matches the install-arlowe-udev-polkit.sh glob pattern
+# (9?-arlowe-*.rules) that the installed_count check at line 66 uses.
+if echo "92-arlowe-audio.rules" | grep -qE '^9[0-9]-arlowe-.*\.rules$'; then
+    pass "filename 92-arlowe-audio.rules matches installer glob 9?-arlowe-*.rules"
+else
+    fail "filename does not match installer glob 9?-arlowe-*.rules"
+fi
+
+# ---- Summary ----
+echo ""
+echo "=== Results: ${pass_count} passed, ${fail_count} failed ==="
+if [[ "${fail_count}" -gt 0 ]]; then
+    exit 1
+fi
+echo "=== PASS ==="


### PR DESCRIPTION
## Summary

- Adds `provision/udev/92-arlowe-audio.rules`: a udev rule scoped to `SUBSYSTEM=="sound"` that restarts `arlowe-voice.service` on USB audio device add/remove, enabling the arlowe_audio resolver (05-01) to re-pick the device on the running system without a reboot.
- Debounced via `KERNEL=="controlC[0-9]*"` anchor: a single USB plug fires multiple sub-events (controlC*, pcmC*, timer); anchoring on the control node fires exactly once per card, avoiding a restart storm.
- Uses `--no-block` to avoid the udev<->systemd deadlock.
- Picked up by the existing `install-arlowe-udev-polkit.sh` glob (`provision/udev/*.rules`) with no script edit — the `92-` prefix follows existing `90-`/`91-` numbering.
- Adds `tests/docker/phase-5-hotplug/test-udev-rule.sh`: a CI-runnable shape test (grep + install-simulation assertions) that validates all security properties without real hardware (udevadm verify skipped gracefully if absent).

## Security properties verified by shape test

- `SUBSYSTEM=="sound"` only — not a broad device match
- `--no-block` present — no deadlock risk
- `controlC*` anchor only — no pcmC* match, debounce intact
- Only `arlowe-voice.service` in `RUN+=` — no foreign unit
- Mode 0644 after install glob simulation

## Shape test evidence

```
=== Phase 5 hotplug rule shape test ===
  SKIP: udevadm not available — skipping syntax verification (acceptable in CI without udev)
  PASS: rule is scoped to SUBSYSTEM=="sound"
  PASS: rule uses --no-block
  PASS: rule anchored on controlC* (debounce: one restart per card, not per pcm sub-node)
  PASS: rule does not match pcmC* sub-nodes (debounce intact)
  PASS: rule targets arlowe-voice.service
  PASS: no non-arlowe-* unit referenced in RUN+= lines
  PASS: install glob places 92-arlowe-audio.rules at expected path
  PASS: installed file has mode 0644
  PASS: filename 92-arlowe-audio.rules matches installer glob 9?-arlowe-*.rules

=== Results: 9 passed, 0 failed ===
=== PASS ===
```

## Hardware-deferred

Confirmation that `controlC*` is the correct anchor for this Pi's USB adapter is deferred to plan 05-07 (requires `udevadm monitor --subsystem-match=sound` on real hardware, research Open Q2).

## Test plan

- [x] `bash tests/docker/phase-5-hotplug/test-udev-rule.sh` exits 0 (9/9 pass)
- [x] `bash scripts/sanitize/check.sh` clean (194 files scanned)
- [ ] CI sanitize workflow green on PR
- [ ] Hardware hotplug confirmation deferred to 05-07

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)