### PR TITLE
feat(audio): boot-check capture+playback sentinel (arlowe_audio --selfcheck)

### DIFF
--- a/.planning/phases/05-audio-device-auto-detection/05-06-PLAN.md
+++ b/.planning/phases/05-audio-device-auto-detection/05-06-PLAN.md
@@ -102,7 +102,7 @@ Replace the hardcoded mic probe (boot-check:78-84, the `TODO(phase-5): plughw:2,
 - Add to the HARDWARE section:
   ```bash
   ARLOWE_LIB="${ARLOWE_LIB:-/opt/arlowe/runtime/lib}"
-  if PYTHONPATH="$ARLOWE_LIB" python3 -m arlowe_audio --selfcheck >/tmp/arlowe-audio-selfcheck.json 2>&1; then
+  if PYTHONPATH="$ARLOWE_LIB" python3 -m arlowe_audio --selfcheck >/tmp/arlowe-audio-selfcheck.json; then  # NOTE: 2>&1 omitted — stderr must reach journald for the [arlowe-audio] journal line; adding it corrupts the JSON file.
       echo "OK  Audio capture + playback sentinel"
       ((PASS++))
   else

--- a/.planning/phases/05-audio-device-auto-detection/05-06-SUMMARY.md
+++ b/.planning/phases/05-audio-device-auto-detection/05-06-SUMMARY.md
@@ -1,0 +1,75 @@
+---
+phase: 05-audio-device-auto-detection
+plan: 06
+type: summary
+status: complete
+pr: pending
+---
+
+# 05-06 Summary: Boot-check capture+playback sentinel
+
+## What was built
+
+- `selfcheck()` function in `runtime/lib/arlowe_audio.py` — capture RMS + playback tone sentinels with retry, JSON persistence, and `[arlowe-audio]` journal line.
+- `--selfcheck` CLI subcommand added to `_cli_main()` — exits 0 on both ok, exits 1 if either fails.
+- `runtime/cli/boot-check` audio section replaced — hardcoded `plughw:2,0` probe gone; calls `python3 -m arlowe_audio --selfcheck` instead.
+- `runtime/lib/tests/test_arlowe_audio_selfcheck.py` — 38 tests, all green; no real audio hardware invoked.
+
+## JSON status contract (Phase 11 consumer)
+
+File: `/var/lib/arlowe/state/audio-selfcheck.json`
+
+```json
+{
+  "check": "audio",
+  "capture": {
+    "device": "plughw:1,0",
+    "ok": true
+  },
+  "playback": {
+    "device": "plughw:1,0",
+    "ok": false,
+    "error": "<error message>"
+  },
+  "ts": "2026-06-13T12:00:00Z"
+}
+```
+
+Keys:
+- `check`: always `"audio"` (type discriminant for Phase 11 parser)
+- `capture.device`: resolved plughw string, or `null` if no device found
+- `capture.ok`: true = RMS above floor; false = silent buffer or exception
+- `capture.error`: error description when ok=false; absent when ok=true
+- `playback.device`: resolved plughw string, or `null` if no device found
+- `playback.ok`: true = playback command exited 0; false = exception
+- `playback.error`: error description when ok=false; absent when ok=true
+- `ts`: ISO 8601 UTC timestamp of the check
+
+Write semantics: atomic temp+rename in the same directory (mirrors Phase 4 convention). If the directory is unwritable, a WARN is emitted to stderr and the check continues without crashing.
+
+## Journal line format
+
+Emitted to stderr with `[arlowe-audio]` prefix (greppable pattern for journald):
+
+```
+[arlowe-audio] selfcheck capture=ok device=plughw:1,0 playback=FAIL device=plughw:0,0
+```
+
+Pattern for log grep: `grep '\[arlowe-audio\]'`
+
+## Retry / floor choices
+
+- **Retries**: 3 attempts per sentinel with 1 s sleep between (devices settle after USB enumeration).
+- **RMS floor**: 10.0 — forgiving; plughw resampling can produce quiet but non-zero buffers; all-zero silence fails cleanly. Hardware-deferred calibration in 05-07.
+- **Capture sentinel**: arecord S16_LE 16 kHz mono 1 s → RMS check.
+- **Playback sentinel**: sox synth 0.3 sine 440 piped to aplay; success = exit 0 (no acoustic loopback — locked CONTEXT decision).
+
+## WARN vs FAIL in boot-check
+
+The old mic probe used `WARN`. The selfcheck follows the same idiom: audio failure emits `WARN` and does NOT increment `FAIL`. Rationale: functional-degraded over hard block (locked CONTEXT decision); a transient audio miss should not read as system-down.
+
+## Deferred to 05-07
+
+- Real RMS assertion on hardware: confirming non-silent buffers actually record audio (not just driver headers).
+- Real tone-plays assertion: confirming aplay exits 0 on hardware.
+- Boot-time run-user and `/var/lib/arlowe/state/` writability under the actual systemd unit context (research P9, Open Q4).

--- a/runtime/cli/boot-check
+++ b/runtime/cli/boot-check
@@ -75,12 +75,16 @@ else
     ((FAIL++))
 fi
 
-# TODO(phase-5): plughw:2,0 hardcoded; replace with auto-detected device.
-if arecord -D plughw:2,0 -d 1 /dev/null 2>/dev/null; then
-    echo "OK  Microphone (WM8960)"
+# Audio capture+playback sentinel via auto-detected device (Phase 5, plan 05-06).
+# Writes structured JSON to /var/lib/arlowe/state/audio-selfcheck.json for
+# Phase 11 dashboard health view; /tmp echo is for the human-readable report.
+# WARN (not FAIL) on audio degraded — functional-degraded over hard block.
+ARLOWE_LIB="${ARLOWE_LIB:-/opt/arlowe/runtime/lib}"
+if PYTHONPATH="$ARLOWE_LIB" python3 -m arlowe_audio --selfcheck >/tmp/arlowe-audio-selfcheck.json 2>&1; then
+    echo "OK  Audio capture + playback sentinel"
     ((PASS++))
 else
-    echo "WARN Microphone may be in use"
+    echo "WARN Audio sentinel degraded (see journal: [arlowe-audio])"
 fi
 
 echo ""

--- a/runtime/cli/boot-check
+++ b/runtime/cli/boot-check
@@ -80,7 +80,7 @@ fi
 # Phase 11 dashboard health view; /tmp echo is for the human-readable report.
 # WARN (not FAIL) on audio degraded — functional-degraded over hard block.
 ARLOWE_LIB="${ARLOWE_LIB:-/opt/arlowe/runtime/lib}"
-if PYTHONPATH="$ARLOWE_LIB" python3 -m arlowe_audio --selfcheck >/tmp/arlowe-audio-selfcheck.json 2>&1; then
+if PYTHONPATH="$ARLOWE_LIB" python3 -m arlowe_audio --selfcheck >/tmp/arlowe-audio-selfcheck.json; then
     echo "OK  Audio capture + playback sentinel"
     ((PASS++))
 else

--- a/runtime/lib/arlowe_audio.py
+++ b/runtime/lib/arlowe_audio.py
@@ -23,12 +23,27 @@ import argparse
 import glob
 import json
 import re
+import subprocess
 import sys
+import tempfile
+import time
+from datetime import datetime, timezone
 from pathlib import Path
 
 WM8960_MATCH = "wm8960"
 HDMI_MATCH = "vc4-hdmi"
 USB_USBID_FILENAME = "usbid"
+
+# Forgiving RMS floor: plughw resampling can produce quiet buffers; set low
+# enough to pass real (non-silent) recordings while rejecting all-zero buffers.
+_CAPTURE_RMS_FLOOR = 10.0
+
+# State directory where selfcheck writes its JSON status.
+_DEFAULT_STATE_DIR = "/var/lib/arlowe/state"
+
+# Retry defaults for the selfcheck sentinels.
+_DEFAULT_RETRIES = 3
+_RETRY_SLEEP_S = 1.0
 
 # Regex for /proc/asound/cards lines:
 #   " 0 [wm8960soundcard]: wm8960-soundcard - wm8960-soundcard"
@@ -254,6 +269,256 @@ def portaudio_index_for_card(
 
 
 # ---------------------------------------------------------------------------
+# Boot-check sentinels — capture RMS + playback tone, retry-then-report
+# ---------------------------------------------------------------------------
+
+def _default_capture_runner(device: str) -> bytes:
+    """Record ~1 s of audio from device, return raw S16_LE PCM bytes.
+
+    Runs arecord and returns the WAV/raw bytes; raises subprocess.CalledProcessError
+    on non-zero exit or OSError if the binary is missing.
+    """
+    result = subprocess.run(
+        [
+            "arecord",
+            "-D", device,
+            "-f", "S16_LE",
+            "-r", "16000",
+            "-c", "1",
+            "-d", "1",
+            "--quiet",
+        ],
+        capture_output=True,
+        check=True,
+        timeout=5,
+    )
+    return result.stdout
+
+
+def _default_playback_runner(device: str) -> None:
+    """Emit a short 440 Hz tone to device.
+
+    Uses sox + aplay pipeline; raises subprocess.CalledProcessError on failure.
+    Falls back to aplay with a generated WAV if sox is unavailable.
+    """
+    try:
+        sox = subprocess.run(
+            ["sox", "-n", "-t", "wav", "-", "synth", "0.3", "sine", "440"],
+            capture_output=True,
+            check=True,
+            timeout=5,
+        )
+        subprocess.run(
+            ["aplay", "-D", device, "--quiet"],
+            input=sox.stdout,
+            capture_output=True,
+            check=True,
+            timeout=5,
+        )
+    except FileNotFoundError:
+        # sox not available — generate a minimal WAV header with silence and
+        # play it; success = aplay exits 0 (locked decision: no acoustic check).
+        subprocess.run(
+            ["aplay", "-D", device, "-f", "S16_LE", "-r", "16000", "-c", "1", "--quiet"],
+            input=b"\x00" * 32000,
+            capture_output=True,
+            check=True,
+            timeout=5,
+        )
+
+
+def _rms_from_pcm(raw_bytes: bytes) -> float:
+    """Compute RMS of raw S16_LE PCM bytes.
+
+    Skips any WAV header (looks for 'data' chunk) so arecord output works
+    whether it includes a header or not.  Returns 0.0 for empty input.
+    """
+    try:
+        import numpy as np  # noqa: PLC0415 — intentionally lazy; numpy is a voice dep
+    except ImportError:
+        # Fallback: pure-Python RMS without numpy (slower but correct).
+        import struct
+        if len(raw_bytes) < 2:
+            return 0.0
+        # Skip WAV header if present.
+        data = _strip_wav_header(raw_bytes)
+        n_samples = len(data) // 2
+        if n_samples == 0:
+            return 0.0
+        samples = struct.unpack(f"<{n_samples}h", data[:n_samples * 2])
+        mean_sq = sum(s * s for s in samples) / n_samples
+        return mean_sq ** 0.5
+
+    data = _strip_wav_header(raw_bytes)
+    if len(data) < 2:
+        return 0.0
+    samples = np.frombuffer(data, dtype=np.int16).astype(np.float64)
+    if len(samples) == 0:
+        return 0.0
+    return float(np.sqrt(np.mean(samples ** 2)))
+
+
+def _strip_wav_header(raw_bytes: bytes) -> bytes:
+    """Strip a WAV header if present; return the raw PCM data portion."""
+    # WAV 'data' chunk marker: search for b'data' and skip 8 bytes (chunk id + size).
+    idx = raw_bytes.find(b"data")
+    if idx != -1 and idx + 8 <= len(raw_bytes):
+        return raw_bytes[idx + 8:]
+    return raw_bytes
+
+
+def _run_capture_sentinel(
+    device: str,
+    capture_runner,
+    retries: int,
+) -> dict:
+    """Run the capture RMS sentinel, retry up to retries times.
+
+    Returns a dict with keys: device, ok (bool), error (str or None).
+    Never raises.
+    """
+    last_error = None
+    for attempt in range(retries):
+        try:
+            raw = capture_runner(device)
+            rms = _rms_from_pcm(raw)
+            if rms >= _CAPTURE_RMS_FLOOR:
+                return {"device": device, "ok": True}
+            last_error = f"RMS {rms:.1f} below floor {_CAPTURE_RMS_FLOOR}"
+        except Exception as exc:
+            last_error = str(exc)
+        if attempt < retries - 1:
+            time.sleep(_RETRY_SLEEP_S)
+    return {"device": device, "ok": False, "error": last_error}
+
+
+def _run_playback_sentinel(
+    device: str,
+    playback_runner,
+    retries: int,
+) -> dict:
+    """Run the playback tone sentinel, retry up to retries times.
+
+    Success = playback_runner exits without exception (locked decision: no
+    acoustic loopback; exit-0 is sufficient proof).  Never raises.
+    """
+    last_error = None
+    for attempt in range(retries):
+        try:
+            playback_runner(device)
+            return {"device": device, "ok": True}
+        except Exception as exc:
+            last_error = str(exc)
+        if attempt < retries - 1:
+            time.sleep(_RETRY_SLEEP_S)
+    return {"device": device, "ok": False, "error": last_error}
+
+
+def selfcheck(
+    state_dir: str | None = _DEFAULT_STATE_DIR,
+    retries: int = _DEFAULT_RETRIES,
+    capture_runner=None,
+    playback_runner=None,
+    proc_root: str = "/proc/asound",
+) -> dict:
+    """Run the audio boot-check sentinel.
+
+    Resolves capture and playback devices, runs each sentinel independently
+    with up to `retries` attempts, persists a Phase-11-consumable JSON status
+    to state_dir, emits a greppable [arlowe-audio] journal line to stderr, and
+    returns the status dict.
+
+    Args:
+        state_dir: Directory where audio-selfcheck.json is written atomically.
+                   None or unwritable => skip file write (no crash).
+        retries:   Max attempts per sentinel before reporting failure.
+        capture_runner: Callable(device: str) -> bytes.  Defaults to the real
+                        arecord helper; inject a fake for unit tests.
+        playback_runner: Callable(device: str) -> None.  Defaults to the real
+                         sox+aplay helper; inject a fake for unit tests.
+        proc_root: /proc/asound root; injectable for tests.
+
+    Returns:
+        {
+          "check": "audio",
+          "capture": {"device": str|None, "ok": bool, "error": str},
+          "playback": {"device": str|None, "ok": bool, "error": str},
+          "ts": "<iso8601>"
+        }
+    """
+    if capture_runner is None:
+        capture_runner = _default_capture_runner
+    if playback_runner is None:
+        playback_runner = _default_playback_runner
+
+    cap_device = resolve_capture(proc_root=proc_root)
+    play_device = resolve_playback(proc_root=proc_root)
+
+    if cap_device is not None:
+        cap_result = _run_capture_sentinel(cap_device, capture_runner, retries)
+    else:
+        cap_result = {"device": None, "ok": False, "error": "no capture device found"}
+
+    if play_device is not None:
+        play_result = _run_playback_sentinel(play_device, playback_runner, retries)
+    else:
+        play_result = {"device": None, "ok": False, "error": "no playback device found"}
+
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    status = {
+        "check": "audio",
+        "capture": cap_result,
+        "playback": play_result,
+        "ts": ts,
+    }
+
+    _persist_status(status, state_dir)
+    _emit_journal_line(cap_result, play_result)
+
+    return status
+
+
+def _persist_status(status: dict, state_dir: str | None) -> None:
+    """Atomically write status JSON to state_dir/audio-selfcheck.json.
+
+    Skips silently if state_dir is None or the directory is unwritable.
+    """
+    if not state_dir:
+        return
+    try:
+        state_path = Path(state_dir)
+        state_path.mkdir(parents=True, exist_ok=True)
+        target = state_path / "audio-selfcheck.json"
+        payload = json.dumps(status, indent=2)
+        # Atomic write: write to a temp file in the same dir, then rename.
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            dir=state_path,
+            prefix=".audio-selfcheck-",
+            suffix=".json.tmp",
+            delete=False,
+        ) as tf:
+            tf.write(payload)
+            tmp_path = Path(tf.name)
+        tmp_path.rename(target)
+    except Exception as exc:
+        print(f"[arlowe-audio] WARN could not write state: {exc}", file=sys.stderr)
+
+
+def _emit_journal_line(cap_result: dict, play_result: dict) -> None:
+    """Print a greppable [arlowe-audio] journal line to stderr."""
+    cap_status = "ok" if cap_result.get("ok") else "FAIL"
+    play_status = "ok" if play_result.get("ok") else "FAIL"
+    cap_device = cap_result.get("device") or "none"
+    play_device = play_result.get("device") or "none"
+    print(
+        f"[arlowe-audio] selfcheck capture={cap_status} device={cap_device}"
+        f" playback={play_status} device={play_device}",
+        file=sys.stderr,
+    )
+
+
+# ---------------------------------------------------------------------------
 # CLI surface — lazy config import so pure functions work without a config file
 # ---------------------------------------------------------------------------
 
@@ -278,11 +543,20 @@ def _cli_main() -> None:
         action="store_true",
         help="Print enumerated cards as JSON.",
     )
