### PR TITLE
feat(image): tryboot root= selector + arlowe-ab CLI + slot-B recovery stub

### DIFF
--- a/.planning/phases/06-image-build-with-a-b-partitions/06-05-SUMMARY.md
+++ b/.planning/phases/06-image-build-with-a-b-partitions/06-05-SUMMARY.md
@@ -1,0 +1,39 @@
+---
+plan: 06-05
+phase: 06-image-build-with-a-b-partitions
+status: complete
+---
+
+## Summary
+
+Implemented the A/B boot selector (tryboot root= swap) and slot-B recovery stub, completing Phase 6 Wave 3.
+
+## Artifacts produced
+
+| File | What it does |
+|------|-------------|
+| `scripts/lib/boot-config.sh` | Build-time library: writes `config.txt` (tryboot_a_b=1), `cmdline.txt` (default root=slot-A), `tryboot.txt` (Phase 9 reserved), `tryboot_cmdline.txt` (slot-B cmdline) into p1 FAT; installs PARTUUID map into slot-A /etc/arlowe/ |
+| `runtime/cli/arlowe-ab` | On-device CLI: `status`, `set A\|B`, `switch A\|B`; rewrites root= in cmdline.txt; Phase 9 OTA seam |
+| `scripts/lib/recovery-stub.sh` | Build-time library: clones slot A → slot B, prunes runtime, installs recovery script + service + WhisPlay driver, writes slot-B fstab (models nofail), writes PARTUUID map, enables service |
+| `runtime/recovery/arlowe-recovery.sh` | Recovery action: Whisplay face + serial/journal state print + root= reset to A + self-reboot |
+| `runtime/recovery/arlowe-recovery.service` | Systemd oneshot, enabled in slot B's multi-user.target.wants |
+| `docs/operations/phase-6-ab-recovery.md` | Operations doc: selector mechanism, arlowe-ab usage, SC3 procedure, slot-B experience, Pi 5 freeze caveat, SD-card fallback |
+
+## Design decisions
+
+- `arlowe-ab` reads `/etc/arlowe/ab-partuuid-map` (installed at build time) to resolve A/B names → PARTUUIDs without needing a build host at runtime.
+- The root= rewrite primitive is the same in both `arlowe-ab set` and `arlowe-recovery.sh` (shared pattern, not a shared import — keeps slot B's dep surface tiny).
+- Recovery stub approach: copy slot A + prune (avoids second debootstrap, keeps B well under 300 MB of active content).
+- `tryboot.txt` laid down but NOT used by arlowe-ab — Phase 9 OTA seam preserved.
+- `ab` added to `install-arlowe-cli.sh`'s CLIS array so the symlink is created on-device.
+
+## Verification results
+
+- `bash -n`: all scripts pass syntax check
+- `shellcheck --severity=warning`: clean across all new scripts
+- All plan `<verify>` checks pass (tryboot_a_b, root=, whisplay, oneshot, models/nofail, extension hooks, ops doc)
+
+## What remains
+
+- On-hardware A→B→recovery→A verification (deferred to plan 06-06 on-hardware checkpoint per plan)
+- Phase 9 OTA will overwrite `tryboot.txt` and use `arlowe-ab` as the flip primitive

--- a/docs/operations/phase-6-ab-recovery.md
+++ b/docs/operations/phase-6-ab-recovery.md
@@ -1,0 +1,181 @@
+# Phase 6 A/B boot selector + slot-B recovery
+
+**Status:** Implementation reference — covers the tryboot root= swap selector,
+the `arlowe-ab` CLI, and the slot-B recovery experience.
+
+---
+
+## A/B selector overview (ADR-0005)
+
+The persistent A/B default is the `root=` (via `cmdline.txt`) inside the single
+shared `/boot/firmware` FAT partition (p1). Per ADR-0005:
+
+- `config.txt` sets `tryboot_a_b=1` and includes `cmdline.txt`.
+- `cmdline.txt` holds the active `root=PARTUUID=<uuid>` line. This is the only
+  field that changes between slot A and slot B — all other kernel flags are
+  identical.
+- `arlowe-ab` is the sole path for changing the persistent default. It rewrites
+  only the `root=` in `cmdline.txt` and reboots. No other file is touched.
+- The A/B selector swaps **only the rootfs** `root=`. Both slot A and slot B
+  mount the **same shared read-only models partition** (`/opt/arlowe/models`)
+  via their respective `/etc/fstab` entries. The selector does not touch the
+  models mount (ADR-0004).
+
+### tryboot.txt — RESERVED for Phase 9 OTA
+
+`tryboot.txt` is present in `/boot/firmware` and mirrors the slot-B parameters
+so that a manual `reboot 0 tryboot` lands on the recovery rootfs safely. This
+file is **not used by `arlowe-ab`** for persistent flips. Phase 9 OTA will
+overwrite `tryboot.txt` with trial-slot parameters before issuing
+`reboot 0 tryboot`. Do not modify `tryboot.txt` manually.
+
+### Boot config files
+
+| File | Purpose |
+|------|---------|
+| `config.txt` | Sets `tryboot_a_b=1`; includes `cmdline.txt` |
+| `cmdline.txt` | Active `root=` line; edited by `arlowe-ab` |
+| `tryboot.txt` | Reserved for Phase 9 OTA one-shot trial-boot |
+| `tryboot_cmdline.txt` | Cmdline for the tryboot one-shot path (slot B) |
+
+---
+
+## arlowe-ab — A/B slot selector CLI
+
+Installed at `/usr/local/sbin/arlowe-ab` via `install-arlowe-cli.sh`.
+Must be run as root.
+
+### Usage
+
+```
+arlowe-ab status          # print current persistent default slot + PARTUUID
+arlowe-ab set A|B         # rewrite cmdline.txt root=; no reboot
+arlowe-ab switch A|B      # set + reboot
+```
+
+### Manual A→B flip (SC3 verification procedure)
+
+1. SSH into the device as root (or `sudo su`).
+2. Check current slot:
+   ```
+   arlowe-ab status
+   # → Persistent default: slot A (root=PARTUUID=<uuid>)
+   ```
+3. Flip to slot B and reboot:
+   ```
+   arlowe-ab switch B
+   ```
+4. Device reboots into slot B (recovery rootfs in v1).
+5. The slot-B recovery service runs: shows a recovery face on the Whisplay,
+   logs state, resets the persistent default back to slot A, and reboots again.
+6. After the self-heal reboot, the device is back in slot A:
+   ```
+   arlowe-ab status
+   # → Persistent default: slot A (root=PARTUUID=<uuid>)
+   ```
+
+### PARTUUID map
+
+`arlowe-ab` reads `/etc/arlowe/ab-partuuid-map` to resolve slot A/B names to
+real PARTUUIDs. This file is written by `boot-config.sh` at image build time
+and is present in both slot A and slot B rootfs images.
+
+### Implementation notes
+
+- Mounts `/boot/firmware` read-write before writing, then remounts read-only.
+- Writes `cmdline.txt` atomically (write to `.tmp`, rename, sync) to minimise
+  partial-write exposure on power-loss mid-flip.
+- Does not use `reboot 0 tryboot` or `tryboot.txt` — those are Phase 9 OTA only.
+
+---
+
+## Slot-B recovery rootfs
+
+Slot B (`system_b`, p3) holds a minimal model-free recovery rootfs in v1. It is
+a pruned copy of slot A with the Arlowe runtime and models removed, leaving only
+the OS, Python, the WhisPlay driver, and the recovery service.
+
+### What slot B does at boot
+
+`arlowe-recovery.service` is a systemd oneshot enabled in slot B's
+`multi-user.target.wants`. It runs `arlowe-recovery.sh`, which:
+
+1. Shows a static recovery face on the Whisplay display (red background,
+   "RECOVERY / Resetting to slot A / Rebooting...").
+2. Prints recovery state to serial (`/dev/ttyAMA0`) and journal: hostname,
+   kernel version, uptime, current cmdline, PARTUUID map.
+3. Resets the persistent default to slot A: mounts `/boot/firmware` read-write,
+   rewrites `root=` in `cmdline.txt` back to slot A's PARTUUID, syncs, remounts
+   read-only.
+4. After 15 seconds (configurable via `RECOVERY_REBOOT_DELAY`), reboots into
+   slot A.
+
+### Recovery experience — what you will see
+
+- The Whisplay lights up with a red recovery screen.
+- Serial console (`/dev/ttyAMA0`, 115200 baud) and `journalctl` show
+  `[arlowe-recovery]` lines.
+- Device reboots into slot A after ~15 seconds.
+
+### Models partition in slot B
+
+Slot B's `/etc/fstab` carries the same shared models partition entry as slot A
+(`PARTUUID=<models-uuid> /opt/arlowe/models ext4 ro,noatime,nofail`), but with
+`nofail` set. Recovery boots and runs correctly even if the models partition is
+absent or unmounted — the recovery face is a static framebuffer draw that does
+not depend on any model artifacts.
+
+### Pi 5 freeze caveat
+
+If the Pi 5 bootloader encounters a corrupted or incompatible kernel, it may
+**freeze rather than auto-falling back to the previous slot**. This is a Pi 5
+firmware characteristic (no automatic rollback on kernel failure in v1 —
+boot-count rollback is deferred to Phase 9).
+
+**If the device freezes after a slot flip:** power-cycle the device. The device
+will resume from `/boot/firmware/cmdline.txt`; if the persistent default was
+reset to slot A before the freeze, it will boot into slot A normally.
+
+---
+
+## Recovery SD-card fallback (PART-06)
+
+If slot A is also corrupted or the device is otherwise unrecoverable via the
+A/B self-heal path, the v1 fallback is to flash a fresh image to a spare SD
+card.
+
+### Procedure
+
+1. Download or build a fresh `arlowe.img`:
+   - Use the pre-built release artifact, or
+   - Run `scripts/build-image.sh` on an arm64 Linux build host.
+
+2. Flash to a spare SD card (minimum 16 GB; 32 GB recommended):
+   ```bash
+   # With dd (slow, fully-corect):
+   sudo dd if=arlowe.img of=/dev/sdX bs=4M status=progress conv=fsync
+   # With bmaptool (fast, sparse-aware — recommended):
+   sudo bmaptool copy arlowe.img /dev/sdX
+   ```
+
+3. Insert the spare SD card into the device and power on. The device will boot
+   into slot A on the freshly flashed image.
+
+4. After recovery, transfer owner-state from the original SD card if needed
+   (mount p4 `owner_state` from the old card and rsync `/var/lib/arlowe/`).
+
+See `docs/operations/phase-6-partitions.md` for partition layout reference.
+
+---
+
+## References
+
+- ADR-0005: `docs/architecture/0005-ab-selector-tryboot-root-swap.md`
+- ADR-0004: `docs/architecture/0004-shared-model-partition-sizing.md`
+- Boot config library: `scripts/lib/boot-config.sh`
+- Recovery stub library: `scripts/lib/recovery-stub.sh`
+- A/B CLI: `runtime/cli/arlowe-ab`
+- Recovery service: `runtime/recovery/arlowe-recovery.service`
+- Recovery script: `runtime/recovery/arlowe-recovery.sh`
+- Partition layout: `docs/operations/phase-6-partitions.md`
+- Build script: `scripts/build-image.sh`

--- a/runtime/cli/arlowe-ab
+++ b/runtime/cli/arlowe-ab
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# runtime/cli/arlowe-ab
+#
+# On-device A/B slot selector CLI (ADR-0005).
+# Installed as /usr/local/sbin/arlowe-ab via install-arlowe-cli.sh.
+#
+# The persistent A/B default is the root= in /boot/firmware/cmdline.txt.
+# This CLI is the sole controlled path for changing the persistent default.
+# Phase 9 OTA calls this CLI rather than writing cmdline.txt directly.
+#
+# Commands:
+#   arlowe-ab status      — print current persistent default slot + PARTUUID
+#   arlowe-ab set A|B     — rewrite cmdline.txt root= to target slot; no reboot
+#   arlowe-ab switch A|B  — set + reboot (triggers systemd reboot)
+#
+# NOTE: This CLI does NOT use "reboot 0 tryboot" or tryboot.txt.
+# The tryboot one-shot path is RESERVED for Phase 9 OTA trial-boot.
+# Persistent flips use cmdline.txt exclusively (per ADR-0005).
+#
+# Root is required — /boot/firmware must be remounted rw to write cmdline.txt.
+set -euo pipefail
+
+BOOT_MOUNT="${BOOT_MOUNT:-/boot/firmware}"
+CMDLINE_FILE="${BOOT_MOUNT}/cmdline.txt"
+
+# PARTUUID map written at build time and carried by each rootfs as a reference.
+# The map lets arlowe-ab resolve A/B symbolic names to the real PARTUUIDs.
+PARTUUID_MAP="${PARTUUID_MAP:-/etc/arlowe/ab-partuuid-map}"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+die() { printf 'arlowe-ab: %s\n' "$*" >&2; exit 1; }
+
+require_root() {
+    [[ "${EUID}" -eq 0 ]] || die "must be run as root"
+}
+
+mount_boot_rw() {
+    mount -o remount,rw "${BOOT_MOUNT}"
+}
+
+mount_boot_ro() {
+    mount -o remount,ro "${BOOT_MOUNT}" 2>/dev/null || true
+}
+
+# Read a PARTUUID from the on-device map file.
+lookup_partuuid() {
+    local slot="$1"
+    [[ -f "${PARTUUID_MAP}" ]] || die "PARTUUID map not found at ${PARTUUID_MAP}"
+    local key="PARTUUID_${slot}"
+    local val
+    val="$(grep "^${key}=" "${PARTUUID_MAP}" | cut -d= -f2)"
+    [[ -n "${val}" ]] || die "PARTUUID for slot ${slot} not found in ${PARTUUID_MAP}"
+    printf '%s' "${val}"
+}
+
+# Read the current root= PARTUUID from cmdline.txt.
+current_partuuid() {
+    [[ -f "${CMDLINE_FILE}" ]] || die "cmdline.txt not found at ${CMDLINE_FILE}"
+    local partuuid
+    partuuid="$(grep -oP '(?<=root=PARTUUID=)[^\s]+' "${CMDLINE_FILE}" || true)"
+    [[ -n "${partuuid}" ]] || die "no root=PARTUUID= found in ${CMDLINE_FILE}"
+    printf '%s' "${partuuid}"
+}
+
+# Resolve the current PARTUUID to slot A or B by comparing to the map.
+partuuid_to_slot() {
+    local partuuid="$1"
+    local puuid_a puuid_b
+    puuid_a="$(lookup_partuuid A)"
+    puuid_b="$(lookup_partuuid B)"
+    if [[ "${partuuid}" == "${puuid_a}" ]]; then
+        printf 'A'
+    elif [[ "${partuuid}" == "${puuid_b}" ]]; then
+        printf 'B'
+    else
+        printf 'unknown'
+    fi
+}
+
+validate_slot_arg() {
+    local slot="$1"
+    [[ "${slot}" == "A" || "${slot}" == "B" ]] \
+        || die "slot must be A or B, got: ${slot}"
+}
+
+# Atomically rewrite root=PARTUUID=<old> to root=PARTUUID=<new> in cmdline.txt.
+# Atomic: write to a temp file in the same FAT directory, then rename.
+# FAT does not support true atomic rename, but sync after write minimises the
+# partial-write window (per ADR-0005 "must sync before rebooting").
+rewrite_root_partuuid() {
+    local target_partuuid="$1"
+    local tmp="${CMDLINE_FILE}.tmp"
+
+    [[ -f "${CMDLINE_FILE}" ]] || die "cmdline.txt not found at ${CMDLINE_FILE}"
+
+    sed "s|root=PARTUUID=[^ ]*|root=PARTUUID=${target_partuuid}|" \
+        "${CMDLINE_FILE}" > "${tmp}"
+    mv "${tmp}" "${CMDLINE_FILE}"
+    sync
+}
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+cmd_status() {
+    local partuuid slot
+    partuuid="$(current_partuuid)"
+    slot="$(partuuid_to_slot "${partuuid}")"
+    printf 'Persistent default: slot %s (root=PARTUUID=%s)\n' "${slot}" "${partuuid}"
+}
+
+cmd_set() {
+    local slot="$1"
+    validate_slot_arg "${slot}"
+    require_root
+
+    local target_partuuid
+    target_partuuid="$(lookup_partuuid "${slot}")"
+
+    mount_boot_rw
+    rewrite_root_partuuid "${target_partuuid}"
+    mount_boot_ro
+
+    printf 'Persistent default set to slot %s (root=PARTUUID=%s)\n' "${slot}" "${target_partuuid}"
+}
+
+cmd_switch() {
+    local slot="$1"
+    cmd_set "${slot}"
+    printf 'Rebooting into slot %s...\n' "${slot}"
+    systemctl reboot
+}
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+usage() {
+    cat <<'EOF'
+Usage: arlowe-ab <command> [slot]
+
+Commands:
+  status        Print current persistent default slot and PARTUUID
+  set A|B       Rewrite cmdline.txt root= to target slot; no reboot
+  switch A|B    set + reboot
+
+The persistent A/B default is the root= in /boot/firmware/cmdline.txt.
+tryboot.txt / "reboot 0 tryboot" are reserved for Phase 9 OTA trial-boot.
+EOF
+}
+
+[[ $# -ge 1 ]] || { usage; exit 1; }
+
+cmd="$1"
+shift
+
+case "${cmd}" in
+    status)
+        cmd_status
+        ;;
+    set)
+        [[ $# -eq 1 ]] || { usage; exit 1; }
+        cmd_set "$1"
+        ;;
+    switch)
+        [[ $# -eq 1 ]] || { usage; exit 1; }
+        cmd_switch "$1"
+        ;;
+    *)
+        usage
+        exit 1
+        ;;
+esac

--- a/runtime/recovery/arlowe-recovery.service
+++ b/runtime/recovery/arlowe-recovery.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Arlowe slot-B recovery action
+Documentation=https://github.com/focal55/arlowe-firmware/blob/main/docs/operations/phase-6-ab-recovery.md
+# Only meaningful when slot B is the active root. Runs once at boot, then
+# resets the persistent default to slot A and reboots into slot A.
+After=local-fs.target network.target
+# The models partition is nofail in slot B; recovery must not depend on it.
+Wants=local-fs.target
+
+[Service]
+Type=oneshot
+# Recovery is a one-shot, non-repeating sequence.
+RemainAfterExit=no
+ExecStart=/opt/arlowe/runtime/recovery/arlowe-recovery.sh
+# Allow generous time: face draw + state print + 15s delay + reboot.
+TimeoutStartSec=120
+StandardOutput=journal+console
+StandardError=journal+console
+
+[Install]
+WantedBy=multi-user.target

--- a/runtime/recovery/arlowe-recovery.service
+++ b/runtime/recovery/arlowe-recovery.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=Arlowe slot-B recovery action
-Documentation=https://github.com/focal55/arlowe-firmware/blob/main/docs/operations/phase-6-ab-recovery.md
 # Only meaningful when slot B is the active root. Runs once at boot, then
 # resets the persistent default to slot A and reboots into slot A.
 After=local-fs.target network.target

--- a/runtime/recovery/arlowe-recovery.sh
+++ b/runtime/recovery/arlowe-recovery.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# runtime/recovery/arlowe-recovery.sh
+#
+# Slot-B recovery action — runs as a systemd oneshot at boot when slot B
+# is the active root (arlowe-recovery.service).
+#
+# Actions (in order):
+#   1. Show a static recovery face on the Whisplay display
+#   2. Print recovery state to serial console + journal
+#   3. Reset the persistent default to slot A (rewrite root= in cmdline.txt)
+#   4. After a brief delay, reboot so the device self-heals into slot A
+#
+# This script does NOT depend on the shared models partition (/opt/arlowe/models).
+# The recovery face is a static framebuffer draw using only the WhisPlay driver.
+# The models partition fstab entry in slot B is marked nofail — it is absent
+# here by design and recovery must function without it.
+#
+# If the Pi 5 bootloader freezes on a corrupted kernel (a Pi 5 hardware
+# characteristic — it does not auto-fall-back on bad kernels, it hangs):
+#   power-cycle the device to recover.
+set -euo pipefail
+
+BOOT_MOUNT="${BOOT_MOUNT:-/boot/firmware}"
+CMDLINE_FILE="${BOOT_MOUNT}/cmdline.txt"
+PARTUUID_MAP="${PARTUUID_MAP:-/etc/arlowe/ab-partuuid-map}"
+WHISPLAY_DRIVER_PATH="${ARLOWE_WHISPLAY_DRIVER_PATH:-/opt/arlowe/third_party/whisplay-driver}"
+
+# Delay before self-reboot (seconds) — long enough for logs to flush.
+RECOVERY_REBOOT_DELAY="${RECOVERY_REBOOT_DELAY:-15}"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+log_recovery() {
+    # Write to both the journal (systemd captures stdout) and the serial console.
+    local msg="[arlowe-recovery] $*"
+    printf '%s\n' "${msg}"
+    # /dev/ttyAMA0 is the Pi 5 primary UART (serial0 alias). Write best-effort;
+    # if the console is not available, continue without failing.
+    printf '%s\n' "${msg}" > /dev/ttyAMA0 2>/dev/null || true
+}
+
+mount_boot_rw() {
+    mount -o remount,rw "${BOOT_MOUNT}"
+}
+
+mount_boot_ro() {
+    mount -o remount,ro "${BOOT_MOUNT}" 2>/dev/null || true
+}
+
+lookup_partuuid_a() {
+    [[ -f "${PARTUUID_MAP}" ]] || { log_recovery "PARTUUID map not found — cannot reset to slot A"; return 1; }
+    local val
+    val="$(grep '^PARTUUID_A=' "${PARTUUID_MAP}" | cut -d= -f2)"
+    [[ -n "${val}" ]] || { log_recovery "PARTUUID_A not found in map"; return 1; }
+    printf '%s' "${val}"
+}
+
+# Rewrite root=PARTUUID=<current> to root=PARTUUID=<slot-A> in cmdline.txt.
+# Same logic as arlowe-ab set A — this shares the rewrite primitive.
+reset_persistent_default_to_a() {
+    local puuid_a
+    puuid_a="$(lookup_partuuid_a)"
+
+    local tmp="${CMDLINE_FILE}.tmp"
+    [[ -f "${CMDLINE_FILE}" ]] || { log_recovery "cmdline.txt not found at ${CMDLINE_FILE}"; return 1; }
+
+    sed "s|root=PARTUUID=[^ ]*|root=PARTUUID=${puuid_a}|" \
+        "${CMDLINE_FILE}" > "${tmp}"
+    mv "${tmp}" "${CMDLINE_FILE}"
+    sync
+    log_recovery "persistent default reset to slot A (root=PARTUUID=${puuid_a})"
+}
+
+# ---------------------------------------------------------------------------
+# Step 1: Show recovery face on Whisplay
+#
+# Uses the vendored WhisPlay driver via a minimal inline Python call.
+# Draws a static recovery indicator (red background + text) on the 240x280 LCD.
+# Does NOT import runtime/face/face.py — keeps slot B's dependency surface tiny.
+# ---------------------------------------------------------------------------
+show_recovery_face() {
+    if ! command -v python3 >/dev/null 2>&1; then
+        log_recovery "python3 not found — skipping Whisplay recovery face"
+        return 0
+    fi
+
+    python3 - "${WHISPLAY_DRIVER_PATH}" <<'PYEOF' 2>/dev/null || log_recovery "Whisplay face draw failed (non-fatal)"
+import sys, os
+driver_path = sys.argv[1]
+if driver_path not in sys.path:
+    sys.path.insert(0, driver_path)
+try:
+    from WhisPlay import WhisPlayBoard
+    from PIL import Image, ImageDraw, ImageFont
+    board = WhisPlayBoard()
+    img = Image.new("RGB", (240, 280), (180, 30, 30))
+    draw = ImageDraw.Draw(img)
+    # Recovery indicator: bold warning text centered on the display
+    draw.rectangle([10, 90, 230, 190], fill=(220, 60, 60))
+    draw.text((120, 115), "RECOVERY", fill=(255, 255, 255), anchor="mm")
+    draw.text((120, 145), "Resetting to slot A", fill=(230, 230, 230), anchor="mm")
+    draw.text((120, 165), "Rebooting...", fill=(200, 200, 200), anchor="mm")
+    board.ShowImage(img)
+except Exception as e:
+    print(f"face draw error: {e}", file=sys.stderr)
+    sys.exit(1)
+PYEOF
+    log_recovery "recovery face shown on Whisplay"
+}
+
+# ---------------------------------------------------------------------------
+# Step 2: Print recovery state to serial + journal
+# ---------------------------------------------------------------------------
+print_recovery_state() {
+    log_recovery "=== SLOT B RECOVERY MODE ==="
+    log_recovery "hostname: $(hostname 2>/dev/null || echo unknown)"
+    log_recovery "kernel:   $(uname -r 2>/dev/null || echo unknown)"
+    log_recovery "uptime:   $(uptime 2>/dev/null || echo unknown)"
+
+    if [[ -f "${CMDLINE_FILE}" ]]; then
+        log_recovery "current cmdline.txt: $(cat "${CMDLINE_FILE}")"
+    else
+        log_recovery "cmdline.txt not readable at ${CMDLINE_FILE}"
+    fi
+
+    if [[ -f "${PARTUUID_MAP}" ]]; then
+        log_recovery "PARTUUID map:"
+        while IFS= read -r line; do
+            log_recovery "  ${line}"
+        done < "${PARTUUID_MAP}"
+    else
+        log_recovery "PARTUUID map not found at ${PARTUUID_MAP}"
+    fi
+
+    log_recovery "==========================="
+}
+
+# ---------------------------------------------------------------------------
+# Main recovery sequence
+# ---------------------------------------------------------------------------
+log_recovery "recovery boot detected — starting recovery sequence"
+
+show_recovery_face
+
+print_recovery_state
+
+log_recovery "resetting persistent default to slot A..."
+mount_boot_rw
+reset_persistent_default_to_a
+mount_boot_ro
+
+log_recovery "recovery complete; rebooting into slot A in ${RECOVERY_REBOOT_DELAY}s"
+log_recovery "(if the device freezes after reboot, power-cycle to recover — Pi 5 does not auto-fall-back on a bad kernel)"
+sleep "${RECOVERY_REBOOT_DELAY}"
+systemctl reboot

--- a/scripts/lib/boot-config.sh
+++ b/scripts/lib/boot-config.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# scripts/lib/boot-config.sh
+#
+# Build-time library: lays the tryboot A/B boot configuration into the shared
+# /boot FAT partition (p1) of the assembled image.
+#
+# Called from build-image.sh's extension hook (Step 4b):
+#   source scripts/lib/boot-config.sh
+#   write_boot_config <partuuid-map-file> <output-img>
+#
+# The partuuid-map file must contain (produced by partition-image.sh):
+#   PARTUUID_BOOT=<uuid>
+#   PARTUUID_A=<uuid>
+#   PARTUUID_B=<uuid>
+#   PARTUUID_MODELS=<uuid>
+#
+# Per ADR-0005, the persistent A/B default is the root= in config.txt:
+#   - config.txt sets tryboot_a_b=1; cmdline.txt points root= at slot A PARTUUID
+#   - tryboot.txt is RESERVED for Phase 9 one-shot OTA trial-boot
+#   - arlowe-ab rewrites config.txt's cmdline= to flip the persistent default
+#   - The selector swaps only root= (rootfs slot); the models mount lives in
+#     each slot's fstab, not in cmdline, and is not touched by this script
+#
+# This library is sourced by build-image.sh; it is NOT executable standalone.
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    echo "boot-config.sh is a library; source it from build-image.sh." >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# write_boot_config <partuuid-map-file> <output-img>
+#
+# Mounts the FAT boot partition (p1) from the image and writes:
+#   config.txt   — tryboot_a_b=1; persistent default cmdline= pointing root=
+#                  at slot A's PARTUUID (factory default)
+#   cmdline.txt  — the active root= line that arlowe-ab edits on the device
+#   tryboot.txt  — RESERVED for Phase 9; in v1 mirrors the B/recovery path so
+#                  "reboot 0 tryboot" lands somewhere sane, but arlowe-ab does
+#                  NOT use this one-shot path for persistent flips
+# ---------------------------------------------------------------------------
+write_boot_config() {
+    local partuuid_map="$1"
+    local output_img="$2"
+
+    [[ -f "${partuuid_map}" ]] || { echo "boot-config.sh: partuuid-map not found: ${partuuid_map}" >&2; return 1; }
+    [[ -f "${output_img}" ]]   || { echo "boot-config.sh: output-img not found: ${output_img}" >&2; return 1; }
+
+    local puuid_a puuid_b
+    puuid_a="$(grep '^PARTUUID_A=' "${partuuid_map}" | cut -d= -f2)"
+    puuid_b="$(grep '^PARTUUID_B=' "${partuuid_map}" | cut -d= -f2)"
+
+    [[ -n "${puuid_a}" ]] || { echo "boot-config.sh: PARTUUID_A missing from map" >&2; return 1; }
+    [[ -n "${puuid_b}" ]] || { echo "boot-config.sh: PARTUUID_B missing from map" >&2; return 1; }
+
+    echo "[boot-config] slot A PARTUUID: ${puuid_a}"
+    echo "[boot-config] slot B PARTUUID: ${puuid_b}"
+
+    local loop_dev mnt_boot mnt_a
+    loop_dev="$(sudo losetup -f --show -P "${output_img}")"
+
+    _bconf_cleanup() {
+        sudo umount "${mnt_boot}" 2>/dev/null || true
+        sudo umount "${mnt_a}" 2>/dev/null || true
+        sudo losetup -d "${loop_dev}" 2>/dev/null || true
+        rmdir "${mnt_boot}" 2>/dev/null || true
+        rmdir "${mnt_a}" 2>/dev/null || true
+    }
+    trap _bconf_cleanup RETURN ERR
+
+    mnt_boot="$(mktemp -d)"
+    sudo mount "${loop_dev}p1" "${mnt_boot}"
+
+    _bconf_write_config "${mnt_boot}" "${puuid_a}" "${puuid_b}"
+
+    sudo umount "${mnt_boot}"
+    rmdir "${mnt_boot}"
+    mnt_boot=""
+
+    # Install the PARTUUID map into slot A's /etc/arlowe/ so arlowe-ab can
+    # resolve A/B slot names to PARTUUIDs at runtime without needing the build host.
+    mnt_a="$(mktemp -d)"
+    sudo mount "${loop_dev}p2" "${mnt_a}"
+    sudo install -d -m 0755 "${mnt_a}/etc/arlowe"
+    sudo install -m 0644 "${partuuid_map}" "${mnt_a}/etc/arlowe/ab-partuuid-map"
+    echo "[boot-config] PARTUUID map installed at /etc/arlowe/ab-partuuid-map in slot A"
+    sudo umount "${mnt_a}"
+    rmdir "${mnt_a}"
+    mnt_a=""
+
+    sudo sync
+    sudo losetup -d "${loop_dev}" 2>/dev/null || true
+    trap - RETURN ERR
+
+    echo "[boot-config] tryboot boot configuration written to /boot (p1)"
+}
+
+# ---------------------------------------------------------------------------
+# Internal: write the three boot config files into the mounted FAT partition
+# ---------------------------------------------------------------------------
+_bconf_write_config() {
+    local mnt="$1"
+    local puuid_a="$2"
+    local puuid_b="$3"
+
+    # Shared kernel command-line options for both slots.
+    # root= is the only slot-discriminating field; everything else is identical.
+    # The models partition (/opt/arlowe/models) is mounted via each slot's fstab
+    # (by PARTUUID, ro,noatime) — it is NOT in the kernel cmdline.
+    local cmdline_common="console=serial0,115200 console=tty1 fsck.repair=yes rootwait"
+
+    # config.txt — persistent default; cmdline= points root= at slot A PARTUUID.
+    # tryboot_a_b=1 enables file-level A/B within the single shared /boot FAT.
+    # When the Pi firmware sees this flag + "reboot 0 tryboot", it reads
+    # tryboot.txt instead of config.txt for that one boot (Phase 9 OTA path).
+    sudo tee "${mnt}/config.txt" >/dev/null <<EOF
+# Arlowe A/B boot configuration (ADR-0005)
+# Managed by arlowe-ab — do not edit manually.
+#
+# tryboot_a_b=1: enables file-level A/B within one shared /boot FAT partition.
+# The persistent A/B default is the root= below (in cmdline.txt, referenced
+# here). arlowe-ab flips the persistent default by rewriting cmdline.txt.
+#
+# tryboot.txt is RESERVED for Phase 9 OTA one-shot trial-boot.
+# arlowe-ab does NOT use "reboot 0 tryboot" for persistent flips.
+tryboot_a_b=1
+
+[pi5]
+# Pi 5 — AARCH64 kernel
+kernel=kernel_2712.img
+arm_64bit=1
+[all]
+# Shared cmdline for both slots (root= overridden by arlowe-ab in cmdline.txt)
+include cmdline.txt
+EOF
+
+    # cmdline.txt — the active root= line. arlowe-ab rewrites only root= here
+    # to flip between slot A and slot B. All other flags stay constant.
+    sudo tee "${mnt}/cmdline.txt" >/dev/null <<EOF
+${cmdline_common} root=PARTUUID=${puuid_a}
+EOF
+
+    # tryboot.txt — RESERVED for Phase 9 OTA one-shot trial-boot.
+    # In v1 this mirrors the slot-B (recovery) boot parameters so that
+    # "reboot 0 tryboot" lands on slot B rather than hanging. arlowe-ab
+    # does NOT use this file for persistent flips.
+    sudo tee "${mnt}/tryboot.txt" >/dev/null <<EOF
+# tryboot.txt — RESERVED for Phase 9 OTA one-shot trial-boot.
+#
+# This file is loaded instead of config.txt when the Pi firmware sees the
+# "tryboot" flag set (via "reboot 0 tryboot"). In v1 it mirrors slot B so
+# that a manual "reboot 0 tryboot" lands on the recovery rootfs safely.
+#
+# Phase 9 OTA will overwrite this file with the trial OS slot's parameters
+# before issuing "reboot 0 tryboot". arlowe-ab DOES NOT write or read this
+# file for persistent slot flips — it uses cmdline.txt exclusively.
+tryboot_a_b=1
+
+[pi5]
+kernel=kernel_2712.img
+arm_64bit=1
+[all]
+include tryboot_cmdline.txt
+EOF
+
+    # tryboot_cmdline.txt — cmdline for the one-shot tryboot path (slot B).
+    sudo tee "${mnt}/tryboot_cmdline.txt" >/dev/null <<EOF
+${cmdline_common} root=PARTUUID=${puuid_b}
+EOF
+
+    echo "[boot-config] wrote config.txt (tryboot_a_b=1, default root=slot-A)"
+    echo "[boot-config] wrote cmdline.txt (root=PARTUUID=${puuid_a})"
+    echo "[boot-config] wrote tryboot.txt (Phase 9 reserved; mirrors slot-B)"
+    echo "[boot-config] wrote tryboot_cmdline.txt (slot-B PARTUUID)"
+}

--- a/scripts/lib/recovery-stub.sh
+++ b/scripts/lib/recovery-stub.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# scripts/lib/recovery-stub.sh
+#
+# Build-time library: writes the minimal slot-B recovery rootfs into p3 of
+# the assembled image, then enables the recovery service inside it.
+#
+# Called from build-image.sh's extension hook (Step 4b), AFTER write_boot_config:
+#   source scripts/lib/recovery-stub.sh
+#   write_recovery_stub <partuuid-map-file> <output-img>
+#
+# Approach: copy slot A (already in p2) into slot B (p3), then aggressively
+# prune everything that is not needed for the recovery action — keeps B minimal
+# (~300 MB target) and avoids a second debootstrap or rootfs build.
+# The recovery action itself (arlowe-recovery.sh + .service) is installed from
+# the repo's runtime/recovery/ directory. The WhisPlay driver minimal subset is
+# copied from third_party/whisplay-driver/.
+#
+# Slot-B fstab carries:
+#   - /boot/firmware (shared FAT, PARTUUID_BOOT)
+#   - /var/lib/arlowe (owner-state, PARTUUID_OWNER, noatime)
+#   - /opt/arlowe/models (shared models, PARTUUID_MODELS, ro,noatime,nofail)
+#     nofail is required: recovery must boot even if the models partition is
+#     absent or unmounted — the recovery action is model-free by design.
+#
+# This library is sourced by build-image.sh; it is NOT executable standalone.
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    echo "recovery-stub.sh is a library; source it from build-image.sh." >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# write_recovery_stub <partuuid-map-file> <output-img>
+# ---------------------------------------------------------------------------
+write_recovery_stub() {
+    local partuuid_map="$1"
+    local output_img="$2"
+
+    [[ -f "${partuuid_map}" ]] || { echo "recovery-stub.sh: partuuid-map not found: ${partuuid_map}" >&2; return 1; }
+    [[ -f "${output_img}" ]]   || { echo "recovery-stub.sh: output-img not found: ${output_img}" >&2; return 1; }
+
+    local puuid_boot puuid_b puuid_owner puuid_models
+    puuid_boot="$(grep '^PARTUUID_BOOT=' "${partuuid_map}"   | cut -d= -f2)"
+    puuid_b="$(grep '^PARTUUID_B=' "${partuuid_map}"         | cut -d= -f2)"
+    puuid_owner="$(grep '^PARTUUID_OWNER=' "${partuuid_map}" | cut -d= -f2)"
+    puuid_models="$(grep '^PARTUUID_MODELS=' "${partuuid_map}" | cut -d= -f2)"
+
+    [[ -n "${puuid_boot}" ]]   || { echo "recovery-stub.sh: PARTUUID_BOOT missing"   >&2; return 1; }
+    [[ -n "${puuid_b}" ]]      || { echo "recovery-stub.sh: PARTUUID_B missing"      >&2; return 1; }
+    [[ -n "${puuid_owner}" ]]  || { echo "recovery-stub.sh: PARTUUID_OWNER missing"  >&2; return 1; }
+    [[ -n "${puuid_models}" ]] || { echo "recovery-stub.sh: PARTUUID_MODELS missing" >&2; return 1; }
+
+    echo "[recovery-stub] slot B PARTUUID:   ${puuid_b}"
+    echo "[recovery-stub] boot PARTUUID:     ${puuid_boot}"
+    echo "[recovery-stub] owner PARTUUID:    ${puuid_owner}"
+    echo "[recovery-stub] models PARTUUID:   ${puuid_models}"
+
+    # Determine repo root from this script's location (scripts/lib/recovery-stub.sh)
+    local repo_root
+    repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+    local loop_dev mnt_a mnt_b
+    loop_dev="$(sudo losetup -f --show -P "${output_img}")"
+
+    _rstub_cleanup() {
+        sudo umount "${mnt_b}" 2>/dev/null || true
+        sudo umount "${mnt_a}" 2>/dev/null || true
+        sudo losetup -d "${loop_dev}" 2>/dev/null || true
+        rmdir "${mnt_b}" 2>/dev/null || true
+        rmdir "${mnt_a}" 2>/dev/null || true
+    }
+    trap _rstub_cleanup RETURN ERR
+
+    mnt_a="$(mktemp -d)"
+    mnt_b="$(mktemp -d)"
+
+    sudo mount -o ro "${loop_dev}p2" "${mnt_a}"
+    sudo mount "${loop_dev}p3" "${mnt_b}"
+
+    _rstub_clone_and_prune "${mnt_a}" "${mnt_b}"
+    _rstub_write_fstab     "${mnt_b}" "${puuid_boot}" "${puuid_owner}" "${puuid_models}"
+    _rstub_install_recovery "${mnt_b}" "${repo_root}"
+    _rstub_write_partuuid_map "${mnt_b}" "${partuuid_map}"
+    _rstub_enable_service  "${mnt_b}"
+
+    sudo sync
+    _rstub_cleanup
+    trap - RETURN ERR
+
+    echo "[recovery-stub] slot-B recovery rootfs written to p3"
+}
+
+# ---------------------------------------------------------------------------
+# Internal: clone slot A into slot B, then prune non-recovery content
+# ---------------------------------------------------------------------------
+_rstub_clone_and_prune() {
+    local mnt_a="$1"
+    local mnt_b="$2"
+
+    echo "[recovery-stub] cloning slot A into slot B..."
+    sudo rsync -aHAX --delete "${mnt_a}/" "${mnt_b}/"
+
+    echo "[recovery-stub] pruning non-recovery content from slot B..."
+
+    # Remove the full Arlowe runtime (voice, LLM, STT, TTS, dashboard, wake-word).
+    # The recovery stub only needs the recovery script + WhisPlay driver.
+    # Keep the venv and system Python packages — the face draw uses system python3 + PIL.
+    local prune_dirs=(
+        opt/arlowe/runtime/voice
+        opt/arlowe/runtime/llm
+        opt/arlowe/runtime/stt
+        opt/arlowe/runtime/tts
+        opt/arlowe/runtime/dashboard
+        opt/arlowe/runtime/wake-word
+        opt/arlowe/runtime/face
+        opt/arlowe/runtime/lib
+    )
+
+    for dir in "${prune_dirs[@]}"; do
+        if [[ -d "${mnt_b}/${dir}" ]]; then
+            sudo rm -rf "${mnt_b:?}/${dir}"
+        fi
+    done
+
+    # Remove model cache directories that might have been copied from rootfs.
+    sudo rm -rf "${mnt_b:?}/opt/arlowe/models" 2>/dev/null || true
+
+    echo "[recovery-stub] pruning complete"
+}
+
+# ---------------------------------------------------------------------------
+# Internal: write slot-B fstab
+# ---------------------------------------------------------------------------
+_rstub_write_fstab() {
+    local mnt_b="$1"
+    local puuid_boot="$2"
+    local puuid_owner="$3"
+    local puuid_models="$4"
+
+    # root (/) comes from kernel root= in cmdline — not in fstab.
+    sudo tee "${mnt_b}/etc/fstab" >/dev/null <<EOF
+# /etc/fstab — slot B (recovery)
+# root (/) is supplied by the kernel root= parameter (tryboot A/B, ADR-0005).
+# Models partition is nofail: recovery is model-free and must boot without it.
+
+# Shared boot firmware (FAT)
+PARTUUID=${puuid_boot}  /boot/firmware      vfat  defaults            0  2
+
+# Owner state (noatime, fixed size — ADR-0004)
+PARTUUID=${puuid_owner}  /var/lib/arlowe    ext4  defaults,noatime    0  2
+
+# Shared models partition — ro,nofail: recovery does not require models
+PARTUUID=${puuid_models}  /opt/arlowe/models  ext4  ro,noatime,nofail  0  2
+EOF
+
+    echo "[recovery-stub] slot-B fstab written (models nofail)"
+}
+
+# ---------------------------------------------------------------------------
+# Internal: install recovery script, service, and WhisPlay driver into slot B
+# ---------------------------------------------------------------------------
+_rstub_install_recovery() {
+    local mnt_b="$1"
+    local repo_root="$2"
+
+    local recovery_src="${repo_root}/runtime/recovery"
+    local whisplay_src="${repo_root}/third_party/whisplay-driver"
+
+    # Install recovery script.
+    sudo install -d -m 0755 "${mnt_b}/opt/arlowe/runtime/recovery"
+    sudo install -m 0755 "${recovery_src}/arlowe-recovery.sh" \
+        "${mnt_b}/opt/arlowe/runtime/recovery/arlowe-recovery.sh"
+
+    # Install systemd service.
+    sudo install -d -m 0755 "${mnt_b}/etc/systemd/system"
+    sudo install -m 0644 "${recovery_src}/arlowe-recovery.service" \
+        "${mnt_b}/etc/systemd/system/arlowe-recovery.service"
+
+    # Install WhisPlay driver (minimal subset: the Python driver file only).
+    # The audio kernel modules are not needed for face rendering alone.
+    sudo install -d -m 0755 "${mnt_b}/opt/arlowe/third_party/whisplay-driver"
+    if [[ -f "${whisplay_src}/WhisPlay.py" ]]; then
+        sudo install -m 0644 "${whisplay_src}/WhisPlay.py" \
+            "${mnt_b}/opt/arlowe/third_party/whisplay-driver/WhisPlay.py"
+    else
+        echo "[recovery-stub] WARN: WhisPlay.py not found at ${whisplay_src}/WhisPlay.py — Whisplay face will be skipped at runtime"
+    fi
+
+    # Create the /opt/arlowe/models mountpoint so the nofail fstab entry works.
+    sudo install -d -m 0755 "${mnt_b}/opt/arlowe/models"
+
+    echo "[recovery-stub] recovery script, service, and WhisPlay driver installed"
+}
+
+# ---------------------------------------------------------------------------
+# Internal: write the PARTUUID map into slot B's /etc/arlowe/ so arlowe-ab
+# and arlowe-recovery.sh can resolve A/B slot names at runtime.
+# ---------------------------------------------------------------------------
+_rstub_write_partuuid_map() {
+    local mnt_b="$1"
+    local partuuid_map="$2"
+
+    sudo install -d -m 0755 "${mnt_b}/etc/arlowe"
+    sudo install -m 0644 "${partuuid_map}" "${mnt_b}/etc/arlowe/ab-partuuid-map"
+    echo "[recovery-stub] PARTUUID map installed at /etc/arlowe/ab-partuuid-map"
+}
+
+# ---------------------------------------------------------------------------
+# Internal: enable the recovery service via systemd wants symlink
+# ---------------------------------------------------------------------------
+_rstub_enable_service() {
+    local mnt_b="$1"
+
+    local wants_dir="${mnt_b}/etc/systemd/system/multi-user.target.wants"
+    sudo install -d -m 0755 "${wants_dir}"
+    sudo ln -sf /etc/systemd/system/arlowe-recovery.service \
+        "${wants_dir}/arlowe-recovery.service"
+
+    echo "[recovery-stub] arlowe-recovery.service enabled (multi-user.target.wants)"
+}

--- a/scripts/provision/install-arlowe-cli.sh
+++ b/scripts/provision/install-arlowe-cli.sh
@@ -19,7 +19,7 @@
 # Must be run as root (or via sudo).
 set -euo pipefail
 
-CLIS=(face speak stt record boot-check purge-logs run-logrotate wake-train)
+CLIS=(face speak stt record boot-check purge-logs run-logrotate wake-train ab)
 TARGET_DIR=/opt/arlowe/runtime/cli
 LINK_DIR=/usr/local/sbin
 


### PR DESCRIPTION
## Summary

Implements the A/B boot selector and slot-B recovery experience (Phase 6 Wave 3).

- **`scripts/lib/boot-config.sh`**: build-time library sourced by the `build-image.sh` extension hook. Writes `config.txt` (`tryboot_a_b=1`, includes `cmdline.txt`), `cmdline.txt` (default `root=PARTUUID=<slot-A>`), `tryboot.txt` (Phase 9 one-shot reserved, mirrors slot-B parameters so a manual `reboot 0 tryboot` lands safely), `tryboot_cmdline.txt`. Also installs the PARTUUID map into slot-A's `/etc/arlowe/ab-partuuid-map` so `arlowe-ab` can resolve A/B → PARTUUID at runtime.
- **`runtime/cli/arlowe-ab`**: on-device A/B selector CLI (`status` / `set A|B` / `switch A|B`). Rewrites only `root=` in `cmdline.txt`. Does NOT touch `tryboot.txt` or use `reboot 0 tryboot` — those are the Phase 9 OTA seam, reserved per ADR-0005.
- **`scripts/lib/recovery-stub.sh`**: build-time library sourced after `boot-config`. Clones slot A → p3 (slot B), prunes the Arlowe voice/LLM/STT/TTS/dashboard/wake-word runtime, installs the recovery script + service + WhisPlay driver minimal subset, writes slot-B fstab (`models` entry `ro,noatime,nofail`), installs the PARTUUID map, and enables the service.
- **`runtime/recovery/arlowe-recovery.sh`**: recovery action: static Whisplay recovery face (red, "RECOVERY / Resetting to slot A / Rebooting..."), serial+journal state print, `root=` reset to slot A in `cmdline.txt`, 15s delay, self-reboot.
- **`runtime/recovery/arlowe-recovery.service`**: systemd oneshot, enabled in slot-B's `multi-user.target.wants`.
- **`scripts/provision/install-arlowe-cli.sh`**: `ab` added to the `CLIS` array so `/usr/local/sbin/arlowe-ab` symlink is created on device.
- **`docs/operations/phase-6-ab-recovery.md`**: A/B selector mechanism, `arlowe-ab` usage, SC3 A→B→recovery flip procedure, slot-B recovery experience, Pi 5 freeze caveat, SD-card fallback (PART-06).

## Key design choices

- `arlowe-ab` and `arlowe-recovery.sh` share the same `root=` rewrite pattern (sed on `cmdline.txt`, write to `.tmp`, rename, sync). Slot B carries no shared library import — keeps its dependency surface tiny.
- Recovery stub uses "copy slot A + prune" rather than a fresh debootstrap, which avoids a second rootfs build and reuses the already-assembled slot-A rootfs.
- Both slot A and slot B carry identical `/opt/arlowe/models` fstab entries; slot B adds `nofail` so recovery boots even if the models partition is unavailable.
- `tryboot.txt` is present but not touched by `arlowe-ab` — Phase 9 OTA will overwrite it before issuing `reboot 0 tryboot`.

## Test plan

- [ ] `bash -n` syntax check on all new scripts: passes
- [ ] `shellcheck --severity=warning` on all new scripts: passes (clean)
- [ ] Plan verification checks from `06-05-PLAN.md`: all pass (`tryboot_a_b`, `root=`, `whisplay`, `oneshot`, `models`/`nofail`, extension hooks wired, ops doc present)
- [ ] On-hardware A→B→recovery→A round-trip: deferred to plan 06-06 on-hardware checkpoint (requires the physical device)

Closes #109