### PR TITLE
docs(06-01): Phase 6 spec reconciliation — shared-model 5-partition layout + tryboot ADRs

### DIFF
--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -83,19 +83,19 @@
 ### Image build pipeline (`IMAGE`)
 
 - [ ] **IMAGE-01**: pi-gen pipeline produces a flashable `.img` file from repo contents + pinned dependencies
-- [ ] **IMAGE-02**: Image stages: base (Pi OS), hardware deps (`axcl_host.deb`, ALSA, NetworkManager, Python), runtime (`/opt/arlowe/runtime/`), models (`/opt/arlowe/models/`), first-boot (pairing daemon armed)
-- [ ] **IMAGE-03**: Image build is reproducible — same inputs produce the same image hash (where pi-gen permits)
-- [ ] **IMAGE-04**: Image size verified ≤ 16 GB target; flash time documented
+- [ ] **IMAGE-02**: Image stages: base (Pi OS), hardware deps (`axcl_host.deb`, ALSA, NetworkManager, Python), runtime (`/opt/arlowe/runtime/`), models (single shared read-only `models` partition mounted at `/opt/arlowe/models` in both slots — see ADR-0004), first-boot (first-boot hook armed — ready-to-pair state; the pairing daemon itself is Phase 8)
+- [ ] **IMAGE-03**: Image build is reproducible — build inputs are pinned (Debian snapshot, debs, submodule, SOURCE_DATE_EPOCH); image-hash equality is NOT gated (ext4 nondeterminism); documented exception list (see ADR / docs/operations/phase-6 repro notes)
+- [ ] **IMAGE-04**: Image size verified ≤ 16 GB viable (single shared model set + fixed overhead fits a 16 GB card; 32 GB recommended for larger-model headroom — see ADR-0004); flash time documented
 - [ ] **IMAGE-05**: `scripts/build-image.sh` runs the full pipeline; `scripts/flash-sd.sh` writes to a connected SD card
 - [ ] **IMAGE-06**: `scripts/dev-deploy.sh` rsyncs `runtime/` to a connected Pi for fast iteration without re-flashing
 
 ### A/B partition layout (`PART`)
 
-- [ ] **PART-01**: Image provisions four partitions: `/boot`, system A (active root), system B (standby root), `/var/lib/arlowe` (owner state)
-- [ ] **PART-02**: Boot-time A/B selector reads a flag (U-Boot env or `/boot/active.txt`) and selects the active root
-- [ ] **PART-03**: First boot lands on system A; system B is empty/standby in v1
+- [ ] **PART-01**: Image provisions FIVE partitions: `/boot`, system A (active root, model-free), system B (recovery rootfs, model-free), a shared read-only `models` partition (mounted at `/opt/arlowe/models` in both slots — see ADR-0004), and `/var/lib/arlowe` (owner state)
+- [ ] **PART-02**: Boot-time A/B selector is the Pi firmware tryboot mechanism (shared /boot, tryboot_a_b=1); the persistent A/B default is the boot root= (cmdline), flipped by arlowe-ab; no U-Boot, no active.txt (see ADR-0005)
+- [ ] **PART-03**: First boot lands on system A; system B holds a minimal recovery rootfs in v1 (boots to recovery, resets default to A); a full standby slot from Phase 9
 - [ ] **PART-04**: `/var/lib/arlowe` partition is shared across A/B, ext4, mounted with appropriate options (noatime, etc.)
-- [ ] **PART-05**: Partition sizes documented: system A and B equal-sized (image + 25% headroom); owner state sized for ~1 GB conversation cache + logs + paired data
+- [ ] **PART-05**: Partition sizes documented (ADR-0004): system A and B equal-sized + model-free (model-free slot rootfs + 25% headroom); the shared `models` partition grows-to-fill the card on first boot; `/var/lib/arlowe` owner-state is a FIXED partition sized for ~1 GB conversation cache + logs + paired data (~2-4 GB). Models do NOT live on owner-state.
 - [ ] **PART-06**: Bricked-system fallback — recovery SD card image documented as v1 fallback (since OS OTA delivery defers to v2+)
 
 ### App-only OTA (`OTA`)

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -152,18 +152,18 @@ Plans:
 
 ### Phase 6: Image build with A/B partitions
 