+    group.add_argument(
+        "--selfcheck",
+        action="store_true",
+        help=(
+            "Run capture+playback sentinels, write JSON status to "
+            "/var/lib/arlowe/state/audio-selfcheck.json, print JSON to stdout. "
+            "Exit 0 if both sentinels pass, exit 1 if either fails."
+        ),
+    )
     args = parser.parse_args()
 
     # Import config lazily so tests of pure functions don't require a config file.
     try:
-        from arlowe_config import load as _load_config
+        from arlowe_config import load as _load_config  # noqa: PLC0415
         cfg = _load_config()
         capture_override = cfg.get("audio", {}).get("capture_device", "auto")
         playback_override = cfg.get("audio", {}).get("playback_device", "auto")
@@ -303,6 +577,11 @@ def _cli_main() -> None:
         if result is None:
             sys.exit(1)
         print(result)
+    elif args.selfcheck:
+        status = selfcheck()
+        print(json.dumps(status, indent=2))
+        if not (status["capture"]["ok"] and status["playback"]["ok"]):
+            sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/runtime/lib/tests/test_arlowe_audio_selfcheck.py
+++ b/runtime/lib/tests/test_arlowe_audio_selfcheck.py
@@ -1,0 +1,537 @@
+"""
+Unit tests for arlowe_audio selfcheck sentinel logic.
+
+All tests use injected capture_runner/playback_runner fakes — no real
+arecord, aplay, or sox invoked.  No real hardware required.
+
+Run from repo root:
+    PYTHONPATH=runtime/lib python3 -m pytest runtime/lib/tests/test_arlowe_audio_selfcheck.py -q
+
+Or from runtime/lib/:
+    python3 -m pytest tests/test_arlowe_audio_selfcheck.py -q
+"""
+
+import json
+import struct
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import arlowe_audio
+
+FIXTURES = Path(__file__).parent / "fixtures" / "proc_asound"
+USB_PLUS_WM8960 = str(FIXTURES / "usb_plus_wm8960")
+
+
+# ---------------------------------------------------------------------------
+# Helpers: fake runners
+# ---------------------------------------------------------------------------
+
+def _make_silent_pcm(n_samples: int = 8000) -> bytes:
+    """Return all-zero S16_LE PCM bytes (silent)."""
+    return struct.pack(f"<{n_samples}h", *([0] * n_samples))
+
+
+def _make_nonsilent_pcm(n_samples: int = 8000, amplitude: int = 2000) -> bytes:
+    """Return S16_LE PCM bytes with a detectable RMS well above the floor."""
+    import math
+    samples = [int(amplitude * math.sin(2 * math.pi * 440 * i / 16000)) for i in range(n_samples)]
+    return struct.pack(f"<{n_samples}h", *samples)
+
+
+def _capture_ok(device: str) -> bytes:
+    return _make_nonsilent_pcm()
+
+
+def _capture_silent(device: str) -> bytes:
+    return _make_silent_pcm()
+
+
+def _capture_raises(device: str) -> bytes:
+    raise RuntimeError("arecord: no such device")
+
+
+def _playback_ok(device: str) -> None:
+    return None
+
+
+def _playback_raises(device: str) -> None:
+    raise RuntimeError("aplay: device busy")
+
+
+# ---------------------------------------------------------------------------
+# Tests: basic happy path
+# ---------------------------------------------------------------------------
+
+class TestSelfcheckBothOk:
+    def test_returns_dict_with_check_audio(self):
+        status = arlowe_audio.selfcheck(
+            state_dir=None,
+            retries=1,
+            capture_runner=_capture_ok,
+            playback_runner=_playback_ok,
+            proc_root=USB_PLUS_WM8960,
+        )
+        assert status["check"] == "audio"
+
+    def test_capture_ok_true(self):
+        status = arlowe_audio.selfcheck(
+            state_dir=None,
+            retries=1,
+            capture_runner=_capture_ok,
+            playback_runner=_playback_ok,
+            proc_root=USB_PLUS_WM8960,
+        )
+        assert status["capture"]["ok"] is True
+
+    def test_playback_ok_true(self):
+        status = arlowe_audio.selfcheck(
+            state_dir=None,
+            retries=1,
+            capture_runner=_capture_ok,
+            playback_runner=_playback_ok,
+            proc_root=USB_PLUS_WM8960,
+        )
+        assert status["playback"]["ok"] is True
+
+    def test_ts_is_iso8601(self):
+        status = arlowe_audio.selfcheck(
+            state_dir=None,
+            retries=1,
+            capture_runner=_capture_ok,
+            playback_runner=_playback_ok,
+            proc_root=USB_PLUS_WM8960,
+        )
+        ts = status["ts"]
+        assert "T" in ts
+        assert ts.endswith("Z")
+
+    def test_capture_device_is_resolved(self):
+        status = arlowe_audio.selfcheck(
+            state_dir=None,
+            retries=1,
+            capture_runner=_capture_ok,
+            playback_runner=_playback_ok,
+            proc_root=USB_PLUS_WM8960,
+        )
+        # USB_PLUS_WM8960 fixture has USB at index 1 -> plughw:1,0
+        assert status["capture"]["device"] == "plughw:1,0"
+
+    def test_playback_device_is_resolved(self):
+        status = arlowe_audio.selfcheck(
+            state_dir=None,
+            retries=1,
+            capture_runner=_capture_ok,
+            playback_runner=_playback_ok,
+            proc_root=USB_PLUS_WM8960,
+        )
+        assert status["playback"]["device"] == "plughw:1,0"
+
+
+# ---------------------------------------------------------------------------
+# Tests: capture failure path
+# ---------------------------------------------------------------------------
+
+class TestSelfcheckCaptureSilent:
+    def test_capture_ok_false_on_silent_buffer(self):
+        status = arlowe_audio.selfcheck(
+            state_dir=None,
+            retries=1,
+            capture_runner=_capture_silent,
+            playback_runner=_playback_ok,
+            proc_root=USB_PLUS_WM8960,
+        )
+        assert status["capture"]["ok"] is False
+
+    def test_capture_error_mentions_rms(self):
+        status = arlowe_audio.selfcheck(
+            state_dir=None,
+            retries=1,
+            capture_runner=_capture_silent,
+            playback_runner=_playback_ok,
+            proc_root=USB_PLUS_WM8960,
+        )
+        assert "RMS" in status["capture"].get("error", "")
+
+    def test_playback_still_ok_when_capture_silent(self):
+        status = arlowe_audio.selfcheck(
+            state_dir=None,
+            retries=1,
+            capture_runner=_capture_silent,
+            playback_runner=_playback_ok,
+            proc_root=USB_PLUS_WM8960,
+        )
+        assert status["playback"]["ok"] is True
+
+
+class TestSelfcheckCaptureRaises:
+    def test_capture_ok_false_on_exception(self):
+        status = arlowe_audio.selfcheck(
+            state_dir=None,
+            retries=1,
+            capture_runner=_capture_raises,
+            playback_runner=_playback_ok,
+            proc_root=USB_PLUS_WM8960,
+        )
+        assert status["capture"]["ok"] is False
+
+    def test_capture_error_populated(self):
+        status = arlowe_audio.selfcheck(
+            state_dir=None,
+            retries=1,
+            capture_runner=_capture_raises,
+            playback_runner=_playback_ok,
+            proc_root=USB_PLUS_WM8960,
+        )
+        assert status["capture"].get("error") is not None
+
+
+# ---------------------------------------------------------------------------
+# Tests: playback failure path
+# ---------------------------------------------------------------------------
+
+class TestSelfcheckPlaybackRaises:
+    def test_playback_ok_false_on_exception(self):
+        status = arlowe_audio.selfcheck(
+            state_dir=None,
+            retries=1,
+            capture_runner=_capture_ok,
+            playback_runner=_playback_raises,
+            proc_root=USB_PLUS_WM8960,
+        )
+        assert status["playback"]["ok"] is False
+
+    def test_playback_error_populated(self):
+        status = arlowe_audio.selfcheck(
+            state_dir=None,
+            retries=1,
+            capture_runner=_capture_ok,
+            playback_runner=_playback_raises,
+            proc_root=USB_PLUS_WM8960,
+        )
+        assert status["playback"].get("error") is not None
+
+    def test_capture_still_ok_when_playback_fails(self):
+        status = arlowe_audio.selfcheck(
+            state_dir=None,
+            retries=1,
+            capture_runner=_capture_ok,
+            playback_runner=_playback_raises,
+            proc_root=USB_PLUS_WM8960,
+        )
+        assert status["capture"]["ok"] is True
+
+
+# ---------------------------------------------------------------------------
+# Tests: retry behavior
+# ---------------------------------------------------------------------------
+
+class TestSelfcheckRetry:
+    def test_capture_retried_n_times_before_failure(self):
+        call_count = []
+
+        def counting_silent(device):
+            call_count.append(1)
+            return _make_silent_pcm()
+
+        arlowe_audio.selfcheck(
+            state_dir=None,
+            retries=3,
+            capture_runner=counting_silent,
+            playback_runner=_playback_ok,
+            proc_root=USB_PLUS_WM8960,
+        )
+        assert len(call_count) == 3
+
+    def test_playback_retried_n_times_before_failure(self):
+        call_count = []
+
+        def counting_raises(device):
+            call_count.append(1)
+            raise RuntimeError("busy")
+
+        arlowe_audio.selfcheck(
+            state_dir=None,
+            retries=3,
+            capture_runner=_capture_ok,
+            playback_runner=counting_raises,
+            proc_root=USB_PLUS_WM8960,
+        )
+        assert len(call_count) == 3
+
+    def test_capture_succeeds_on_second_attempt(self):
+        attempts = []
+
+        def flaky_capture(device):
+            attempts.append(1)
+            if len(attempts) == 1:
+                return _make_silent_pcm()
+            return _make_nonsilent_pcm()
+
+        status = arlowe_audio.selfcheck(
+            state_dir=None,
+            retries=3,
+            capture_runner=flaky_capture,
+            playback_runner=_playback_ok,
+            proc_root=USB_PLUS_WM8960,
+        )
+        assert status["capture"]["ok"] is True
+        assert len(attempts) == 2
+
+    def test_playback_succeeds_on_second_attempt(self):
+        attempts = []
+
+        def flaky_playback(device):
+            attempts.append(1)
+            if len(attempts) == 1:
+                raise RuntimeError("busy")
+
+        status = arlowe_audio.selfcheck(
+            state_dir=None,
+            retries=3,
+            capture_runner=_capture_ok,
+            playback_runner=flaky_playback,
+            proc_root=USB_PLUS_WM8960,
+        )
+        assert status["playback"]["ok"] is True
+        assert len(attempts) == 2
+
+
+# ---------------------------------------------------------------------------
+# Tests: JSON status file persistence
+# ---------------------------------------------------------------------------
+
+class TestSelfcheckPersistence:
+    def test_json_written_to_state_dir(self, tmp_path):
+        arlowe_audio.selfcheck(
+            state_dir=str(tmp_path),
+            retries=1,
+            capture_runner=_capture_ok,
+            playback_runner=_playback_ok,
+            proc_root=USB_PLUS_WM8960,
+        )
+        target = tmp_path / "audio-selfcheck.json"
+        assert target.exists()
+
+    def test_json_has_required_keys(self, tmp_path):
+        arlowe_audio.selfcheck(
+            state_dir=str(tmp_path),
+            retries=1,
+            capture_runner=_capture_ok,
+            playback_runner=_playback_ok,
+            proc_root=USB_PLUS_WM8960,
+        )
+        data = json.loads((tmp_path / "audio-selfcheck.json").read_text())
+        assert data["check"] == "audio"
+        assert "capture" in data
+        assert "playback" in data
+        assert "ts" in data
+
+    def test_json_capture_has_device_and_ok(self, tmp_path):
+        arlowe_audio.selfcheck(
+            state_dir=str(tmp_path),
+            retries=1,
+            capture_runner=_capture_ok,
+            playback_runner=_playback_ok,
+            proc_root=USB_PLUS_WM8960,
+        )
+        data = json.loads((tmp_path / "audio-selfcheck.json").read_text())
+        assert "device" in data["capture"]
+        assert "ok" in data["capture"]
+
+    def test_json_playback_has_device_and_ok(self, tmp_path):
+        arlowe_audio.selfcheck(
+            state_dir=str(tmp_path),
+            retries=1,
+            capture_runner=_capture_ok,
+            playback_runner=_playback_ok,
+            proc_root=USB_PLUS_WM8960,
+        )
+        data = json.loads((tmp_path / "audio-selfcheck.json").read_text())
+        assert "device" in data["playback"]
+        assert "ok" in data["playback"]
+
+    def test_json_overwritten_on_second_run(self, tmp_path):
+        arlowe_audio.selfcheck(
+            state_dir=str(tmp_path),
+            retries=1,
+            capture_runner=_capture_ok,
+            playback_runner=_playback_ok,
+            proc_root=USB_PLUS_WM8960,
+        )
+        first_mtime = (tmp_path / "audio-selfcheck.json").stat().st_mtime
+
+        import time
+        time.sleep(0.01)
+
+        arlowe_audio.selfcheck(
+            state_dir=str(tmp_path),
+            retries=1,
+            capture_runner=_capture_ok,
+            playback_runner=_playback_ok,
+            proc_root=USB_PLUS_WM8960,
+        )
+        second_mtime = (tmp_path / "audio-selfcheck.json").stat().st_mtime
+        assert second_mtime >= first_mtime
+
+    def test_state_dir_none_does_not_crash(self):
+        status = arlowe_audio.selfcheck(
+            state_dir=None,
+            retries=1,
+            capture_runner=_capture_ok,
+            playback_runner=_playback_ok,
+            proc_root=USB_PLUS_WM8960,
+        )
+        assert status["check"] == "audio"
+
+    def test_unwritable_state_dir_does_not_crash(self, tmp_path):
+        bad_dir = tmp_path / "no_access"
+        bad_dir.mkdir()
+        bad_dir.chmod(0o000)
+        try:
+            status = arlowe_audio.selfcheck(
+                state_dir=str(bad_dir),
+                retries=1,
+                capture_runner=_capture_ok,
+                playback_runner=_playback_ok,
+                proc_root=USB_PLUS_WM8960,
+            )
+            assert status["check"] == "audio"
+        finally:
+            bad_dir.chmod(0o755)
+
+
+# ---------------------------------------------------------------------------
+# Tests: no devices — graceful degraded path
+# ---------------------------------------------------------------------------
+
+class TestSelfcheckNoDevices:
+    def test_no_capture_device_reports_fail(self, tmp_path):
+        """When proc_root has no capture devices, capture ok=False, no crash."""
+        no_capture_root = str(FIXTURES / "no_capture")
+        status = arlowe_audio.selfcheck(
+            state_dir=None,
+            retries=1,
+            capture_runner=_capture_ok,
+            playback_runner=_playback_ok,
+            proc_root=no_capture_root,
+        )
+        assert status["capture"]["ok"] is False
+        assert status["capture"]["device"] is None
+
+    def test_no_capture_device_error_populated(self, tmp_path):
+        no_capture_root = str(FIXTURES / "no_capture")
+        status = arlowe_audio.selfcheck(
+            state_dir=None,
+            retries=1,
+            capture_runner=_capture_ok,
+            playback_runner=_playback_ok,
+            proc_root=no_capture_root,
+        )
+        assert "no capture device" in status["capture"].get("error", "")
+
+
+# ---------------------------------------------------------------------------
+# Tests: internal helpers
+# ---------------------------------------------------------------------------
+
+class TestRmsFromPcm:
+    def test_silent_pcm_returns_zero(self):
+        rms = arlowe_audio._rms_from_pcm(_make_silent_pcm())
+        assert rms == 0.0
+
+    def test_nonsilent_pcm_returns_above_floor(self):
+        rms = arlowe_audio._rms_from_pcm(_make_nonsilent_pcm(amplitude=2000))
+        assert rms >= arlowe_audio._CAPTURE_RMS_FLOOR
+
+    def test_empty_bytes_returns_zero(self):
+        rms = arlowe_audio._rms_from_pcm(b"")
+        assert rms == 0.0
+
+    def test_wav_header_is_stripped(self):
+        # Construct minimal WAV: 'data' marker + 4-byte size + PCM.
+        pcm = _make_nonsilent_pcm(amplitude=2000)
+        import struct as st
+        wav = b"RIFF\x00\x00\x00\x00WAVEfmt \x10\x00\x00\x00\x01\x00\x01\x00"
+        wav += st.pack("<I", 16000) + st.pack("<I", 32000)
+        wav += b"\x02\x00\x10\x00data"
+        wav += st.pack("<I", len(pcm)) + pcm
+        rms = arlowe_audio._rms_from_pcm(wav)
+        assert rms >= arlowe_audio._CAPTURE_RMS_FLOOR
+
+
+class TestStripWavHeader:
+    def test_no_header_returns_original(self):
+        pcm = b"\x01\x00\x02\x00"
+        result = arlowe_audio._strip_wav_header(pcm)
+        assert result == pcm
+
+    def test_data_marker_is_stripped(self):
+        import struct as st
+        pcm = b"\x01\x00\x02\x00"
+        # Prefix must not contain the literal b"data" to avoid confusing find().
+        wav = b"RIFF\x00\x00\x00\x00WAVEfmt " + b"data" + st.pack("<I", len(pcm)) + pcm
+        result = arlowe_audio._strip_wav_header(wav)
+        assert result == pcm
+
+
+# ---------------------------------------------------------------------------
+# Tests: journal line format
+# ---------------------------------------------------------------------------
+
+class TestJournalLine:
+    def test_journal_line_emitted_to_stderr(self, capsys):
+        arlowe_audio.selfcheck(
+            state_dir=None,
+            retries=1,
+            capture_runner=_capture_ok,
+            playback_runner=_playback_ok,
+            proc_root=USB_PLUS_WM8960,
+        )
+        captured = capsys.readouterr()
+        assert "[arlowe-audio]" in captured.err
+
+    def test_journal_line_contains_selfcheck(self, capsys):
+        arlowe_audio.selfcheck(
+            state_dir=None,
+            retries=1,
+            capture_runner=_capture_ok,
+            playback_runner=_playback_ok,
+            proc_root=USB_PLUS_WM8960,
+        )
+        captured = capsys.readouterr()
+        assert "selfcheck" in captured.err
+
+    def test_journal_line_contains_capture_status(self, capsys):
+        arlowe_audio.selfcheck(
+            state_dir=None,
+            retries=1,
+            capture_runner=_capture_ok,
+            playback_runner=_playback_ok,
+            proc_root=USB_PLUS_WM8960,
+        )
+        captured = capsys.readouterr()
+        assert "capture=ok" in captured.err
+
+    def test_journal_line_contains_fail_on_silent(self, capsys):
+        arlowe_audio.selfcheck(
+            state_dir=None,
+            retries=1,
+            capture_runner=_capture_silent,
+            playback_runner=_playback_ok,
+            proc_root=USB_PLUS_WM8960,
+        )
+        captured = capsys.readouterr()
+        assert "capture=FAIL" in captured.err
+
+    def test_journal_line_contains_playback_status(self, capsys):
+        arlowe_audio.selfcheck(
+            state_dir=None,
+            retries=1,
+            capture_runner=_capture_ok,
+            playback_runner=_playback_ok,
+            proc_root=USB_PLUS_WM8960,
+        )
+        captured = capsys.readouterr()
+        assert "playback=ok" in captured.err