-**Goal**: Produce a flashable `.img` from this repo via pi-gen, with the A/B partition layout provisioned from day one (even though OS OTA delivery defers to v2+). Make the build reproducible enough for CI and small enough to fit on a 16 GB SD card.
+**Goal**: Produce a flashable `.img` from this repo via pi-gen, with the A/B partition layout provisioned from day one (even though OS OTA delivery defers to v2+). Make the build reproducible enough for CI; a single shared model partition keeps a 16 GB SD card viable (32 GB recommended for larger-model headroom — see ADR-0004).
 
 **Depends on**: Phase 1 (runtime to package), Phase 3 (filesystem layout to provision), Phase 4 (defaults.yml to ship)
 
 **Requirements**: IMAGE-01, IMAGE-02, IMAGE-03, IMAGE-04, IMAGE-05, IMAGE-06, PART-01, PART-02, PART-03, PART-04, PART-05, PART-06
 
 **Success Criteria** (what must be TRUE):
-  1. `scripts/build-image.sh` produces a `.img` file from a clean checkout that, when flashed via `scripts/flash-sd.sh` to a 16 GB+ SD card, boots a Pi 5 to a "ready to pair" state (config overlay absent, pairing daemon armed).
-  2. The flashed card has four partitions: `/boot`, system A (active), system B (empty/standby in v1), and `/var/lib/arlowe` (owner state, ext4, noatime); partition sizes are documented and within the 16 GB budget.
-  3. The boot-time A/B selector reads its flag (U-Boot env or `/boot/active.txt`) and lands on system A by default; flipping the flag manually and rebooting selects system B (which boots to a recovery prompt in v1, since B is empty).
+  1. `scripts/build-image.sh` produces a `.img` file from a clean checkout that, when flashed via `scripts/flash-sd.sh` to a 16 GB+ SD card (32 GB recommended), boots a Pi 5 to a "ready to pair" state (config overlay absent, first-boot hook armed — ready-to-pair state; the pairing daemon itself is Phase 8).
+  2. The flashed card has FIVE partitions: `/boot`, system A (active, model-free), system B (recovery rootfs, model-free), a shared read-only `models` partition (mounted at `/opt/arlowe/models` in both slots), and `/var/lib/arlowe` (owner state, ext4, noatime, FIXED size); the `models` partition grows-to-fill on first boot; partition sizes are documented (16 GB viable, 32 GB recommended — see ADR-0004).
+  3. The boot-time A/B selector is the Pi tryboot root= selector (arlowe-ab flips the persistent default by rewriting root=) and lands on system A by default; flipping manually and rebooting selects system B, which boots a minimal recovery rootfs that surfaces recovery on Whisplay + serial and resets the default to A.
   4. `scripts/dev-deploy.sh` rsyncs `runtime/` to a connected Pi over SSH for fast iteration without re-flashing, and the recovery SD-card image procedure is documented in `docs/`.
-  5. Two clean builds from the same commit produce images with the same hash for inputs pi-gen permits to be reproducible (documented exceptions allowed).
+  5. Two clean builds from the same commit produce images with the same hash for inputs pi-gen permits to be reproducible (documented exceptions allowed; input reproducibility only; no image-hash gate — ext4 nondeterminism documented as an exception).
 
 **Plans**: 6 plans
 

--- a/.planning/phases/06-image-build-with-a-b-partitions/06-01-SUMMARY.md
+++ b/.planning/phases/06-image-build-with-a-b-partitions/06-01-SUMMARY.md
@@ -1,0 +1,50 @@
+---
+plan: 06-01
+phase: 06-image-build-with-a-b-partitions
+status: complete
+date: 2026-06-13
+---
+
+## What was done
+
+Two ADRs written and REQUIREMENTS.md / ROADMAP.md Phase 6 text amended to reflect two design decisions that contradicted the existing spec.
+
+### ADR-0004 — Shared model partition + sizing
+
+`docs/architecture/0004-shared-model-partition-sizing.md`
+
+Records the reversal of "models baked into each rootfs slot" in favor of a single shared read-only `models` partition mounted at `/opt/arlowe/models` in both slots. Includes measured model-size evidence from GATE 1 (Qwen 7B 5.51 GB, Qwen 1.5B 1.53 GB, Whisper small.en 0.49 GB, Piper 0.07 GB). States that the GATE 1 "32 GB floor" conclusion is superseded. Documents 16 GB as viable (one ~6 GB model set + ~5.5 GB fixed overhead fits a 16 GB card's ~14.8 GB usable), 32 GB recommended but not mandated. Records the accepted v2-OS-OTA model-sharing tradeoff.
+
+### ADR-0005 — A/B selector: tryboot root= swap
+
+`docs/architecture/0005-ab-selector-tryboot-root-swap.md`
+
+Corrects PART-02/SC3 "U-Boot env or /boot/active.txt" wording. Records the Pi-native tryboot mechanism: `tryboot_a_b=1` + file-level slot distinction inside one shared /boot FAT partition. Documents that `reboot "0 tryboot"` is one-shot (reverts on power-cycle), so the persistent default flip must rewrite `root=` in `config.txt`. `arlowe-ab` owns the rewrite; `tryboot.txt` + one-shot path are reserved for Phase 9 OTA trial-boot.
+
+### REQUIREMENTS.md amendments
+
+- IMAGE-02: models stage now describes shared read-only `models` partition; "pairing daemon armed" replaced with "first-boot hook armed — ready-to-pair state; the pairing daemon itself is Phase 8"
+- IMAGE-03: reframed as input reproducibility (pinned inputs); no image-hash gate (ext4 nondeterminism); documented exception list
+- IMAGE-04: "≤ 16 GB target" changed to "≤ 16 GB viable ... 32 GB recommended" with ADR-0004 citation
+- PART-01: "four partitions" changed to "FIVE partitions" with the shared models partition listed
+- PART-02: U-Boot/active.txt wording replaced with tryboot_a_b=1 / root= / arlowe-ab description; ADR-0005 cited
+- PART-03: "system B is empty/standby in v1" replaced with "minimal recovery rootfs that boots to recovery and resets default to A"
+- PART-05: reframed with model-free slot sizing, grow-to-fill models partition, FIXED owner-state, ADR-0004 citation
+
+### ROADMAP.md Phase 6 amendments
+
+- Goal line: reframed from "small enough to fit on a 16 GB SD card" to "shared model partition keeps a 16 GB SD card viable (32 GB recommended)"
+- SC1: "pairing daemon armed" → "first-boot hook armed — ready-to-pair state; the pairing daemon itself is Phase 8"; "16 GB+ SD card" → "16 GB+ SD card (32 GB recommended)"
+- SC2: "four partitions" → "FIVE partitions" with five-partition list; grow-to-fill and sizing note
+- SC3: U-Boot/active.txt/empty-B wording replaced with tryboot root= selector and minimal recovery rootfs
+- SC5: appended "(input reproducibility only; no image-hash gate — ext4 nondeterminism documented as an exception)"
+
+Phase 8 block was not touched (pairing daemon wording there is correct for Phase 8).
+
+## Verification results
+
+All 18 greps from the plan passed:
+- ADR-0004: file exists, contains "shared", "5.51", "grow-to-fill", "16 GB"
+- ADR-0005: file exists, contains "tryboot_a_b", "root="
+- REQUIREMENTS.md: "single shared read-only", "FIVE partitions", "tryboot", "first-boot hook armed" present; "four partitions", "pairing daemon armed", "32 GB floor/minimum" absent
+- ROADMAP.md: "FIVE partitions", "first-boot hook armed" present; "16 GB budget", "four partitions" absent

--- a/docs/architecture/0004-shared-model-partition-sizing.md
+++ b/docs/architecture/0004-shared-model-partition-sizing.md
@@ -1,0 +1,88 @@
+# ADR-0004: Shared model partition + sizing
+
+<!-- status: accepted -->
+**Status:** Accepted
+**Date:** 2026-06-13
+**Phase:** 6 (Image build with A/B partitions)
+**Closes:** IMAGE-04, PART-01, PART-05
+**Supersedes:** GATE 1 "16 GB impossible → 32 GB floor" verdict in `.planning/phases/06-image-build-with-a-b-partitions/06-RESEARCH.md`
+
+## Context
+
+Phase 6 research (GATE 1) measured the model artifact sizes needed by Arlowe v1:
+
+| Artifact | Disk size |
+|----------|-----------|
+| Qwen2.5-7B-Instruct GPTQ-Int4 (AX650 layout) | 5.51 GB |
+| Qwen2.5-1.5B-Instruct GPTQ-Int4 AX650 | 1.53 GB |
+| faster-whisper small.en | 0.49 GB |
+| Piper en_US-lessac-medium | 0.07 GB |
+| runtime/ tree | 0.46 GB |
+
+A single shared model set (7B + whisper small.en + piper) totals approximately 6 GB.
+
+The original REQUIREMENTS.md (PART-01/PART-05) described models baked into each rootfs slot — that is, each slot carried its own full copy of the model artifacts alongside the OS and runtime. Under the locked "equal-sized A/B slots" constraint, this produced:
+
+- Qwen 7B config: ~10 GB per slot → ~26.5 GB total (A + B + /boot + owner-state)
+- Qwen 1.5B config: ~6 GB per slot → ~16.6 GB total
+
+Both exceed a 16 GB card's ~14.8 GB usable space. GATE 1 concluded 32 GB was a hard floor.
+
+That conclusion is superseded. The owner reversed the "models baked into each slot" decision. Models now live ONCE on a shared partition, not duplicated in each slot.
+
+Model-free slot footprint: Pi OS Lite arm64 (~1.6 GB) + axcl + ALSA/NetworkManager/Python + Python/ML deps + runtime tree ≈ ~2–3 GB per slot.
+
+Fixed overhead with model-free slots: ~5.5 GB (/boot 0.5 GB + slot A ~2.5 GB + slot B ~2.5 GB recovery + owner-state ~2 GB initial). One ~6 GB model set + ~5.5 GB overhead = ~11.5 GB, well within a 16 GB card's ~14.8 GB usable. Approximately 3 GB remains for the models grow-to-fill partition on a 16 GB card; on a 32 GB card that headroom is ~25 GB.
+
+## Decision
+
+A **single shared, read-only, root-owned `models` partition** is mounted at `/opt/arlowe/models` in **both slot A and slot B**. System A and B remain full per-slot rootfs (complete OS + runtime, equal-sized — the locked slot-independence decision is unchanged) but without the bulky model artifacts.
+
+Partition layout (five partitions total):
+
+| Partition | Filesystem | Size | Notes |
+|-----------|-----------|------|-------|
+| `/boot` (shared FAT) | FAT32 | 512 MB | firmware + both slots' kernels + tryboot configs |
+| system A (ext4) | ext4 | ~3 GB + 25% headroom | active root; model-free; fixed size for swap symmetry |
+| system B (ext4) | ext4 | equal to A | recovery rootfs in v1; full standby from Phase 9 |
+| shared `models` (ext4) | ext4 | grows-to-fill | mounts at `/opt/arlowe/models` in both slots; read-only + root-owned in v1 |
+| `/var/lib/arlowe` (ext4, noatime) | ext4 | ~2–4 GB fixed | owner state; FIXED size (not grow-to-fill) |
+
+The **`models` partition is the grow-to-fill partition**: a first-boot service runs `resize2fs` on it once to consume all remaining card space, maximizing headroom for larger models via future model-OTA. `/var/lib/arlowe` owner-state is a **fixed** modest partition. The concrete starting sizes for A, B, and owner-state are MEASURE-THEN-SET values: plan 06-04 measures the assembled model-free slot rootfs with `du` and sets fixed partition numbers from the real data; the models partition takes the remainder.
+
+**Sizing:**
+- **16 GB is VIABLE.** One ~6 GB model set + ~5.5 GB fixed overhead (boot + slot A + slot B + owner-state) fits a 16 GB card's ~14.8 GB usable space, leaving ~3 GB for the models grow-to-fill partition on initial image (the first-boot resize2fs expands it to the card's full remainder). IMAGE-04's ≤16 GB target is achievable again.
+- **32 GB is RECOMMENDED** for larger-model headroom (~25 GB for the models partition on a 32 GB card) but is NOT mandated. There is no 32 GB floor.
+
+**In v1**, the `models` partition is read-only and root-owned. A v2 model-OTA agent can remount it read-write for updates.
+
+**Models must NOT live on `/var/lib/arlowe` owner-state.** Factory reset (PAIR-07) wipes owner-state, and it is owner-writable. Storing models there would lose them on reset and violate the read-only model contract.
+
+## Accepted tradeoff: v2 OS-OTA model sharing
+
+A future OS slot (v2 OS-OTA) shares the same `models` partition. If a new OS version requires model artifacts in a different format or layout, it cannot swap models atomically with the OS slot — the models partition upgrade must be handled separately.
+
+This is acceptable:
+- Phase 9 app-OTA touches `runtime/` only; it never modifies the `models` partition.
+- Model-OTA is a v2 concern (MOD-OTA-01 through MOD-OTA-03 are v2 requirements).
+- There is no v1 cost to this tradeoff. v2 can introduce a coordinated OS+model-OTA agent if needed.
+
+## Consequences
+
+**Positive:**
+- 16 GB cards are viable again. IMAGE-04's target is achievable.
+- A single model copy maximizes headroom for larger models as AI capabilities improve.
+- Equal-sized A/B slots remain enforced (the model-free slot size is the slot size, and both slots are equal).
+- The models partition grow-to-fill approach means larger cards automatically get more model headroom without any build configuration change.
+
+**Negative / known tradeoffs:**
+- v2 OS-OTA cannot atomically swap models with the OS slot (see accepted tradeoff above).
+- The models partition must be mounted in both slots' `/etc/fstab` by PARTUUID; forgetting this mount in the recovery rootfs (slot B) would prevent recovery from accessing models if recovery ever needs them. Plan 06-05 owns the fstab wiring.
+
+## References
+
+- Research: `.planning/phases/06-image-build-with-a-b-partitions/06-RESEARCH.md` GATE 1 (superseded by this decision)
+- Context: `.planning/phases/06-image-build-with-a-b-partitions/06-CONTEXT.md` §Partition sizing + growth
+- Plan: `.planning/phases/06-image-build-with-a-b-partitions/06-04-PLAN.md` (measure-then-set partition sizing)
+- Plan: `.planning/phases/06-image-build-with-a-b-partitions/06-05-PLAN.md` (fstab wiring for both slots)
+- Requirements amended: REQUIREMENTS.md IMAGE-04, PART-01, PART-05