### PR DESCRIPTION
## Summary

- Adds `selfcheck()` to `runtime/lib/arlowe_audio.py` with a `--selfcheck` CLI subcommand: runs capture RMS and playback tone sentinels independently (injectable runners for unit testability), retries 3 times with 1s sleep, then reports — never hard-blocks boot
- Atomically writes Phase-11-consumable JSON status to `/var/lib/arlowe/state/audio-selfcheck.json`; emits a greppable `[arlowe-audio]` journal line to stderr
- Replaces the hardcoded `plughw:2,0` probe in `runtime/cli/boot-check` (and its `TODO(phase-5)` comment) with a call to the auto-detected selfcheck
- WARN (not FAIL) on audio degraded per locked CONTEXT decision (functional-degraded over hard block)
- Adds `runtime/lib/tests/test_arlowe_audio_selfcheck.py`: 38 tests covering happy path, silent buffer, runner exceptions, retry behavior, JSON shape, unwritable state dir, no-device path, journal line format — all green, no real hardware

## Test evidence

```
$ cd runtime/lib && python3 -m pytest tests/test_arlowe_audio_selfcheck.py tests/test_arlowe_audio.py -q
76 passed in 6.62s
```

Full suite (81 tests):
```
$ python3 -m pytest tests/ -q
81 passed in 6.64s
```

Sanitization gate:
```
$ bash scripts/sanitize/check.sh
--- grep gate ---
sanitize grep: clean (194 files scanned)
--- units gate ---
sanitize units: clean (9 unit files checked)
```

Syntax checks:
```
$ python3 -m py_compile runtime/lib/arlowe_audio.py  # OK
$ bash -n runtime/cli/boot-check  # OK
$ grep plughw:2,0 runtime/cli/boot-check  # (no output — gone)
```

## Deferred to 05-07

Real-hardware RMS calibration (confirming buffers are non-silent on the Pi) and `/var/lib/arlowe/state/` writability verification under the actual systemd unit context.

Closes #93