--- a/docs/architecture/0005-ab-selector-tryboot-root-swap.md
+++ b/docs/architecture/0005-ab-selector-tryboot-root-swap.md
@@ -1,0 +1,72 @@
+# ADR-0005: A/B selector — tryboot root= swap
+
+<!-- status: accepted -->
+**Status:** Accepted
+**Date:** 2026-06-13
+**Phase:** 6 (Image build with A/B partitions)
+**Closes:** PART-02, SC3
+**Corrects:** REQUIREMENTS.md PART-02/ROADMAP.md SC3 wording ("U-Boot env or `/boot/active.txt`")
+
+## Context
+
+REQUIREMENTS.md PART-02 and ROADMAP.md SC3 described the A/B boot selector as reading "a flag (U-Boot env or `/boot/active.txt`)". This is wrong for the locked single-shared-`/boot` + Pi-native tryboot design. This ADR records the correct mechanism.
+
+**Pi 5 firmware A/B: two styles**
+
+The Pi bootloader reads `/boot/firmware/autoboot.txt` early (before `config.txt`). Two A/B styles exist:
+
+*Style 1 — partition-level (firmware default):* `autoboot.txt` carries `[all] boot_partition=N` and `[tryboot] boot_partition=M`. Normal boot uses partition N; `reboot "0 tryboot"` does a one-shot boot from partition M, reverting on the next power-cycle. Each slot is its own FAT boot partition with its own `config.txt` and kernel. **This is the two-FAT-boot-partition style.** The locked decision explicitly rejects it: Phase 6 requires a single shared `/boot` partition (SC2), so two FAT boot partitions are out.
+
+*Style 2 — file-level within one boot partition (the locked design):* Set `tryboot_a_b=1` in `config.txt`. When the tryboot flag is set, firmware loads **`tryboot.txt`** instead of **`config.txt`** from the same FAT partition. Slot A's `config.txt` sets `cmdline`/`root=` to rootfs partition A; `tryboot.txt` sets `root=` to rootfs partition B. One shared `/boot`, both kernels present, slots distinguished only by the `root=` they point at. This is the Pi-native mechanism that makes Style 1's "partition-level" behavior file-level inside one boot partition.
+
+**One-shot vs persistent semantics**
+
+`reboot "0 tryboot"` is **one-shot**: it boots `tryboot.txt` once; any subsequent reboot or power-cycle reverts to `config.txt` (slot A). The free fallback behavior is desirable for Phase 9 OTA trial-boot, but it means `reboot "0 tryboot"` cannot implement a *persistent* slot flip.
+
+To flip the **persistent** default to slot B, `arlowe-ab` must rewrite the `root=` in `config.txt` to point at slot B's PARTUUID — making `config.txt` itself carry slot B's boot parameters.
+
+**No U-Boot, no `active.txt`**
+
+U-Boot is not used on this platform. There is no custom initramfs that reads a flag file. `/boot/active.txt` is not part of the design.
+
+## Decision
+
+The **persistent A/B default** is the `root=` (or inline `cmdline=`) in the shared `/boot/firmware/config.txt`. `arlowe-ab` implements the persistent flip by rewriting the `root=` in `config.txt` to point at the target slot's PARTUUID, then rebooting. The recovery stub in slot B self-heals by rewriting `config.txt`'s `root=` back to slot A's PARTUUID and rebooting.
+
+`tryboot_a_b=1` is set in `config.txt`. The resulting boot layout:
+
+```
+/boot/firmware/
+  config.txt      # persistent default; root= points at slot A PARTUUID (factory default)
+  tryboot.txt     # one-shot trial slot (reserved for Phase 9 OTA trial-boot; in v1 mirrors B/recovery)
+  cmdline.txt     # or inline cmdline= in config.txt
+  kernel_2712.img # Pi 5 kernel (shared by both slots)
+  *.dtb, overlays/
+```
+
+**`arlowe-ab` owns the `root=` rewrite** as the seam Phase 9 OTA reuses. It is the single controlled path for changing the persistent default. Phase 9 OTA calls `arlowe-ab` rather than writing `config.txt` directly.
+
+**`tryboot.txt` + `reboot "0 tryboot"` are RESERVED for Phase 9** OTA one-shot trial-boot. They are not used for v1 persistent flips.
+
+Both slots mount the same shared `models` partition (ADR-0004) at `/opt/arlowe/models`. The A/B selector swaps only the rootfs `root=`; the models mount is identical for both slots and is not part of the flip logic.
+
+## Consequences
+
+**Positive:**
+- No U-Boot dependency. No custom initramfs. The selector is pure Pi firmware + a config file rewrite.
+- `arlowe-ab` is the sole abstraction Phase 9 OTA calls; the implementation detail (which file, which key) is encapsulated.
+- The one-shot `tryboot.txt` / `reboot "0 tryboot"` path remains available for Phase 9 without any v1 changes.
+- The slot-B recovery stub self-heals (resets default to A) without requiring a reflash.
+
+**Negative / known constraints:**
+- A corrupted or incompatible kernel on Pi 5 can freeze the bootloader rather than auto-falling back; a power-cycle recovers. This is a Pi 5 hardware characteristic relevant to the recovery framing (PART-06): document "if it freezes after a bad slot flip, power-cycle."
+- The persistent default lives in `config.txt` inside the FAT partition; `arlowe-ab` must mount `/boot/firmware` read-write to rewrite it and must sync before rebooting to avoid a partial write on power-loss mid-flip.
+- Boot-count / automatic A↔B rollback on failed boots is deferred to Phase 9. In v1 there is no auto-rollback; manual intervention or recovery-slot self-heal is the recovery path.
+
+## References
+
+- Research: `.planning/phases/06-image-build-with-a-b-partitions/06-RESEARCH.md` GATE 2
+- Context: `.planning/phases/06-image-build-with-a-b-partitions/06-CONTEXT.md` §A/B switch mechanism, §A/B flip + fallback, §Slot B recovery experience
+- Plan: `.planning/phases/06-image-build-with-a-b-partitions/06-05-PLAN.md` (arlowe-ab CLI + recovery stub)
+- ADR-0004: shared model partition (models mount is identical for both slots; selector is rootfs-only)
+- Requirements amended: REQUIREMENTS.md PART-02, PART-03; ROADMAP.md Phase 6 SC3


### PR DESCRIPTION
## Summary

- Write `docs/architecture/0004-shared-model-partition-sizing.md`: ADR recording the single shared read-only models partition design. Includes measured model-size evidence (Qwen 7B 5.51 GB, 1.5B 1.53 GB, Whisper small.en 0.49 GB, Piper 0.07 GB). Supersedes GATE 1 "32 GB floor" conclusion. States 16 GB viable / 32 GB recommended; not mandated. Documents the accepted v2-OS-OTA model-sharing tradeoff.
- Write `docs/architecture/0005-ab-selector-tryboot-root-swap.md`: ADR correcting PART-02/SC3. Records Pi-native `tryboot_a_b=1` + file-level slot distinction inside one shared /boot. Persistent default is the `root=` in `config.txt`, flipped by `arlowe-ab`. `tryboot.txt` + one-shot `reboot "0 tryboot"` reserved for Phase 9 OTA trial-boot.
- Amend `.planning/REQUIREMENTS.md`: PART-01 four→FIVE partitions; PART-02 U-Boot/active.txt→tryboot root=; PART-03 empty-B→minimal recovery rootfs; PART-05 grow-to-fill models + fixed owner-state; IMAGE-02 shared models partition note + first-boot hook wording; IMAGE-03 input reproducibility reframe (no image-hash gate); IMAGE-04 16 GB viable / 32 GB recommended.
- Amend `.planning/ROADMAP.md` Phase 6 block: Goal, SC1, SC2, SC3, SC5 aligned to locked decisions. Phase 8 block untouched.

## Verification

All 18 plan-specified greps passed before commit:
- ADR-0004 contains: "shared", "5.51", "grow-to-fill", "16 GB"
- ADR-0005 contains: "tryboot_a_b", "root="
- REQUIREMENTS.md has "single shared read-only", "FIVE partitions", "tryboot", "first-boot hook armed"; no "four partitions", "pairing daemon armed", "32 GB floor/minimum"
- ROADMAP.md has "FIVE partitions", "first-boot hook armed"; no "16 GB budget", "four partitions"

Closes #105